### PR TITLE
Add sets for receiving certain types of spells

### DIFF
--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -3012,7 +3012,11 @@ do
 								equip(set_combine(choose_set(), setToEquip))
 							elseif data.category == 4 then
 								-- Finished casting spell on me
-								equip(choose_set())
+								if choose_set_custom then
+									equip(set_combine(choose_set(), choose_set_custom()))
+								else
+									equip(set_combine(choose_set()))
+								end
 							end
 						end
 					end

--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -161,6 +161,9 @@ sets.Geomancy.Indi = {}
 sets.Geomancy.Indi.Entrust = {}
 sets.Pet_Midcast = {}
 
+sets.PhalanxReceived = {}
+sets.CureReceived = {}
+sets.RefreshReceived = {}
 
 sets.Ready = {}
 sets.Ready.Magic = {}
@@ -388,7 +391,11 @@ do
 	local UtsusemiSpell = S{'Utsusemi: Ichi','Utsusemi: Ni', 'Utsusemi: San'}
 	local RecastTimers = S{'WhiteMagic','BlackMagic','Ninjutsu','BlueMagic','BardSong','SummoningMagic','SummonerPact'}
 	local SleepSongs = S{'Foe Lullaby','Foe Lullaby II','Horde Lullaby','Horde Lullaby II',}
-
+	local Phalanxes = S{'Phalanx', 'Phalanx II' }
+	local CureSpells = S{'Cure','Cure II','Cure III','Cure IV','Cure V','Cure VI','Magic Fruit','Wild Carrot','Plenilune Embrace',}
+	local CuragaSpells = S{'Curaga','Curaga II','Curaga III','Curaga IV','Curaga V','Cura','Cura II','Cura III','White Wind',}
+	local RefreshSpells =  S{"Refresh","Refresh II", "Refresh III",}
+	
 	local Divergence_Zones = S { "Dynamis - San d'Oria [D]", "Dynamis - Bastok [D]", "Dynamis - Windurst [D]", "Dynamis - Jeuno [D]" }
 
 	local settings = config.load(default)
@@ -2981,6 +2988,36 @@ do
 						end
 					end
 				end
+				
+			elseif data.targets[1].id == player.id then -- others casting on me
+				if S{4, 8}:contains(data.category) then
+					local action = nil
+					if data.category == 4 then
+						action = res.spells[data.param]
+					elseif data.category == 8 then
+						action = res.spells[data.targets[1].actions[1].param]
+					end
+					if action then
+						local setToEquip = nil
+						if Phalanxes:contains(action.name) then
+							setToEquip = sets.PhalanxReceived
+						elseif CureSpells:contains(action.name) or CuragaSpells:contains(action.name) then
+							setToEquip = sets.CureReceived
+						elseif RefreshSpells:contains(action.name) then
+							setToEquip = sets.RefreshReceived
+						end
+						if setToEquip then
+							if data.category == 8 then
+								-- Casting spell on me
+								equip(set_combine(choose_set(), setToEquip))
+							elseif data.category == 4 then
+								-- Finished casting spell on me
+								equip(choose_set())
+							end
+						end
+					end
+				end
+				
 			end
 			-- Casting Spell
 			if data.category == 8 then


### PR DESCRIPTION
Hey!

Was looking for a way to add automatic phalanx received sets. Seems to work well for me so far. I was hoping you could take a look and see if it looks ok, and if it's something you want to include

The only issues I can think of are potentially if the caster gets interrupted I dont know if that does the category 4? Or if there's a different category for that? I'm not very familiar with the windower stuff

Also if you want to include it, I could also commit 

``` lua
sets.PhalanxReceived = {}
sets.CureReceived = {}
sets.RefreshReceived = {}
```

With some defaults into the job files

There's a cavaet the curaga type spells only work if you are the target. It seems pretty convoluted to do a proper check. That the person is in the same party and the target of the spell is close enough to you that you'd receive it too. Then there's cases like a paladin in the alliance casting majesty cure to someone in your party... didn't really want to go down that rabbit hole.

It would also need to call `ffxi.get_mob_by_id` a lot I think for the curaga stuff and I've no idea if that's expensive or not