### PR TITLE
PhantomRoll fix: These lines just stomp on any specfic roll sets defined with the generic ph…

### DIFF
--- a/Sample Job Files/COR.lua
+++ b/Sample Job Files/COR.lua
@@ -593,9 +593,6 @@ function precast_custom(spell)
 	if spell.english == 'Fold' then
 		equipSet = set_combine(equipSet, {hands={ name="Lanun Gants +3", augments={'Enhances "Fold" effect',}}})
     end
-	if spell.id == 123 or spell.type == 'CorsairRoll' then -- Double up and bypass weapon check
-		equipSet = set_combine(equipSet, sets.PhantomRoll)
-	end
 	equipSet = Job_Mode_Check(equipSet)
 	return equipSet
 end
@@ -605,9 +602,6 @@ function midcast_custom(spell)
 	if spell.english == 'Fold' then
 		equipSet = set_combine(equipSet, {hands={ name="Lanun Gants +3", augments={'Enhances "Fold" effect',}}})
     end
-	if spell.id == 123 or spell.type == 'CorsairRoll' then -- Double up and bypass weapon check
-		equipSet = set_combine(equipSet, sets.PhantomRoll)
-	end
 	equipSet = Job_Mode_Check(equipSet)
 	return equipSet
 end


### PR DESCRIPTION
It's putting sets.PhantomRoll over the top of specifically defined sets (eg. PhantomRoll["Bolter's Roll"] etc.)

Was causing any gear defined in the specifc sets to be overwritten, Blitzers to not roll with Empy for bonus for example 