### PR TITLE
Dev

### DIFF
--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -13,7 +13,7 @@ Original credit to Mirdain.  Pull request to be submitted after beta testing.
 ]]
 
 -- Global Variables
-Mirdain_GS = '1.6.0'
+Mirdain_GS = '1.6.1'
 
 -- Modes is the include file for a mode-tracking variable class.  Used for state vars, below.
 include('Modes')
@@ -676,6 +676,44 @@ do
         return false
     end
 
+    --Given the mob being targeted and the name currently addressed on the outgoing IPC message,
+    --expand target_name to a comma-separated list of party members within AoE range (10 yalms),
+    --or return it unchanged if the target isn't a valid AoE candidate.
+    local function resolve_aoe_target_name(target_mob, target_name)
+        local party = get_party()
+        if not (party and is_target_in_party(target_name, party)) then
+            return target_name
+        end
+    
+        local count = 0
+        for k in pairs(NEARBY_MEMBERS_BUFFER) do NEARBY_MEMBERS_BUFFER[k] = nil end
+    
+        for slot, member in pairs(party) do
+            if type(member) == 'table' and member.name then
+                local m_mob = get_mob_by_name(member.name)
+                if m_mob then
+                    local dx = m_mob.x - target_mob.x
+                    local dy = m_mob.y - target_mob.y
+                    local dz = m_mob.z - target_mob.z
+                    if ((dx * dx) + (dy * dy) + (dz * dz)) <= 100 then
+                        if settings.debug then debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name) end
+                        count = count + 1
+                        NEARBY_MEMBERS_BUFFER[count] = member.name
+                    else
+                        if settings.debug then debug(member.name .. " is OUT of aoe range from " .. target_mob.name) end
+                    end
+                else
+                    if settings.debug then debug(member.name .. " data unavailable (Too far away).") end
+                end
+            end
+        end
+    
+        if count > 0 then
+            return table.concat(NEARBY_MEMBERS_BUFFER, ",")
+        end
+        return target_name
+    end
+    
     --Calculate and return how many strategems are off cooldown.
     local function get_current_stratagem_count()
         local charge_cooldown = windower.ffxi.get_ability_recasts()[231] or 0
@@ -898,31 +936,7 @@ do
                     --AoE Checks
                     if a_info.aoe then
                         if settings.debug then debug("AoE Ability Cast Detected.  Calculating targets.") end
-                        local party = get_party()
-                        if party and is_target_in_party(target_name, party) then
-                            local count = 0
-                            for k, v in pairs(NEARBY_MEMBERS_BUFFER) do NEARBY_MEMBERS_BUFFER[k] = nil end
-
-                            for slot, member in pairs(party) do
-                                if type(member) == 'table' and member.name then
-                                    local m_mob = get_mob_by_name(member.name)
-                                    if m_mob then
-                                        local dx, dy, dz = m_mob.x - target_mob.x, m_mob.y - target_mob.y,
-                                            m_mob.z - target_mob.z
-                                        if ((dx * dx) + (dy * dy) + (dz * dz)) <= 100 then
-                                            if settings.debug then debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name) end
-                                            count = count + 1
-                                            NEARBY_MEMBERS_BUFFER[count] = member.name
-                                        else
-                                            if settings.debug then debug(member.name .. " is OUT of aoe range from " .. target_mob.name) end
-                                        end
-                                    else
-                                        if settings.debug then debug(member.name .. " data unavailable (Too far away).") end
-                                    end
-                                end
-                            end
-                            if count > 0 then target_name = table.concat(NEARBY_MEMBERS_BUFFER, ",") end
-                        end
+                        target_name = resolve_aoe_target_name(target_mob, target_name)
                     end
                     if settings.debug then debug(string.format("IPC message sent: MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name,
                         spell.id, get_time())) end
@@ -1011,35 +1025,7 @@ do
                 local has_yagrush = (s_info.divine and get_slot_item_name(sets.Midcast["Cursna"], 'main') == "Yagrush")
                 if (s_info.aoe or ((accession_predicted or accession_active) and s_info.accession) or (majesty_active and s_info.majesty) or ((divine_seal_predicted or divine_veil_active or has_yagrush) and s_info.divine)) then
                     if settings.debug then debug("AoE Spell Cast Detected. Calculating targets.") end
-                    local party = get_party()
-                    if party and is_target_in_party(target_name, party) then
-                        local count = 0
-                        for k in pairs(NEARBY_MEMBERS_BUFFER) do NEARBY_MEMBERS_BUFFER[k] = nil end
-
-                        for slot, member in pairs(party) do
-                            if type(member) == 'table' and member.name then
-                                local m_mob = get_mob_by_name(member.name)
-                                if m_mob then
-                                    local dx = m_mob.x - target_mob.x
-                                    local dy = m_mob.y - target_mob.y
-                                    local dz = m_mob.z - target_mob.z
-                                    if ((dx * dx) + (dy * dy) + (dz * dz)) <= 100 then
-                                        if settings.debug then debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name) end
-                                        count = count + 1
-                                        NEARBY_MEMBERS_BUFFER[count] = member.name
-                                    else
-                                        if settings.debug then debug(member.name .. " is OUT of aoe range from " .. target_mob.name) end
-                                    end
-                                else
-                                    if settings.debug then debug(member.name .. " data unavailable (Too far away).") end
-                                end
-                            end
-                        end
-
-                        if count > 0 then
-                            target_name = table.concat(NEARBY_MEMBERS_BUFFER, ",")
-                        end
-                    end
+                    target_name = resolve_aoe_target_name(target_mob, target_name)
                 end
                 if settings.debug then debug(string.format("IPC message sent: MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id,
                     get_time())) end
@@ -1440,31 +1426,7 @@ do
                     --AoE Checks
                     if a_info.aoe then
                         if settings.debug then debug("AoE Ability Cast Detected.  Calculating targets.") end
-                        local party = get_party()
-                        if party and is_target_in_party(target_name, party) then
-                            local count = 0
-                            for k, v in pairs(NEARBY_MEMBERS_BUFFER) do NEARBY_MEMBERS_BUFFER[k] = nil end
-
-                            for slot, member in pairs(party) do
-                                if type(member) == 'table' and member.name then
-                                    local m_mob = get_mob_by_name(member.name)
-                                    if m_mob then
-                                        local dx, dy, dz = m_mob.x - target_mob.x, m_mob.y - target_mob.y,
-                                            m_mob.z - target_mob.z
-                                        if ((dx * dx) + (dy * dy) + (dz * dz)) <= 100 then
-                                            if settings.debug then debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name) end
-                                            count = count + 1
-                                            NEARBY_MEMBERS_BUFFER[count] = member.name
-                                        else
-                                            if settings.debug then debug(member.name .. " is OUT of aoe range from " .. target_mob.name) end
-                                        end
-                                    else
-                                        if settings.debug then debug(member.name .. " data unavailable (Too far away).") end
-                                    end
-                                end
-                            end
-                            if count > 0 then target_name = table.concat(NEARBY_MEMBERS_BUFFER, ",") end
-                        end
+                        target_name = resolve_aoe_target_name(target_mob, target_name)
                     end
                     if settings.debug then debug(string.format("IPC message sent: MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name,
                         spell.id, get_time())) end
@@ -1653,35 +1615,7 @@ do
                 local has_yagrush = (s_info.divine and get_slot_item_name(sets.Midcast["Cursna"], 'main') == "Yagrush")
                 if (s_info.aoe or ((accession_predicted or accession_active) and s_info.accession) or (majesty_active and s_info.majesty) or ((divine_seal_predicted or divine_veil_active or has_yagrush) and s_info.divine)) then
                     if settings.debug then debug("AoE Spell Cast Detected. Calculating targets.") end
-                    local party = get_party()
-                    if party and is_target_in_party(target_name, party) then
-                        local count = 0
-                        for k in pairs(NEARBY_MEMBERS_BUFFER) do NEARBY_MEMBERS_BUFFER[k] = nil end
-
-                        for slot, member in pairs(party) do
-                            if type(member) == 'table' and member.name then
-                                local m_mob = get_mob_by_name(member.name)
-                                if m_mob then
-                                    local dx = m_mob.x - target_mob.x
-                                    local dy = m_mob.y - target_mob.y
-                                    local dz = m_mob.z - target_mob.z
-                                    if ((dx * dx) + (dy * dy) + (dz * dz)) <= 100 then
-                                        if settings.debug then debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name) end
-                                        count = count + 1
-                                        NEARBY_MEMBERS_BUFFER[count] = member.name
-                                    else
-                                        if settings.debug then debug(member.name .. " is OUT of aoe range from " .. target_mob.name) end
-                                    end
-                                else
-                                    if settings.debug then debug(member.name .. " data unavailable (Too far away).") end
-                                end
-                            end
-                        end
-
-                        if count > 0 then
-                            target_name = table.concat(NEARBY_MEMBERS_BUFFER, ",")
-                        end
-                    end
+                    target_name = resolve_aoe_target_name(target_mob, target_name)
                 end
                 if settings.debug then debug(string.format("IPC message sent: MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id, get_time())) end
                 send_ipc(string.format("MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id, get_time()))

--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -3298,10 +3298,12 @@ do
             if settings.visible == true then
                 settings.visible = false
                 gs_status:hide()
+                gs_status:draggable(false)
                 add_to_chat(80, 'The UI is now hidden')
             else
-                gs_status:show()
                 settings.visible = true
+                gs_status:draggable(true)
+                gs_status:show()
                 display_box_update()
                 add_to_chat(80, 'The UI is now shown')
             end
@@ -4148,12 +4150,14 @@ do
         end
     end
 
-    -- Zero the display window
+    -- Zero the display and debug windows
     function display_zero_command()
         gs_status:pos_x(0)
-        gs_status:pos_y(0)
+        gs_status:pos_y(0)        
+        gs_debug:pos_x(0)
+        gs_debug:pos_y(100)
         config.save(settings)
-        add_to_chat("Settings Saved")
+        add_to_chat("Displays reset and positions saved")
     end
 
     local debug_box_state = {}

--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -4129,22 +4129,28 @@ do
     windower.raw_register_event('outgoing chunk', main_engine)
     windower.raw_register_event('zone change', on_zone_change_for_th)
 
-    -- Auto save function for dragging and dropping status and debug boxes
     local is_dragging = false
-    windower.register_event('mouse', function(type, x, y, delta, blocked)
-        -- Windower Type 1 = Left Click Down - sets dragging state
-        if type == 1 and (gs_status:hover(x, y) or gs_debug:hover(x, y)) then
-            is_dragging = true
-            -- Windower Type 2 = Left Click Up / Drag Release triggers saving and resets state
-        elseif type == 2 and is_dragging then
-            is_dragging = false
-            settings.Display_Box.pos.x = gs_status:settings().pos.x
-            settings.Display_Box.pos.y = gs_status:settings().pos.y
-            settings.Debug_Box.pos.x = gs_debug:settings().pos.x
-            settings.Debug_Box.pos.y = gs_debug:settings().pos.y
+    windower.raw_register_event('mouse', function(type, x, y, delta, blocked)
+        -- Mouse move is type 0.  Reject anything other than left click up (2) and down (1).
+        if type ~= 1 and type ~= 2 then return end
 
-            config.save(settings)
-            windower.add_to_chat(80, "Settings saved")
+        if type == 1 then
+            is_dragging = gs_status:hover(x, y) or gs_debug:hover(x, y)
+        elseif is_dragging then
+            is_dragging = false
+            local status_pos = gs_status:settings().pos
+            local debug_pos = gs_debug:settings().pos
+
+            if settings.Display_Box.pos.x ~= status_pos.x or settings.Display_Box.pos.y ~= status_pos.y
+                or settings.Debug_Box.pos.x ~= debug_pos.x or settings.Debug_Box.pos.y ~= debug_pos.y then
+                settings.Display_Box.pos.x = status_pos.x
+                settings.Display_Box.pos.y = status_pos.y
+                settings.Debug_Box.pos.x = debug_pos.x
+                settings.Debug_Box.pos.y = debug_pos.y
+
+                config.save(settings)
+                windower.add_to_chat(80, "Settings saved")
+            end
         end
     end)
 
@@ -4226,7 +4232,7 @@ do
         end
     end)
 
-    windower.register_event('prerender', function()
+    windower.raw_register_event('prerender', function()
         if not failsafe_active or state.SpellReceived.value == "OFF" then return end
 
         if os.clock() >= failsafe_trigger_time then

--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -1,8 +1,25 @@
--- Globals Variables
-Mirdain_GS = '1.5.12'
+--[[
+This revision of Mirdain-Include was conceived and programmed by Rahvin.
+Enhanced features:
+-Hoxne Ampulla Mode
+-Multibox Spell-Received Gear Tracking with AoE prediction for -aga, -ra, Accession, Divine Veil and Majesty
+-Automated Holy Water gear equipping
+-Twilight Cape support
+-One-Line or Full display toggling with automated position saving
+-Optimization to the pretarget and precast routines
+
+See https://www.github.com/rahvincode for full details.
+Original credit to Mirdain.  Pull request to be submitted after beta testing.
+]]
+
+-- Global Variables
+Mirdain_GS = '1.6.0'
 
 -- Modes is the include file for a mode-tracking variable class.  Used for state vars, below.
 include('Modes')
+
+--Herald Lock State Tracking
+active_external_locks = {}
 
 -- Weapons
 sets.Weapons = {}
@@ -20,7 +37,16 @@ sets.Idle.ACC = {}
 sets.Idle.DT = {}
 
 sets.Movement = {}
+
+--Spell Received Sets
+sets.Cure_Received = {}
 sets.Cursna_Received = {}
+sets.Phalanx_Received = {}
+sets.Protect_Shell_Received = {}
+sets.Regen_Received = {}
+sets.Refresh_Received = {}
+sets.Waltz_Received = {}
+sets.Holy_Water = {}
 
 -- State sets
 sets.OffenseMode = {}
@@ -30,7 +56,7 @@ sets.OffenseMode.AM2 = {}
 sets.OffenseMode.AM3 = {}
 
 sets.DualWield = {}
-		
+
 -- Precast
 sets.Precast = {}
 sets.Precast.FastCast = {}
@@ -51,13 +77,13 @@ sets.Midcast.RA['True Shot'] = {}
 sets.Midcast.RA.TripleShot = {}
 sets.Midcast.RA.DoubleShot = {}
 sets.Midcast.RA.Barrage = {}
-		
+
 sets.Midcast.Enfeebling = {}
 sets.Midcast.Enfeebling.MACC = {}
 sets.Midcast.Enfeebling.Potency = {}
 sets.Midcast.Enfeebling.Duration = {}
 
--- Midcast		
+-- Midcast
 sets.Midcast.SIRD = {}
 sets.Midcast.Nuke = {}
 sets.Midcast.Burst = {}
@@ -72,7 +98,7 @@ sets.Midcast.Enhancing.Gain = {}
 sets.Midcast.Enhancing.Elemental = {}
 sets.Midcast.Enhancing.Status = {}
 sets.Midcast.Enhancing.Skill = {}
-		
+
 sets.Midcast.Aspir = {}
 sets.Midcast.Drain = {}
 sets.Midcast.Dark = {}
@@ -104,7 +130,7 @@ sets.Midcast.Minne = {}
 sets.Midcast.Mambo = {}
 sets.Midcast.Etude = {}
 sets.Midcast.Prelude = {}
-sets.Midcast.Dirge ={}
+sets.Midcast.Dirge = {}
 sets.Midcast.Sirvente = {}
 sets.Midcast.Aria = {}
 
@@ -121,7 +147,7 @@ sets.Midcast.RA.AM3 = {}
 --Weaponskills
 sets.WS = {}
 sets.WS.RA = {}
-sets.WS.ACC =  {}
+sets.WS.ACC = {}
 sets.WS.RA.ACC = {}
 sets.WS.PDL = {}
 sets.WS.RA.PDL = {}
@@ -139,7 +165,7 @@ sets.WS.AM2 = {}
 sets.WS.RA.AM2 = {}
 sets.WS.AM3 = {}
 sets.WS.RA.AM3 = {}
-		
+
 -- Other Sets
 sets.JA = {}
 sets.Waltz = {}
@@ -166,7 +192,7 @@ sets.Ready = {}
 sets.Ready.Magic = {}
 sets.Ready.TP = {}
 sets.Ready.Debuff = {}
-sets.Ready.Standard = {}	
+sets.Ready.Standard = {}
 
 Instrument = {}
 Instrument.Count = {}
@@ -184,47 +210,59 @@ Instrument.MAB = {}
 state = state or {}
 
 --Modes for Melee
-state.OffenseMode = M{['description']='Melee Mode'}
-state.OffenseMode:options('TP','ACC','DT')
+state.OffenseMode = M { ['description'] = 'Melee Mode' }
+state.OffenseMode:options('TP', 'ACC', 'DT')
 state.OffenseMode:set('TP')
 
+--Modes for Spell-Received Tracking via IPC. Locked will keep spell received gear
+--slots locked while waiting for spell completion from the caster.
+--Unlocks slots at spell completion and defined delay as failsafe.
+state.SpellReceived = M { ['description'] = "Spell-Received" }
+state.SpellReceived:options('OFF', 'ON-Locked', 'ON-Unlocked')
+state.SpellReceived:set('ON-LOCKED')
+
+--Modes for Hoxne Ampulla locking
+state.Hoxne = M { ['description'] = 'Hoxne' }
+state.Hoxne:options('OFF', 'ON')
+state.Hoxne:set('OFF')
+
 --Modes for Auto Buff
-state.AutoBuff = M{['description']='Auto Buff Mode'}
-state.AutoBuff:options('OFF','ON')
+state.AutoBuff = M { ['description'] = 'Auto Buff Mode' }
+state.AutoBuff:options('OFF', 'ON')
 state.AutoBuff:set('OFF')
 
 --TH mode handling
-state.TreasureMode = M{['description']='Treasure Mode'}
+state.TreasureMode = M { ['description'] = 'Treasure Mode' }
 if player.main_job == "THF" then
-	state.TreasureMode:options('None','Tag','Full Time','SATA')
-	state.TreasureMode:set('Full Time')
+    state.TreasureMode:options('None', 'Tag', 'Full Time', 'SATA')
+    state.TreasureMode:set('Full Time')
 else
-	state.TreasureMode:options('None','Tag','Full Time')
-	state.TreasureMode:set('None')
+    state.TreasureMode:options('None', 'Tag', 'Full Time')
+    state.TreasureMode:set('None')
 end
 
 --Weapon specific modes
 state.WeaponMode = {}
-state.WeaponMode = M{['description']='Weapon Specific Mode'}
-state.WeaponMode:options('OFF','ON')
+state.WeaponMode = M { ['description'] = 'Weapon Specific Mode' }
+state.WeaponMode:options('OFF', 'ON')
 state.WeaponMode:set('OFF')
 
 --Job specific modes
 state.JobMode = {}
-state.JobMode = M{['description']='Job Specific Mode'}
-state.JobMode:options('OFF','ON')
+state.JobMode = M { ['description'] = 'Job Specific Mode' }
+state.JobMode:options('OFF', 'ON')
 state.JobMode:set('OFF')
 
 --Job specific modes
 state.JobMode2 = {}
-state.JobMode2 = M{['description']='Job Specific Mode'}
-state.JobMode2:options('OFF','ON')
+state.JobMode2 = M { ['description'] = 'Job Specific Mode' }
+state.JobMode2:options('OFF', 'ON')
 state.JobMode2:set('OFF')
 
 --Ranged Attack mode
 state.RAMode = {}
-state.RAMode = M{['description']='Ranged Attack Mode'}
-state.RAMode:options('Bullet','Arrow','Bolt')
+state.RAMode = M { ['description'] = 'Ranged Attack Mode' }
+state.RAMode:options('Bullet', 'Arrow', 'Bolt')
 state.RAMode:set('Bullet')
 
 --State for Ammunition check
@@ -238,3020 +276,4424 @@ Ammo.Bolt = {}
 
 Ammo_Warning_Limit = 99
 
--- User Definde
+-- User Defined
 
 is_Busy = false
+is_Dragging = false
 AutoItem = false
 Random_Lockstyle = false
 Target_Assist = true
 Lockstyle_List = {}
 
-Elemental_WS = S{
-	'Earth Shot','Ice Shot','Water Shot','Fire Shot','Wind Shot','Thunder Shot',
-	'Gust Slash','Cyclone','Energy Steal','Energy Drain','Aeolian Edge',
-	'Burning Blade','Red Lotus Blade','Shining Blade','Seraph Blade','Sanguine Blade',
-	'Frostbite','Freezebite','Herculean Slash',
-	'Cloudsplitter','Primal Rend',
-	'Dark Harvest','Shadow of Death','Infernal Scythe',
-	'Thunder Thrust','Raiden Thrust',
-	'Blade: Teki','Blade: To','Blade: Chi','Blade: Ei','Blade: Yu',
-	'Tachi: Goten','Tachi: Kagero','Tachi: Jinpu','Tachi: Koki',
-	'Shining Strike','Seraph Strike','Flash Nova',
-	'Rock Crusher','Earth Crusher', 'Starburst', 'Sunburst','Cataclysm','Vidohunir','Garland of Bliss','Omniscience',
-	'Flaming Arrow',
-	'Hot Shot','Wildfire','Trueflight','Leaden Salute',
-	}
+Elemental_WS = S {
+    'Earth Shot', 'Ice Shot', 'Water Shot', 'Fire Shot', 'Wind Shot', 'Thunder Shot',
+    'Gust Slash', 'Cyclone', 'Energy Steal', 'Energy Drain', 'Aeolian Edge',
+    'Burning Blade', 'Red Lotus Blade', 'Shining Blade', 'Seraph Blade', 'Sanguine Blade',
+    'Frostbite', 'Freezebite', 'Herculean Slash',
+    'Cloudsplitter', 'Primal Rend',
+    'Dark Harvest', 'Shadow of Death', 'Infernal Scythe',
+    'Thunder Thrust', 'Raiden Thrust',
+    'Blade: Teki', 'Blade: To', 'Blade: Chi', 'Blade: Ei', 'Blade: Yu',
+    'Tachi: Goten', 'Tachi: Kagero', 'Tachi: Jinpu', 'Tachi: Koki',
+    'Shining Strike', 'Seraph Strike', 'Flash Nova',
+    'Rock Crusher', 'Earth Crusher', 'Starburst', 'Sunburst', 'Cataclysm', 'Vidohunir', 'Garland of Bliss', 'Omniscience',
+    'Flaming Arrow',
+    'Hot Shot', 'Wildfire', 'Trueflight', 'Leaden Salute',
+}
 
-Geomancy_List = M('Geo-Acumen', 'Geo-Attunement', 'Geo-Barrier', 'Geo-STR', 'Geo-DEX', 'Geo-VIT', 'Geo-AGI', 'Geo-INT', 'Geo-MND', 'Geo-CHR', 'Geo-Fade',
-             'Geo-Fend', 'Geo-Focus', 'Geo-Frailty', 'Geo-Fury', 'Geo-Gravity', 'Geo-Haste', 'Geo-Languor', 'Geo-Malaise', 'Geo-Paralysis', 
-             'Geo-Poison', 'Geo-Precision', 'Geo-Refresh', 'Geo-Regen', 'Geo-Slip', 'Geo-Slow', 'Geo-Torpor', 'Geo-Vex', 'Geo-Voidance', 'Geo-Wilt')
+Geomancy_List = M('Geo-Acumen', 'Geo-Attunement', 'Geo-Barrier', 'Geo-STR', 'Geo-DEX', 'Geo-VIT', 'Geo-AGI', 'Geo-INT',
+    'Geo-MND', 'Geo-CHR', 'Geo-Fade',
+    'Geo-Fend', 'Geo-Focus', 'Geo-Frailty', 'Geo-Fury', 'Geo-Gravity', 'Geo-Haste', 'Geo-Languor', 'Geo-Malaise',
+    'Geo-Paralysis',
+    'Geo-Poison', 'Geo-Precision', 'Geosettings.Dis-Refresh', 'Geo-Regen', 'Geo-Slip', 'Geo-Slow', 'Geo-Torpor',
+    'Geo-Vex',
+    'Geo-Voidance', 'Geo-Wilt')
 
-Indicolure_List = M('Indi-Acumen', 'Indi-Attunement', 'Indi-Barrier', 'Indi-STR', 'Indi-DEX', 'Indi-VIT', 'Indi-AGI', 'Indi-INT', 'Indi-MND', 'Indi-CHR', 'Indi-Fade',
-             'Indi-Fend', 'Indi-Focus', 'Indi-Frailty', 'Indi-Fury', 'Indi-Gravity', 'Indi-Haste', 'Indi-Languor', 'Indi-Malaise', 'Indi-Paralysis', 
-             'Indi-Poison', 'Indi-Precision', 'Indi-Refresh', 'Indi-Regen', 'Indi-Slip', 'Indi-Slow', 'Indi-Torpor', 'Indi-Vex', 'Indi-Voidance', 'Indi-Wilt')
+Indicolure_List = M('Indi-Acumen', 'Indi-Attunement', 'Indi-Barrier', 'Indi-STR', 'Indi-DEX', 'Indi-VIT', 'Indi-AGI',
+    'Indi-INT', 'Indi-MND', 'Indi-CHR', 'Indi-Fade',
+    'Indi-Fend', 'Indi-Focus', 'Indi-Frailty', 'Indi-Fury', 'Indi-Gravity', 'Indi-Haste', 'Indi-Languor', 'Indi-Malaise',
+    'Indi-Paralysis',
+    'Indi-Poison', 'Indi-Precision', 'Indi-Refresh', 'Indi-Regen', 'Indi-Slip', 'Indi-Slow', 'Indi-Torpor', 'Indi-Vex',
+    'Indi-Voidance', 'Indi-Wilt')
 
-Enfeebling_Song = S{ 'Foe Requiem','Foe Requiem II','Foe Requiem III','Foe Requiem IV','Foe Requiem V','Foe Requiem VI','Foe Requiem VII','Battlefield Elegy', 'Carnage Elegy',
-	'Fire Threnody', 'Ice Threnody', 'Wind Threnody', 'Earth Threnody', 'Ltng. Threnody', 'Water Threnody', 'Light Threnody','Dark Threnody','Fire Threnody II',
-	'Ice Threnody II', 'Wind Threnody II', 'Earth Threnody II', 'Ltng. Threnody II', 'Water Threnody II', 'Light Threnody II','Dark Threnody II','Magic Finale', 'Pining Nocturne'}
+Enfeebling_Song = S { 'Foe Requiem', 'Foe Requiem II', 'Foe Requiem III', 'Foe Requiem IV', 'Foe Requiem V', 'Foe Requiem VI', 'Foe Requiem VII', 'Battlefield Elegy', 'Carnage Elegy',
+    'Fire Threnody', 'Ice Threnody', 'Wind Threnody', 'Earth Threnody', 'Ltng. Threnody', 'Water Threnody', 'Light Threnody', 'Dark Threnody', 'Fire Threnody II',
+    'Ice Threnody II', 'Wind Threnody II', 'Earth Threnody II', 'Ltng. Threnody II', 'Water Threnody II', 'Light Threnody II', 'Dark Threnody II', 'Magic Finale', 'Pining Nocturne' }
 
-Enfeeble_Acc = S{'Dispel','Aspir','Aspir II','Aspir III','Drain','Drain II','Drain III','Frazzle','Frazzle II','Stun','Poison','Poison II','Poisonga'}
-Enfeeble_Potency = S{'Paralyze','Paralyze II','Slow','Slow II','Addle','Addle II','Distract','Distract II','Distract III','Frazzle III','Blind','Blind II','Gravity','Gravity II'}
-Enfeeble_Duration = S{'Sleep','Sleep II','Sleepga','Sleepga II','Diaga','Dia','Dia II','Dia III','Bio','Bio II','Bio III','Silence','Inundation','Break','Breakaga','Bind','Bind II'}
+Enfeeble_Acc = S { 'Dispel', 'Aspir', 'Aspir II', 'Aspir III', 'Drain', 'Drain II', 'Drain III', 'Frazzle', 'Frazzle II', 'Stun', 'Poison', 'Poison II', 'Poisonga' }
+Enfeeble_Potency = S { 'Paralyze', 'Paralyze II', 'Slow', 'Slow II', 'Addle', 'Addle II', 'Distract', 'Distract II', 'Distract III', 'Frazzle III', 'Blind', 'Blind II', 'Gravity', 'Gravity II' }
+Enfeeble_Duration = S { 'Sleep', 'Sleep II', 'Sleepga', 'Sleepga II', 'Diaga', 'Dia', 'Dia II', 'Dia III', 'Bio', 'Bio II', 'Bio III', 'Silence', 'Inundation', 'Break', 'Breakaga', 'Bind', 'Bind II' }
 
-Dark_Acc = S{'Death','Kaustra','Stun'}
-Dark_Absorb = S{'Absorb-ACC','Absorb-AGI','Absorb-Attri','Absorb-CHR','Absorb-DEX','Absorb-INT','Absorb-MND','Absorb-STR','Absorb-TP','Absorb-VIT','Aspir','Aspir II','Aspir III','Drain','Drain II','Drain III'}
-Dark_Enhancing = S{'Dread Spikes','Endark','Endark II','Klimaform','Tractor'}
+Dark_Acc = S { 'Death', 'Kaustra', 'Stun' }
+Dark_Absorb = S { 'Absorb-ACC', 'Absorb-AGI', 'Absorb-Attri', 'Absorb-CHR', 'Absorb-DEX', 'Absorb-INT', 'Absorb-MND', 'Absorb-STR', 'Absorb-TP', 'Absorb-VIT', 'Aspir', 'Aspir II', 'Aspir III', 'Drain', 'Drain II', 'Drain III' }
+Dark_Enhancing = S { 'Dread Spikes', 'Endark', 'Endark II', 'Klimaform', 'Tractor' }
 
-Enhancing_Skill = S{'Temper','Temper II','Enaero','Enstone','Enthunder','Enwater','Enfire','Enblizzard','Boost-STR','Boost-DEX','Boost-VIT','Boost-AGI','Boost-INT','Boost-MND','Boost-CHR'}
-Divine_Skill = S{'Enlight', 'Enlight II', 'Flash', 'Repose', 'Holy', 'Holy II', 'Banish', 'Banish II', 'Banish III', 'Banishga', 'Banishga II',}
+Enhancing_Skill = S { 'Temper', 'Temper II', 'Enaero', 'Enstone', 'Enthunder', 'Enwater', 'Enfire', 'Enblizzard', 'Boost-STR', 'Boost-DEX', 'Boost-VIT', 'Boost-AGI', 'Boost-INT', 'Boost-MND', 'Boost-CHR' }
+Divine_Skill = S { 'Enlight', 'Enlight II', 'Flash', 'Repose', 'Holy', 'Holy II', 'Banish', 'Banish II', 'Banish III', 'Banishga', 'Banishga II', }
 
-BlueNuke = S{'Spectral Floe','Entomb', 'Magic Hammer', 'Tenebral Crush'}
-BlueACC = S{'Cruel Joke','Dream Flower','Reaving Wind'}
-BlueHealing = S{'Magic Fruit','Healing Breeze','Wild Carrot','Plenilune Embrace','Restoral'}
-BlueSkill = S{'Occultation','Erratic Flutter','Nature\'s Meditation','Cocoon','Barrier Tusk','Metallic Body','Mighty Guard'}
-BlueTank = S{'Jettatura','Geist Wall','Blank Gaze','Sheep Song','Sandspin','Healing Breeze'}
+BlueNuke = S { 'Spectral Floe', 'Entomb', 'Magic Hammer', 'Tenebral Crush' }
+BlueACC = S { 'Cruel Joke', 'Dream Flower', 'Reaving Wind' }
+BlueHealing = S { 'Magic Fruit', 'Healing Breeze', 'Wild Carrot', 'Plenilune Embrace', 'Restoral' }
+BlueSkill = S { 'Occultation', 'Erratic Flutter', 'Nature\'s Meditation', 'Cocoon', 'Barrier Tusk', 'Metallic Body', 'Mighty Guard' }
+BlueTank = S { 'Jettatura', 'Geist Wall', 'Blank Gaze', 'Sheep Song', 'Sandspin', 'Healing Breeze' }
 
-Elemental_Enfeeble = S{'Burn','Frost','Choke','Rasp','Shock','Drown'}
+Elemental_Enfeeble = S { 'Burn', 'Frost', 'Choke', 'Rasp', 'Shock', 'Drown' }
 
-Healing_Magic = S{'Arise','Blinda','Esuna','Paralyna','Poisona','Raise','Raise II','Raise III','Reraise','Reraise II','Reraise III','Reraise IV','Sacrifice','Silena','Stona','Viruna','Cursna'}
+Healing_Magic = S { 'Arise', 'Blinda', 'Esuna', 'Paralyna', 'Poisona', 'Raise', 'Raise II', 'Raise III', 'Reraise', 'Reraise II', 'Reraise III', 'Reraise IV', 'Sacrifice', 'Silena', 'Stona', 'Viruna', 'Cursna' }
 
-Buff_BPs_Duration = S{'Shining Ruby','Aerial Armor','Frost Armor','Rolling Thunder','Crimson Howl','Lightning Armor','Ecliptic Growl','Glittering Ruby','Earthen Ward','Hastega',
-	'Noctoshield','Ecliptic Howl','Dream Shroud','Earthen Armor','Fleet Wind','Inferno Howl','Heavenward Howl','Hastega II','Soothing Current','Crystal Blessing'}
-Buff_BPs_Healing = S{'Healing Ruby','Healing Ruby II','Whispering Wind','Spring Water'}
-Debuff_BPs = S{'Mewing Lullaby','Eerie Eye','Lunar Cry','Lunar Roar','Nightmare','Pavor Nocturnus','Ultimate Terror','Somnolence','Slowga','Tidal Roar','Diamond Storm','Sleepga','Shock Squall'}
-Debuff_Rage_BPs = S{'Moonlit Charge','Tail Whip'}
-Magic_BPs_NoTP = S{'Holy Mist','Nether Blast','Aerial Blast','Searing Light','Diamond Dust','Earthen Fury','Zantetsuken','Tidal Wave','Judgment Bolt','Inferno','Howling Moon','Ruinous Omen','Night Terror','Thunderspark'}
-Magic_BPs_TP = S{'Impact','Conflag Strike','Level ? Holy','Lunar Bay'}
-Merit_BPs = S{'Meteor Strike','Geocrush','Grand Fall','Wind Blade','Heavenly Strike','Thunderstorm'}
-Physical_BPs_TP = S{'Rock Buster','Mountain Buster','Crescent Fang','Spinning Dive'}
-AvatarList = S{'Shiva','Ramuh','Garuda','Leviathan','Diabolos','Titan','Fenrir','Ifrit','Carbuncle','Fire Spirit','Air Spirit','Ice Spirit','Thunder Spirit',
-	'Light Spirit','Dark Spirit','Earth Spirit','Water Spirit','Cait Sith','Alexander','Odin','Atomos'}
+Buff_BPs_Duration = S { 'Shining Ruby', 'Aerial Armor', 'Frost Armor', 'Rolling Thunder', 'Crimson Howl', 'Lightning Armor', 'Ecliptic Growl', 'Glittering Ruby', 'Earthen Ward', 'Hastega',
+    'Noctoshield', 'Ecliptic Howl', 'Dream Shroud', 'Earthen Armor', 'Fleet Wind', 'Inferno Howl', 'Heavenward Howl', 'Hastega II', 'Soothing Current', 'Crystal Blessing' }
+Buff_BPs_Healing = S { 'Healing Ruby', 'Healing Ruby II', 'Whispering Wind', 'Spring Water' }
+Debuff_BPs = S { 'Mewing Lullaby', 'Eerie Eye', 'Lunar Cry', 'Lunar Roar', 'Nightmare', 'Pavor Nocturnus', 'Ultimate Terror', 'Somnolence', 'Slowga', 'Tidal Roar', 'Diamond Storm', 'Sleepga', 'Shock Squall' }
+Debuff_Rage_BPs = S { 'Moonlit Charge', 'Tail Whip' }
+Magic_BPs_NoTP = S { 'Holy Mist', 'Nether Blast', 'Aerial Blast', 'Searing Light', 'Diamond Dust', 'Earthen Fury', 'Zantetsuken', 'Tidal Wave', 'Judgment Bolt', 'Inferno', 'Howling Moon', 'Ruinous Omen', 'Night Terror', 'Thunderspark' }
+Magic_BPs_TP = S { 'Impact', 'Conflag Strike', 'Level ? Holy', 'Lunar Bay' }
+Merit_BPs = S { 'Meteor Strike', 'Geocrush', 'Grand Fall', 'Wind Blade', 'Heavenly Strike', 'Thunderstorm' }
+Physical_BPs_TP = S { 'Rock Buster', 'Mountain Buster', 'Crescent Fang', 'Spinning Dive' }
+AvatarList = S { 'Shiva', 'Ramuh', 'Garuda', 'Leviathan', 'Diabolos', 'Titan', 'Fenrir', 'Ifrit', 'Carbuncle', 'Fire Spirit', 'Air Spirit', 'Ice Spirit', 'Thunder Spirit',
+    'Light Spirit', 'Dark Spirit', 'Earth Spirit', 'Water Spirit', 'Cait Sith', 'Alexander', 'Odin', 'Atomos' }
 
-SongCount = S{"Knight's Minne", "Knight's Minne II", "Army's Paeon", "Army's Paeon II", "Army's Paeon III", "Army's Paeon IV", "Fowl Aubade", "Herb Pastoral", 
-	"Shining Fantasia", "Scop's Operetta", "Puppet's Operetta", "Gold Capriccio", "Warding Round", "Goblin Gavotte"}
+SongCount = S { "Knight's Minne", "Knight's Minne II", "Army's Paeon", "Army's Paeon II", "Army's Paeon III", "Army's Paeon IV", "Fowl Aubade", "Herb Pastoral",
+    "Shining Fantasia", "Scop's Operetta", "Puppet's Operetta", "Gold Capriccio", "Warding Round", "Goblin Gavotte" }
 
-Enfeebling_Ninjitsu = S{'Jubaku: Ichi','Kurayami: Ni', 'Hojo: Ichi', 'Hojo: Ni', 'Kurayami: Ichi', 'Dokumori: Ichi', 'Aisha: Ichi', 'Yurin: Ichi'}
+Enfeebling_Ninjitsu = S { 'Jubaku: Ichi', 'Kurayami: Ni', 'Hojo: Ichi', 'Hojo: Ni', 'Kurayami: Ichi', 'Dokumori: Ichi', 'Aisha: Ichi', 'Yurin: Ichi' }
 
-Elemental_Bar = S{'Barfire','Barblizzard','Baraero','Barstone','Barthunder','Barwater','Barfira','Barblizzara','Baraera','Barstonra','Barthundra','Barwatera'}
-Status_Bar = S{'Barsleepra','Barpoisonra','Barparalyzra','Barblindra','Barvira','Barpetra','Baramnesra','Barsilencera','Barsleep','Barpoison','Barparalyze','Barblind','Barvirus','Barpetrify','Baramnesia','Barsilence'}
+Elemental_Bar = S { 'Barfire', 'Barblizzard', 'Baraero', 'Barstone', 'Barthunder', 'Barwater', 'Barfira', 'Barblizzara', 'Baraera', 'Barstonra', 'Barthundra', 'Barwatera' }
+Status_Bar = S { 'Barsleepra', 'Barpoisonra', 'Barparalyzra', 'Barblindra', 'Barvira', 'Barpetra', 'Baramnesra', 'Barsilencera', 'Barsleep', 'Barpoison', 'Barparalyze', 'Barblind', 'Barvirus', 'Barpetrify', 'Baramnesia', 'Barsilence' }
 
 -- Standard Ready Moves
-Ready_Standard = S{'Sic','Whirl Claws','Dust Cloud','Foot Kick','Sheep Song','Sheep Charge','Lamb Chop',
-    'Rage','Head Butt','Scream','Dream Flower','Wild Oats','Leaf Dagger','Claw Cyclone','Razor Fang',
-    'Roar','Gloeosuccus','Palsy Pollen','Soporific','Cursed Sphere','Venom','Geist Wall','Toxic Spit',
-    'Numbing Noise','Nimble Snap','Cyclotail','Spoil','Rhino Guard','Rhino Attack','Power Attack',
-    'Hi-Freq Field','Sandpit','Sandblast','Venom Spray','Mandibular Bite','Metallic Body','Bubble Shower',
-    'Bubble Curtain','Scissor Guard','Big Scissors','Grapple','Spinning Top','Double Claw','Filamented Hold',
-    'Frog Kick','Queasyshroom','Silence Gas','Numbshroom','Spore','Dark Spore','Shakeshroom','Blockhead',
-    'Secretion','Fireball','Tail Blow','Plague Breath','Brain Crush','Infrasonics','??? Needles',
-    'Needleshot','Chaotic Eye','Blaster','Scythe Tail','Ripper Fang','Chomp Rush','Intimidate','Recoil Dive',
-    'Water Wall','Snow Cloud','Wild Carrot','Sudden Lunge','Spiral Spin','Noisome Powder','Wing Slap',
-    'Beak Lunge','Suction','Drainkiss','Acid Mist','TP Drainkiss','Back Heel','Jettatura','Choke Breath',
-    'Fantod','Charged Whisker','Purulent Ooze','Corrosive Ooze','Tortoise Stomp','Harden Shell','Aqua Breath',
-    'Sensilla Blades','Tegmina Buffet','Molting Plumage','Swooping Frenzy','Pentapeck','Sweeping Gouge',
-    'Zealous Snort','Somersault ','Tickling Tendrils','Stink Bomb','Nectarous Deluge','Nepenthic Plunge',
-    'Pecking Flurry','Pestilent Plume','Foul Waters','Spider Web','Sickle Slash','Crossthrash','Predatory Glare',
-	'Hoof Volley','Nihility Song','Frenzied Rage','Venom Shower','Mega Scissors','Fluid Toss','Fluid Spread',
-	'Digest','Rhinowrecker'}
+Ready_Standard = S { 'Sic', 'Whirl Claws', 'Dust Cloud', 'Foot Kick', 'Sheep Song', 'Sheep Charge', 'Lamb Chop',
+    'Rage', 'Head Butt', 'Scream', 'Dream Flower', 'Wild Oats', 'Leaf Dagger', 'Claw Cyclone', 'Razor Fang',
+    'Roar', 'Gloeosuccus', 'Palsy Pollen', 'Soporific', 'Cursed Sphere', 'Venom', 'Geist Wall', 'Toxic Spit',
+    'Numbing Noise', 'Nimble Snap', 'Cyclotail', 'Spoil', 'Rhino Guard', 'Rhino Attack', 'Power Attack',
+    'Hi-Freq Field', 'Sandpit', 'Sandblast', 'Venom Spray', 'Mandibular Bite', 'Metallic Body', 'Bubble Shower',
+    'Bubble Curtain', 'Scissor Guard', 'Big Scissors', 'Grapple', 'Spinning Top', 'Double Claw', 'Filamented Hold',
+    'Frog Kick', 'Queasyshroom', 'Silence Gas', 'Numbshroom', 'Spore', 'Dark Spore', 'Shakeshroom', 'Blockhead',
+    'Secretion', 'Fireball', 'Tail Blow', 'Plague Breath', 'Brain Crush', 'Infrasonics', '??? Needles',
+    'Needleshot', 'Chaotic Eye', 'Blaster', 'Scythe Tail', 'Ripper Fang', 'Chomp Rush', 'Intimidate', 'Recoil Dive',
+    'Water Wall', 'Snow Cloud', 'Wild Carrot', 'Sudden Lunge', 'Spiral Spin', 'Noisome Powder', 'Wing Slap',
+    'Beak Lunge', 'Suction', 'Drainkiss', 'Acid Mist', 'TP Drainkiss', 'Back Heel', 'Jettatura', 'Choke Breath',
+    'Fantod', 'Charged Whisker', 'Purulent Ooze', 'Corrosive Ooze', 'Tortoise Stomp', 'Harden Shell', 'Aqua Breath',
+    'Sensilla Blades', 'Tegmina Buffet', 'Molting Plumage', 'Swooping Frenzy', 'Pentapeck', 'Sweeping Gouge',
+    'Zealous Snort', 'Somersault ', 'Tickling Tendrils', 'Stink Bomb', 'Nectarous Deluge', 'Nepenthic Plunge',
+    'Pecking Flurry', 'Pestilent Plume', 'Foul Waters', 'Spider Web', 'Sickle Slash', 'Crossthrash', 'Predatory Glare',
+    'Hoof Volley', 'Nihility Song', 'Frenzied Rage', 'Venom Shower', 'Mega Scissors', 'Fluid Toss', 'Fluid Spread',
+    'Digest', 'Rhinowrecker' }
 
 -- List of Magic-based Ready moves
-Ready_Magic = S{'Dust Cloud','Sheep Song','Scream','Dream Flower','Roar','Gloeosuccus','Palsy Pollen',
-	'Soporific','Cursed Sphere','Venom','Geist Wall','Toxic Spit','Numbing Noise','Spoil','Hi-Freq Field',
-	'Sandpit','Sandblast','Venom Spray','Bubble Shower','Filamented Hold','Queasyshroom','Silence Gas',
-	'Numbshroom','Spore','Dark Spore','Shakeshroom','Fireball','Plague Breath','Infrasonics','Chaotic Eye',
-	'Blaster','Intimidate','Snow Cloud','Noisome Powder','TP Drainkiss','Jettatura','Charged Whisker',
-	'Purulent Ooze','Corrosive Ooze','Aqua Breath','Molting Plumage','Stink Bomb','Nectarous Deluge',
-	'Nepenthic Plunge','Pestilent Plume','Foul Waters','Spider Web'}
+Ready_Magic = S { 'Dust Cloud', 'Sheep Song', 'Scream', 'Dream Flower', 'Roar', 'Gloeosuccus', 'Palsy Pollen',
+    'Soporific', 'Cursed Sphere', 'Venom', 'Geist Wall', 'Toxic Spit', 'Numbing Noise', 'Spoil', 'Hi-Freq Field',
+    'Sandpit', 'Sandblast', 'Venom Spray', 'Bubble Shower', 'Filamented Hold', 'Queasyshroom', 'Silence Gas',
+    'Numbshroom', 'Spore', 'Dark Spore', 'Shakeshroom', 'Fireball', 'Plague Breath', 'Infrasonics', 'Chaotic Eye',
+    'Blaster', 'Intimidate', 'Snow Cloud', 'Noisome Powder', 'TP Drainkiss', 'Jettatura', 'Charged Whisker',
+    'Purulent Ooze', 'Corrosive Ooze', 'Aqua Breath', 'Molting Plumage', 'Stink Bomb', 'Nectarous Deluge',
+    'Nepenthic Plunge', 'Pestilent Plume', 'Foul Waters', 'Spider Web' }
 
 -- List of TP based Ready moves
-Ready_TP = S{'Sic','Somersault','Dust Cloud','Foot Kick','Sheep Song','Sheep Charge','Lamb Chop',
-	'Rage','Head Butt','Scream','Dream Flower','Wild Oats','Leaf Dagger','Claw Cyclone','Razor Fang','Roar',
-	'Gloeosuccus','Palsy Pollen','Soporific','Cursed Sphere','Geist Wall','Numbing Noise','Frogkick',
-	'Nimble Snap','Cyclotail','Spoil','Rhino Guard','Rhino Attack','Hi-Freq Field','Sandpit','Sandblast',
-	'Mandibular Bite','Metallic Body','Bubble Shower','Bubble Curtain','Scissor Guard','Grapple','Spinning Top',
-	'Double Claw','Filamented Hold','Spore','Blockhead','Secretion','Fireball','Tail Blow','Plague Breath',
-	'Brain Crush','Infrasonics','Needleshot','Chaotic Eye','Blaster','Ripper Fang','Intimidate','Recoil Dive',
-	'Water Wall','Snow Cloud','Wild Carrot','Sudden Lunge','Noisome Powder','Beak Lunge','Suction',
-	'Drainkiss','Acid Mist','TP Drainkiss','Back Heel','Jettatura','Choke Breath','Fantod','Charged Whisker',
-	'Purulent Ooze','Corrosive Ooze','Tortoise Stomp','Harden Shell','Aqua Breath','Sensilla Blades',
-	'Tegmina Buffet','Zealous Snort','Pestilent Plume','Foul Waters','Spider Web'}
+Ready_TP = S { 'Sic', 'Somersault', 'Dust Cloud', 'Foot Kick', 'Sheep Song', 'Sheep Charge', 'Lamb Chop',
+    'Rage', 'Head Butt', 'Scream', 'Dream Flower', 'Wild Oats', 'Leaf Dagger', 'Claw Cyclone', 'Razor Fang', 'Roar',
+    'Gloeosuccus', 'Palsy Pollen', 'Soporific', 'Cursed Sphere', 'Geist Wall', 'Numbing Noise', 'Frogkick',
+    'Nimble Snap', 'Cyclotail', 'Spoil', 'Rhino Guard', 'Rhino Attack', 'Hi-Freq Field', 'Sandpit', 'Sandblast',
+    'Mandibular Bite', 'Metallic Body', 'Bubble Shower', 'Bubble Curtain', 'Scissor Guard', 'Grapple', 'Spinning Top',
+    'Double Claw', 'Filamented Hold', 'Spore', 'Blockhead', 'Secretion', 'Fireball', 'Tail Blow', 'Plague Breath',
+    'Brain Crush', 'Infrasonics', 'Needleshot', 'Chaotic Eye', 'Blaster', 'Ripper Fang', 'Intimidate', 'Recoil Dive',
+    'Water Wall', 'Snow Cloud', 'Wild Carrot', 'Sudden Lunge', 'Noisome Powder', 'Beak Lunge', 'Suction',
+    'Drainkiss', 'Acid Mist', 'TP Drainkiss', 'Back Heel', 'Jettatura', 'Choke Breath', 'Fantod', 'Charged Whisker',
+    'Purulent Ooze', 'Corrosive Ooze', 'Tortoise Stomp', 'Harden Shell', 'Aqua Breath', 'Sensilla Blades',
+    'Tegmina Buffet', 'Zealous Snort', 'Pestilent Plume', 'Foul Waters', 'Spider Web' }
 
 -- Magic ACC Based Ready moves
-Ready_Debuff = S{'Dust Cloud','Sheep Song','Scream','Dream Flower','Roar','Gloeosuccus','Palsy Pollen',
-    'Soporific','Geist Wall','Numbing Noise','Spoil','Hi-Freq Field','Sandpit','Sandblast','Filamented Hold',
-	'Spore','Fireball','Infrasonics','Chaotic Eye','Blaster','Intimidate','Noisome Powder','TP Drainkiss',
-	'Jettatura','Purulent Ooze','Corrosive Ooze','Pestilent Plume','Spider Web','Nihility Song'}
+Ready_Debuff = S { 'Dust Cloud', 'Sheep Song', 'Scream', 'Dream Flower', 'Roar', 'Gloeosuccus', 'Palsy Pollen',
+    'Soporific', 'Geist Wall', 'Numbing Noise', 'Spoil', 'Hi-Freq Field', 'Sandpit', 'Sandblast', 'Filamented Hold',
+    'Spore', 'Fireball', 'Infrasonics', 'Chaotic Eye', 'Blaster', 'Intimidate', 'Noisome Powder', 'TP Drainkiss',
+    'Jettatura', 'Purulent Ooze', 'Corrosive Ooze', 'Pestilent Plume', 'Spider Web', 'Nihility Song' }
 
 -- Physical Ready moves that have Multi-Hit
-Ready_Multi = S{'Sweeping Gouge','Tickling Tendrils','Chomp Rush','Pentapeck','Wing Slap','Pecking Flurry'}
+Ready_Multi = S { 'Sweeping Gouge', 'Tickling Tendrils', 'Chomp Rush', 'Pentapeck', 'Wing Slap', 'Pecking Flurry' }
 
 UI_Name = ''
 UI_Name2 = ''
 
 -- Keep local variables to the include
 do
-	-- Used to save the user specific settings
-	local config = require('config')
-	local res = require 'resources'
-
-	local default = { visible = true, debug = false, info = true, warn = true,
-		Display_Box = {text={size=10,font='Consolas',red=255,green=255,blue=255,alpha=255},pos={x=1636,y=803},bg={visible=true,red=0,green=0,blue=0,alpha=102},},
-		Debug_Box = {text={size=10,font='Consolas',red=255,green=255,blue=255,alpha=255},pos={x=1470,y=764},bg={visible=true,red=0,green=0,blue=0,alpha=102},},}
-
-	local buttons = {'State','TH Mode','Auto Buff','Weapon','Job Mode'}
-
-	local Storms = S{"Aurorastorm", "Voidstorm", "Firestorm", "Sandstorm", "Rainstorm", "Windstorm", "Hailstorm", "Thunderstorm", 
-	"Aurorastorm II", "Voidstorm II", "Firestorm II", "Sandstorm II", "Rainstorm II", "Windstorm II", "Hailstorm II", "Thunderstorm II"}
-
-	local UtsusemiSpell = S{'Utsusemi: Ichi','Utsusemi: Ni', 'Utsusemi: San'}
-	local RecastTimers = S{'WhiteMagic','BlackMagic','Ninjutsu','BlueMagic','BardSong','SummoningMagic','SummonerPact'}
-	local SleepSongs = S{'Foe Lullaby','Foe Lullaby II','Horde Lullaby','Horde Lullaby II',}
-
-	local Divergence_Zones = S { "Dynamis - San d'Oria [D]", "Dynamis - Bastok [D]", "Dynamis - Windurst [D]", "Dynamis - Jeuno [D]" }
-
-	local settings = config.load(default)
-
-	local gs_status = texts.new("",settings.Display_Box)
-	if settings.visible then gs_status:show() end
-
-	local gs_debug = texts.new("",settings.Debug_Box)
-	if settings.debug then gs_debug:show() end
-
-	local DualWield = false
-	local TwoHand = false
-
-	local SpellCastTime = 0
-	local Spellstart = os.clock()
-
-	local is_moving = false
-	local is_first_time_load = true
-
-	local last_skillchain_id = 0
-	local last_skillchain_time = 0
-	local last_skillchain_elements = {}
-
-	local UpdateTime1 = os.clock()
-	local UpdateTime2 = os.clock()
-	local Location = {x=0, y=0, z=0}
-	local main_engine_time = os.clock()
-
-	local Require_Update = false
-	local Use_Item_Command = ''
-	local available_bullets = 0
-
-	-- Tracking vars for TH
-	local th_info = {}
-	th_info.tagged_mobs = T{}
-	th_info.last_player_target_index = 0
-
-	-- For TH handling, which event IDs to register for tagging
-	local TaggingCategories = S{1,2,3,4,6,11,14} 
-
-	local Mage_Job = S{'BLM','RDM','WHM','BRD','BLU','GEO','SCH','NIN','PLD','RUN','DRK','SMN'}
-
-	-- City areas for town gear and behavior.
-	local Cities = S{"Ru'Lude Gardens","Upper Jeuno","Lower Jeuno","Port Jeuno","Port Windurst","Windurst Waters","Windurst Woods","Windurst Walls","Heavens Tower","Port San d'Oria","Northern San d'Oria",
-		"Southern San d'Oria","Chateau d'Oraguille","Port Bastok","Bastok Markets","Bastok Mines","Metalworks","Aht Urhgan Whitegate","The Colosseum","Tavnazian Safehold","Nashmau","Selbina",
-		"Mhaura","Rabao","Norg","Kazham","Eastern Adoulin","Western Adoulin","Celennia Memorial Library","Mog Garden","Leafallia"}
-
-	local Language = windower.ffxi.get_info().language:lower()
-
-	local skillchains = {
-		[288] = {id=288,english='Light',elements={'Light','Lightning','Wind','Fire'}},
-		[289] = {id=289,english='Darkness',elements={'Dark','Ice','Water','Earth'}},
-		[290] = {id=290,english='Gravitation',elements={'Dark','Earth'}},
-		[291] = {id=291,english='Fragmentation',elements={'Lightning','Wind'}},
-		[292] = {id=292,english='Distortion',elements={'Ice','Water'}},
-		[293] = {id=293,english='Fusion',elements={'Light','Fire'}},
-		[294] = {id=294,english='Compression',elements={'Dark'}},
-		[295] = {id=295,english='Liquefaction',elements={'Fire'}},
-		[296] = {id=296,english='Induration',elements={'Ice'}},
-		[297] = {id=297,english='Reverberation',elements={'Water'}},
-		[298] = {id=298,english='Transfixion', elements={'Light'}},
-		[299] = {id=299,english='Scission',elements={'Earth'}},
-		[300] = {id=300,english='Detonation',elements={'Wind'}},
-		[301] = {id=301,english='Impaction',elements={'Lightning'}},
-		[385] = {id=385,english='Light',elements={'Light','Lightning','Wind','Fire'}},
-		[386] = {id=386,english='Darkness',elements={'Dark','Ice','Water','Earth'}},
-		[387] = {id=387,english='Gravitation',elements={'Dark','Earth'}},
-		[388] = {id=388,english='Fragmentation',elements={'Lightning','Wind'}},
-		[389] = {id=389,english='Distortion',elements={'Ice','Water'}},
-		[390] = {id=390,english='Fusion',elements={'Light','Fire'}},
-		[391] = {id=391,english='Compression',elements={'Dark'}},
-		[392] = {id=392,english='Liquefaction',elements={'Fire'}},
-		[393] = {id=393,english='Induration',elements={'Ice'}},
-		[394] = {id=394,english='Reverberation',elements={'Water'}},
-		[395] = {id=395,english='Transfixion', elements={'Light'}},
-		[396] = {id=396,english='Scission',elements={'Earth'}},
-		[397] = {id=397,english='Detonation',elements={'Wind'}},
-		[398] = {id=398,english='Impaction',elements={'Lightning'}},
-		[767] = {id=767,english='Radiance',elements={'Light','Lightning','Wind','Fire'}},
-		[768] = {id=768,english='Umbra',elements={'Dark','Ice','Water','Earth'}},
-		[769] = {id=769,english='Radiance',elements={'Light','Lightning','Wind','Fire'}},
-		[770] = {id=770,english='Umbra',elements={'Dark','Ice','Water','Earth'}},}
-
-	--Unlock any previously locked gear
-	enable('main','sub','range','ammo','head','neck','lear','rear','body','hands','lring','rring','waist','legs','feet')
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function is called from the default GearSwap Function "pretarget" to validate the user action
-	-------------------------------------------------------------------------------------------------------------------
-
-	function pretargetcheck(spell,action)
-		log('pretargetcheck called')
-		--Cancel if pet is in middle of move
-		if (pet.isvalid and pet_midaction()) then
-			cancel_spell()
-			return
-		-- Status Ailment Check
-		elseif buffactive['Sleep'] then
-			cancel_spell()
-			if sets.Idle then
-				equip(sets.Idle)
-			else warn('sets.Idle not found!') end
-			if sets.Weapons then
-				if sets.Weapons.Sleep then
-					equip(sets.Weapons.Sleep)
-				else warn('sets.Weapons.Sleep not found!') end
-			else warn('sets.Weapons not found!') end
-		elseif buffactive['Stun'] then
-			cancel_spell()	
-			if sets.Idle then
-				equip(sets.Idle)
-			else warn('sets.Idle not found!') end
-			return
-		elseif buffactive['KO'] then
-			cancel_spell()
-			return
-		elseif buffactive['Petrification'] then
-			cancel_spell()	
-			if sets.Idle then
-				equip(sets.Idle)
-			else warn('sets.Idle not found!') end
-			return
-		elseif buffactive['Charm'] then
-			cancel_spell()
-			return
-		elseif buffactive['Terror'] then
-			cancel_spell()
-			if sets.Idle then
-				equip(sets.Idle)
-			else warn('sets.Idle not found!') end
-			return
-		elseif AutoItem and not buffactive['Muddle'] then
-			-- Auto Remedy --
-			if buffactive['Paralysis'] and spell.type == 'JobAbility' then
-				if player.inventory['Remedy'] ~= nil then
-					cancel_spell()
-					windower.chat.input('/item "Remedy" <me>')
-					log('Cancel Spell - Using Items')
-				end
-			end
-			-- Auto Echo Drops
-			if spell.action_type == 'Magic' and buffactive['Silence'] then
-				if player.inventory['Remedy'] ~= nil then
-					cancel_spell()			
-					windower.chat.input('/item "Remedy" <me>')
-					log('Cancel Spell - Using Items')
-				end
-			end											
-		--Weapon Skill checks
-		elseif spell.type == 'WeaponSkill' then
-			--Stop gear swap when you can't WS
-			if player.tp < 1000 then
-				cancel_spell()
-				log('TP:['..player.tp..']')
-				return
-			--Stop gear swap when you can't WS
-			elseif buffactive['Amnesia'] then
-				cancel_spell()
-				info('Can\'t Weapon Skill due to amnesia.')
-				return
-			end
-		--Cancel ability due to abilty not ready
-		elseif spell.type == 'JobAbility' or spell.type == 'BloodPactWard' or spell.type == 'BloodPactRage' or spell.type == 'PetCommand' then
-			local abil_recasts_table = windower.ffxi.get_ability_recasts()
-			local ability_time = abil_recasts_table[spell.recast_id] / 60
-			local min = math.floor(ability_time)
-			local sec = (ability_time - min) * 60
-			if ability_time > 0 then
-				info(''..spell.name..' ['..string.format("%d:%02d",min,sec)..']')
-				cancel_spell()
-				return
-			end
-		--Cancel certain actions (Defined by RecastTimers) if not ready
-		elseif RecastTimers:contains(spell.type) then
-			local spell_recasts = windower.ffxi.get_spell_recasts()
-			local spell_time = spell_recasts[spell.recast_id] / 60
-			local min = math.floor(spell_time)
-			local sec = (spell_time - min) * 60
-			if spell_time > 0 then
-				info(''..spell.name..' ['..string.format("%d:%02d",min,sec)..']')
-				cancel_spell()
-				return
-			end
-			if target_assist then
-				--Cancel if null target and redirect to self if bard song
-				if not spell.target.type and spell.type == 'BardSong' then
-					if buffactive['Pianissimo'] then
-						if not is_Pianissimo then
-							cancel_spell()
-							windower.chat.input('/ma "'..spell.name..'" <stpc>')
-							is_Pianissimo = true
-						else
-							is_Pianissimo = false
-						end
-					else
-						change_target('<me>')
-					end
-				elseif spell.target.type then
-					local cast_spell = res.spells[spell.id]
-					if not cast_spell.targets then
-						info('Unable to find spell ['..spell.name..']')
-					-- Self Target spells
-					elseif tostring(cast_spell.targets) == '{Self}' then
-						if spell.target.type ~= 'SELF' then
-							-- Change Target Spell
-							log('Redirect Spell:[SELF TARGET]')
-							change_target('<me>')
-						end
-					-- Enemy Spells but not targeting an enemy
-					elseif tostring(cast_spell.targets) == '{Enemy}' then
-						if spell.target.type ~= 'MONSTER' and not spell.name:contains('Lullaby') and not spell.name:contains('Sleep') then
-							--Cancel Spell
-							log('Cancel Spell:['..tostring(spell.target.type)..']')
-							log('Cancel Spell:[ENEMY TARGET]')
-							cancel_spell()
-							return
-						end
-					-- Party Buffs
-					elseif tostring(cast_spell.targets) == '{Self, Party}' or tostring(cast_spell.targets) == '{Self, Party, Ally, NPC}' then
-						if spell.target.type == 'MONSTER' then
-							if spell.type == 'BardSong' then
-								if buffactive['pianissimo'] then
-									if is_Pianissimo == false then
-										cancel_spell()
-										--log('Piassimo Redirect - Select Character')
-										windower.chat.input('/ma \"'..spell.name..'\" <stpc>')
-										is_Pianissimo = true
-									else
-										is_Pianissimo = false
-									end
-								else
-									change_target('<me>')
-									log('Redirect Spell:[SELF TARGET]')
-								end
-							else
-								-- Cancel Spell
-								log('Cancel Spell:[PARTY TARGET]')
-								cancel_spell()
-								return
-							end
-						else
-							if spell.type == 'BardSong' and spell.target.type == 'SELF' and buffactive['Pianissimo'] then
-								log('Pianissimo Redirect - Select Character')
-								cancel_spell()
-								windower.chat.input('/ma \"'..spell.name..'\" <stpc>')
-								return
-							end
-						end
-					end
-				end
-			end
-		end
-		log('pretargetcheck finished')
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function is called from the default GearSwap Function "precast" to build an built_set
-	-------------------------------------------------------------------------------------------------------------------
-
-	function precastequip(spell)
-		log('precastequip Called')
-		--Cancel for SMN if Avatar is mid action
-		if pet.isvalid and pet_midaction() then return end
-		--Default gearset
-		local built_set = {}
-		-- Merge the Idle incase a midcast is not set
-		if sets.Idle then built_set = set_combine(built_set, sets.Idle) end
-		-- WeaponSkill
-		if spell.type == 'WeaponSkill' then
-			if sets.WS then
-				built_set = set_combine(built_set, sets.WS)
-				local message = ''
-				if spell.skill == "Marksmanship" or spell.skill == "Archery" then
-
-					-- Try to equip a generic ranged WS set
-					if sets.WS.RA then 
-						built_set = set_combine(built_set, sets.WS.RA) 
-					else warn('sets.WS.RA not found!') end
-
-					-- Set is defined
-					if sets.WS[spell.english] then
-						built_set = set_combine(built_set, sets.WS[spell.english])
-						-- Example would be WS[Savage Blade]['PDL']
-						if sets.WS[spell.english][state.OffenseMode.value] then
-							built_set = set_combine(built_set, sets.WS[spell.english][state.OffenseMode.value])
-							message = '['..spell.english..'] Set (Augmented)'
-						-- Example would be WS.RA.ACC
-						elseif state.OffenseMode.value ~= 'TP' and sets.WS.RA and sets.WS.RA[state.OffenseMode.value] then
-							built_set = set_combine(built_set, sets.WS.RA[state.OffenseMode.value])
-							-- Augment the specified WS
-							if state.OffenseMode.value == 'ACC' then
-								message = '['..spell.english..'] Set with Accuracy'
-							elseif state.OffenseMode.value == 'PDL' then
-								message = '['..spell.english..'] Set with Physical Damage Limit'
-							elseif state.OffenseMode.value == 'SB' then
-								message = '['..spell.english..'] Set with Subtle Blow'
-							elseif state.OffenseMode.value == 'MEVA' then
-								message = '['..spell.english..'] Set with Magic Evasion'
-							elseif state.OffenseMode.value == 'CRIT' then
-								message = '['..spell.english..'] Set with Critical Hit'
-							end
-						else message = '['..spell.english..'] Set' end
-
-					-- Generic
-					else
-						if state.OffenseMode.value ~= 'TP' and sets.WS.RA and sets.WS.RA[state.OffenseMode.value] then
-							built_set = set_combine(built_set, sets.WS.RA[state.OffenseMode.value])
-							if state.OffenseMode.value == 'ACC' then
-								message = 'Using Default WS Set with Accuracy'
-							elseif state.OffenseMode.value == 'PDL' then
-								message = 'Using Default WS Set with Physical Damage Limit'
-							elseif state.OffenseMode.value == 'SB' then
-								message = 'Using Default WS Set with Subtle Blow'
-							elseif state.OffenseMode.value == 'MEVA' then
-								message = 'Using Default WS Set with Magic Evasion'
-							elseif state.OffenseMode.value == 'CRIT' then
-								message = 'Using Default WS Set with Critical Hit'
-							end
-						else message = 'Using Default WS Set' end
-					end
-
-					-- Check if Aftermath is active
-					if sets.WS.RA then
-						if buffactive['Aftermath: Lv.3'] and sets.WS.RA.AM3 and sets.WS.RA.AM3[state.WeaponMode.value] then
-							built_set = set_combine(built_set, sets.WS.RA.AM3[state.WeaponMode.value])
-							message = message..' and Level 3 Aftermath ['..state.WeaponMode.value..']'
-						elseif buffactive['Aftermath: Lv.2'] and sets.WS.RA.AM2 and sets.WS.RA.AM2[state.WeaponMode.value] then
-							built_set = set_combine(built_set, sets.WS.RA.AM2[state.WeaponMode.value])
-							message = message..' and Level 2 Aftermath ['..state.WeaponMode.value..']'
-						elseif buffactive['Aftermath: Lv.1'] and sets.WS.RA.AM1 and sets.WS.RA.AM1[state.WeaponMode.value] then
-							built_set = set_combine(built_set, sets.WS.RA.AM1[state.WeaponMode.value])
-							message = message..' and Level 1 Aftermath ['..state.WeaponMode.value..']'
-						elseif buffactive['Aftermath'] and sets.WS.RA.AM and sets.WS.RA.AM[state.WeaponMode.value] then
-							built_set = set_combine(built_set, sets.WS.RA.AM[state.WeaponMode.value])
-							message = message..' and Aftermath ['..state.WeaponMode.value..']'
-						end
-					end
-
-					-- Bullet Check
-					do_bullet_checks(spell, built_set)
-
-					-- Variable Ammo
-					if Ammo and Ammo[state.OffenseMode.value] then built_set = set_combine(built_set, { ammo = Ammo[state.OffenseMode.value] }) end
-
-					message = message..' ['..available_bullets..'x]'
-				else
-					-- Set is defined
-					if sets.WS[spell.english] then
-						built_set = set_combine(built_set, sets.WS[spell.english])
-						-- Example would be WS[Savage Blade]['PDL']
-						if sets.WS[spell.english][state.OffenseMode.value] then
-							built_set = set_combine(built_set, sets.WS[spell.english][state.OffenseMode.value])
-							message = '['..spell.english..'] Set (Augmented)'
-						-- Example would be WS.ACC
-						elseif state.OffenseMode.value ~= 'TP' and sets.WS[state.OffenseMode.value] then
-							built_set = set_combine(built_set, sets.WS[state.OffenseMode.value])
-							-- Augment the specified WS
-							if state.OffenseMode.value == 'ACC' then
-								message = '['..spell.english..'] Set with Accuracy'
-							elseif state.OffenseMode.value == 'PDL' then
-								message = '['..spell.english..'] Set with Physical Damage Limit'
-							elseif state.OffenseMode.value == 'SB' then
-								message = '['..spell.english..'] Set with Subtle Blow'
-							elseif state.OffenseMode.value == 'MEVA' then
-								message = '['..spell.english..'] Set with Magic Evasion'
-							elseif state.OffenseMode.value == 'CRIT' then
-								message = '['..spell.english..'] Set with Critical Hit'
-							end
-						else message = '['..spell.english..'] Set' end
-
-					-- Generic
-					else
-						if state.OffenseMode.value ~= 'TP' and sets.WS[state.OffenseMode.value] then
-							built_set = set_combine(built_set, sets.WS[state.OffenseMode.value])
-							-- Augment the specified WS
-							if state.OffenseMode.value == 'ACC' then
-								message = 'Using Default WS Set with Accuracy'
-							elseif state.OffenseMode.value == 'PDL' then
-								message = 'Using Default WS Set with Physical Damage Limit'
-							elseif state.OffenseMode.value == 'SB' then
-								message = 'Using Default WS Set with Subtle Blow'
-							elseif state.OffenseMode.value == 'MEVA' then
-								message = 'Using Default WS Set with Magic Evasion'
-							elseif state.OffenseMode.value == 'CRIT' then
-								message = 'Using Default WS Set with Critical Hit'
-							end
-						else message = 'Using Default WS Set' end
-					end
-
-					-- Check if Aftermath is active
-					if buffactive['Aftermath: Lv.3'] and sets.WS.AM3 and sets.WS.AM3[state.WeaponMode.value] then
-						built_set = set_combine(built_set, sets.WS.AM3[state.WeaponMode.value])
-						message = message..' and Level 3 Aftermath'
-					elseif buffactive['Aftermath: Lv.2'] and sets.WS.AM2 and sets.WS.AM2[state.WeaponMode.value] then
-						built_set = set_combine(built_set, sets.WS.AM2[state.WeaponMode.value])
-						message = message..' and Level 2 Aftermath'
-					elseif buffactive['Aftermath: Lv.1'] and sets.WS.AM1 and sets.WS.AM1[state.WeaponMode.value] then
-						built_set = set_combine(built_set, sets.WS.AM1[state.WeaponMode.value])
-						message = message..' and Level 1 Aftermath'
-					elseif buffactive['Aftermath'] and sets.WS.AM and sets.WS.AM[state.WeaponMode.value] then
-						built_set = set_combine(built_set, sets.WS.AM[state.WeaponMode.value])
-						message = message..' and Aftermath'
-					end
-				end
-
-				-- Check if an Obi or Orpheus is to be Equiped
-				if Elemental_WS:contains(spell.name) then built_set =  elemental_check(spell, built_set) end
-
-				info(message)
-			else warn('sets.WS not found!') end
-		-- Ranged attack
-		elseif spell.action_type == 'Ranged Attack' then
-			if sets.Precast then
-				built_set = set_combine(built_set, sets.Precast)
-				if sets.Precast.RA then
-					built_set = set_combine(built_set, sets.Precast.RA)
-					if buffactive[265] then -- Flurry
-						if sets.Precast.RA.Flurry then
-							built_set = set_combine(built_set, sets.Precast.RA.Flurry)
-						else warn('sets.Precast.RA.Flurry not found!') end
-					elseif buffactive[581] then -- Flurry II
-						if sets.Precast.RA.Flurry_II then
-							built_set = set_combine(built_set, sets.Precast.RA.Flurry_II)
-						else warn('sets.Precast.RA.Flurry_II not found!') end
-					elseif buffactive[228] then -- Embrava
-						if sets.Precast.RA.Flurry_II then
-							built_set = set_combine(built_set, sets.Precast.RA.Flurry_II)
-						else warn('sets.Precast.RA.Flurry_II not found!') end
-					end
-
-					-- Variable Ammo
-					if Ammo and Ammo[state.OffenseMode.value] then built_set = set_combine(built_set, { ammo = Ammo[state.OffenseMode.value] }) end
-
-				else warn('sets.Precast.RA not found!') end
-			else warn('sets.Precast not found!') end
-
-			-- Check for bullets if shooting a round
-			if built_set.ammo ~= "" and built_set.ranged ~= "" then do_bullet_checks(spell, built_set) end
-		-- JobAbility
-		elseif spell.type == 'JobAbility' then
-			if sets.JA then
-				built_set = set_combine(built_set, sets.JA)
-				if spell.name == 'Double-Up' then -- Double Up for distance
-					if sets.PhantomRoll then
-						built_set = set_combine(built_set, sets.PhantomRoll)
-						info('['..spell.english..'] Set')
-					else warn('sets.PhantomRoll not found!') end
-				elseif sets.JA[spell.english] then
-					built_set = set_combine(built_set, sets.JA[spell.english])
-					--Summon the correct jug pet
-					if spell.name == 'Bestial Loyalty' or spell.name == 'Call Beast' then
-						if sets.Jugs[state.JobMode.value] then
-							built_set = set_combine(built_set, sets.Jugs[state.JobMode.value])
-						else warn('sets.Jugs.'..state.JobMode.value..' not found!') end
-					end
-					info('['..spell.english..'] Set')
-				else info('JA not set for ['..spell.english..']') end
-				-- Check for bounty shot ammo
-				if spell.name == 'Bounty Shot' then
-					do_bullet_checks(spell, built_set)
-				end
-			else warn('sets.JA not found!') end
-		-- Items
-		elseif spell.type == 'Item' then 
-			log('Item Use - Precast')
-			if sets.Idle then
-				built_set = sets.Idle
-			else warn('sets.Idle not found!') end
-		-- Scholar
-		elseif spell.type == 'Scholar' then
-			if sets.JA then
-				built_set = set_combine(built_set, sets.JA)
-				if sets.JA[spell.english] then
-					built_set = set_combine(built_set, sets.JA[spell.english])
-					info('['..spell.english..'] Set')
-				else info('Using Default Scholar Set') end
-			else warn('sets.JA not found!') end
-		-- Ward
-		elseif spell.type == 'Ward' then
-			if sets.JA then
-				built_set = set_combine(built_set, sets.JA)
-				if sets.JA[spell.english] then
-					built_set = set_combine(built_set, sets.JA[spell.english])
-					info('['..spell.english..'] Set')
-				else info('Using Default Ward Set') end
-			else warn('sets.JA not found!') end
-		-- Rune
-		elseif spell.type == 'Rune' then
-			if sets.JA then
-				built_set = set_combine(built_set, sets.JA)
-				if sets.JA[spell.english] then
-					built_set = set_combine(built_set, sets.JA[spell.english])
-					info('['..spell.english..'] Set')
-				else info('Using Default Rune Set') end
-			else warn('sets.JA not found!') end
-		-- Effusion
-		elseif spell.type == 'Effusion' then
-			if sets.JA then
-				built_set = set_combine(built_set, sets.JA)
-				if sets.JA[spell.english] then
-					built_set = set_combine(built_set, sets.JA[spell.english])
-					info('['..spell.english..'] Set')
-				else info('Using Default Effusion Set') end
-			else warn('sets.JA not found!') end
-		-- CorsairRoll
-		elseif spell.type == 'CorsairRoll' then
-			log('CorsairRoll')
-			if sets.PhantomRoll then
-				built_set = set_combine(built_set, sets.PhantomRoll)
-				if sets.PhantomRoll[spell.english] then
-					built_set = set_combine(built_set, sets.PhantomRoll[spell.english])
-					info( '['..spell.english..'] Set ')
-				else info('Roll not set') end
-			else warn('sets.PhantomRoll not found!') end
-		-- CorsairShot
-		elseif spell.type == 'CorsairShot' then
-			if sets.QuickDraw then
-				built_set = set_combine(built_set, sets.QuickDraw)
-				if sets.QuickDraw[spell.english] then
-					built_set = set_combine(built_set, sets.QuickDraw[spell.english])
-					info( '['..spell.english..'] Set')
-				else info('Using Default Quick Draw Set') end
-			else warn('sets.QuickDraw not found!') end
-		-- Waltz
-		elseif spell.type == 'Waltz' then
-			if sets.Waltz then
-				built_set = set_combine(built_set, sets.Waltz)
-				if sets.Waltz[spell.english] then
-					built_set = set_combine(built_set, sets.Waltz[spell.english])
-					info('['..spell.english..'] Set')
-				else info('Using Default Waltz Set') end
-			else warn('sets.Waltz not found!') end
-		-- Jig
-		elseif spell.type == 'Jig' then
-			if sets.Jig then
-				built_set = set_combine(built_set, sets.Jig)
-				if sets.Jig[spell.english] then
-					built_set = set_combine(built_set, sets.Jig[spell.english])
-					info('['..spell.english..'] Set')
-				else info('Using Default Jig Set') end
-			else warn('sets.Jig not found!') end
-		-- Samba
-		elseif spell.type == 'Samba' then
-			if sets.Samba then
-				built_set = set_combine(built_set, sets.Samba)
-				if sets.Samba[spell.english] then
-					built_set = set_combine(built_set, sets.Samba[spell.english])
-					info('['..spell.english..'] Set')
-				else info('Using Default Samba Set') end
-			else warn('sets.Samba not found!') end
-		-- Step
-		elseif spell.type == 'Step' then
-			if sets.Step then
-				built_set = set_combine(built_set, sets.Step)
-				if sets.Step[spell.english] then
-					built_set = set_combine(built_set, sets.Step[spell.english])
-					info('['..spell.english..'] Set')
-				else info('Using Default Step Set') end
-			else warn('sets.Step not found!') end
-		-- Flourishes
-		elseif spell.type == 'Flourish1' or spell.type == 'Flourish2' or spell.type == 'Flourish3' then
-			if sets.Flourish then
-				built_set = set_combine(built_set, sets.Flourish)
-				if sets.Flourish[spell.english] then
-					built_set = set_combine(built_set, sets.Flourish[spell.english])
-					info('['..spell.english..'] Set')
-				else info('Using Default Flourish Set') end
-			else warn('sets.Flourish not found!') end
-		-- Magic based actions
-		else
-			-- Precast
-			if sets.Precast then
-				built_set = set_combine(built_set, sets.Precast)
-				-- FastCast
-				if sets.Precast.FastCast then
-					built_set = set_combine(built_set, sets.Precast.FastCast)
-					-- Augment with Enhancing set
-					if spell.skill == 'Enhancing Magic' then
-						if sets.Precast.Enhancing then
-							built_set = set_combine(built_set, sets.Precast.Enhancing)
-						else warn('sets.Precast.Enhancing not found!') end
-					end
-					-- Specified Sets
-					if sets.Precast[spell.english] then
-						built_set = set_combine(built_set, sets.Precast[spell.english])
-					-- Augment with Cure Casting set
-					elseif spell.name:contains('Cure') or spell.name:contains('Cura') then
-						if sets.Precast.Cure then
-							built_set = set_combine(built_set, sets.Precast.Cure)
-						else warn('sets.Precast.Cure not found!') end
-				    -- Augment with Healing Magic set
-					elseif Healing_Magic:contains(spell.name) then
-						if sets.Precast.Healing then
-							built_set = set_combine(built_set, sets.Precast.Healing)
-						else warn('sets.Precast.Healing not found!') end
-					-- Ninjutsu
-					elseif spell.type == 'Ninjutsu' and UtsusemiSpell:contains(spell.name) then
-						do_Utsu_checks(spell)
-						if sets.Precast.Utsusemi then
-							built_set = set_combine(built_set, sets.Precast.Utsusemi)
-						else warn('sets.Precast.Utsusemi not found!') end	
-					-- Blue Magic
-					elseif spell.type == 'BlueMagic' then
-						if sets.Precast.BlueMagic then
-							built_set = set_combine(built_set, sets.Precast.BlueMagic)
-						else warn('sets.Precast.BlueMagic not found!') end		
-					-- BardSong
-					elseif spell.type == 'BardSong' then
-						if buffactive['Nightingale'] then
-							-- Default BRD song gear is in Midcast
-							if sets.Midcast then 
-								built_set = set_combine(built_set, sets.Midcast)
-							else warn('sets.Midcast not found!') end
-							-- Song Count for Dummy Songs
-							if SongCount:contains(spell.name) then
-								if sets.Midcast.DummySongs then
-									built_set = set_combine(built_set, sets.Midcast.DummySongs)
-								else warn('sets.Midcast.DummySongs not found!') end
-								built_set = set_combine(built_set, { range=Instrument.Count })
-							-- Potency / Instruments
-							else
-								-- Defined Gear Set
-								if sets.Midcast[spell.english] then
-									built_set = set_combine(built_set, sets.Midcast[spell.english])
-								-- Equip Harp
-								elseif spell.name:contains('Horde') then
-									if sets.Midcast.Enfeebling then
-										built_set = set_combine(built_set, sets.Midcast.Enfeebling)
-									else warn('sets.Midcast.Enfeebling not found!') end
-									built_set = set_combine(built_set, {range=Instrument.AOE_Sleep})
-								-- Normal Enfeebles
-								elseif Enfeebling_Song:contains(spell.english) then
-									if sets.Midcast.Enfeebling then
-										built_set = set_combine(built_set, sets.Midcast.Enfeebling)
-									else warn('sets.Midcast.Enfeebling not found!') end
-									built_set = set_combine(built_set, {range=Instrument.Potency})
-								-- Augment the buff songs
-								else
-									built_set = set_combine(built_set, {range=Instrument.Potency})
-								end
-								-- Augment the specific Song if set
-								built_set = set_combine(built_set, equip_song_gear(spell, built_set['range']))
-							end
-						else
-							if sets.Precast.Songs then
-								built_set = set_combine(built_set, sets.Precast.Songs)
-							else warn('sets.Precast.Songs not found!') end
-						end
-					end
-				else warn('sets.Precast.FastCast not found!') end
-			else warn('sets.Precast not found!') end
-		end
-
-		-- Weapon Checks for precast
-		-- If it set to unlocked it will not swap the weapons even if defined in the built_set job lua
-		if state.WeaponMode.value ~= "Unlocked" and spell.type ~= 'CorsairRoll' and spell.name ~= 'Double-Up' then
-			log('Update Weapons - Precast')
-			if state.WeaponMode.value == "Locked" then
-				built_set = set_combine(built_set, { main = player.equipment.main, sub = player.equipment.sub, range = player.equipment.range})
-			else
-				if sets.Weapons then
-					if sets.Weapons[state.WeaponMode.value] then
-						built_set = set_combine(built_set, sets.Weapons[state.WeaponMode.value])
-						if not TwoHand and not DualWield then
-							if sets.Weapons.Shield then
-								built_set = set_combine(built_set, sets.Weapons.Shield)
-							else warn('sets.Weapons.Shield not found!') end
-						end
-					else warn('sets.Weapons.'..state.WeaponMode.value..' not found!') end
-				else warn('sets.Weapons not found!') end
-			end
-		end
-
-		--Swap in bard song weapons no matter the mode
-		if spell.type == 'BardSong' and spell.target.type ~= 'MONSTER' then
-			if sets.Weapons then
-				if sets.Weapons.Songs then
-					built_set = set_combine(built_set, sets.Weapons.Songs)
-					if sets.Weapons.Songs.Midcast then
-						if not DualWield and not TwoHand then
-							if sets.Weapons.Shield then
-								built_set = set_combine(built_set, sets.Weapons.Shield)
-							else warn('sets.Weapons.Shield not found!') end
-						end
-						built_set = set_combine(built_set, sets.Weapons.Songs.Midcast)
-					else warn('sets.Weapons.Songs.Midcast not found!') end
-				else warn('sets.Weapons.Songs not found!') end
-			else warn('sets.Weapons not found!') end
-		end
-
-		-- If TH mode is on - check if new mob and then equip TH gear
-		if state.TreasureMode.value ~= 'None' and spell.target.type == 'MONSTER' and not th_info.tagged_mobs[spell.target.id] then
-			if sets.TreasureHunter then
-				built_set = set_combine(built_set, sets.TreasureHunter)
-				info('['..spell.english..'] Set with Treasure Hunter')
-			else warn('sets.TreasureHunter not found!') end
-		end
-		-- Final built_set built to return.  This is not the final set as custom Job can Augment
-		return built_set
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function is called from the default GearSwap Function "midcast" to build an built_set
-	-------------------------------------------------------------------------------------------------------------------
-
-	function midcastequip(spell)
-
-		if spell.type == 'WeaponSkill' then log('abort midcast') return end
-		if spell.type == 'JobAbility' then log('abort midcast') return end
-		if spell.type == 'Item' then log('abort midcast') return end
-		if spell.type == 'Scholar' then log('abort midcast') return end
-		if spell.type == 'Ward' then log('abort midcast') return end
-		if spell.type == 'Rune' then log('abort midcast') return end
-		if spell.type == 'Effusion' then log('abort midcast') return end
-		if spell.type == 'CorsairRoll' then log('abort midcast') return end
-		if spell.type == 'CorsairShot' then log('abort midcast') return end
-		if spell.type == 'Waltz' then log('abort midcast') return end
-		if spell.type == 'Jig' then log('abort midcast') return end
-		if spell.type == 'Samba' then log('abort midcast') return end
-		if spell.type == 'Step' then log('abort midcast') return end
-		if spell.type == 'Flourish1' or spell.type == 'Flourish2' or spell.type == 'Flourish3' then log('abort midcast') return end
-		if pet.isvalid and pet_midaction() then return end
-
-		--Default gearset
-		local built_set = {}
-		-- Merge the Idle incase a midcast is not set
-		if sets.Idle then built_set = set_combine(built_set, sets.Idle) end
-		-- Merget the Midcast Set
-		if sets.Midcast then 
-			built_set = set_combine(built_set, sets.Midcast)
-			-- Spell interruption Down for the rest of the actions
-			if sets.Midcast.SIRD and spell.action_type ~= 'Ranged Attack' then built_set = set_combine(built_set, sets.Midcast.SIRD) end
-
-			-- Ranged Attack
-			if spell.action_type == 'Ranged Attack' then
-				if sets.Midcast.RA then 
-					local message = ''
-					built_set = set_combine(built_set, sets.Midcast.RA)
-
-					-- Augment based off Mode
-					if state.OffenseMode.value ~= 'TP' and sets.Midcast.RA[state.OffenseMode.value] then
-						built_set = set_combine(built_set, sets.Midcast.RA[state.OffenseMode.value])
-						if state.OffenseMode.value == 'ACC' then
-							message = 'Ranged Attack with Accuracy'
-						elseif state.OffenseMode.value == 'PDL' then
-							message = 'Ranged Attack with Physical Damage Limit'
-						elseif state.OffenseMode.value == 'SB' then
-							message = 'Ranged Attack with Subtle Blow'
-						elseif state.OffenseMode.value == 'MEVA' then
-							message = 'Ranged Attack with Magic Evasion'
-						elseif state.OffenseMode.value == 'DT' then
-							message = 'Ranged Attack with Damage Taken'
-						elseif state.OffenseMode.value == 'PDT' then
-							message = 'Ranged Attack with Physical Damage Taken'
-						elseif state.OffenseMode.value == 'CRIT' then
-							message = 'Ranged Attack with Critical Hit'
-						elseif state.OffenseMode.value == 'True Shot' then
-							message = 'Ranged Attack with True Shot'
-						end
-					else message = 'Ranged Attack Set' end
-
-					-- Check if Aftermath is active
-					if buffactive['Aftermath: Lv.3'] and sets.Midcast.RA.AM3 and sets.Midcast.RA.AM3[state.WeaponMode.value] then
-						built_set = set_combine(built_set, sets.Midcast.RA.AM3[state.WeaponMode.value])
-						message = message.. ' and with Aftermath 3 ['..state.WeaponMode.value..']'
-					elseif buffactive['Aftermath: Lv.2'] and sets.Midcast.RA.AM2 and sets.Midcast.RA.AM2[state.WeaponMode.value] then
-						built_set = set_combine(built_set, sets.Midcast.RA.AM2[state.WeaponMode.value])
-						message = message.. ' and with Aftermath 2 ['..state.WeaponMode.value..']'
-					elseif buffactive['Aftermath: Lv.1'] and sets.Midcast.RA.AM1 and sets.Midcast.RA.AM1[state.WeaponMode.value] then
-						built_set = set_combine(built_set, sets.Midcast.RA.AM1[state.WeaponMode.value])
-						message = message.. ' and with Aftermath 1 ['..state.WeaponMode.value..']'
-					elseif buffactive['Aftermath'] and sets.Midcast.RA.AM and sets.Midcast.RA.AM[state.WeaponMode.value] then
-						built_set = set_combine(built_set, sets.Midcast.RA.AM[state.WeaponMode.value])
-						message = message.. ' and with Aftermath ['..state.WeaponMode.value..']'
-					end
-
-					-- Buffs
-					if buffactive['Triple Shot'] and sets.Midcast.RA.TripleShot then 
-						built_set = set_combine(built_set, sets.Midcast.RA.TripleShot)
-						message = 'Using Triple Shot Set'
-					elseif buffactive['Double Shot'] and sets.Midcast.RA.DoubleShot then 
-						built_set = set_combine(built_set, sets.Midcast.RA.DoubleShot)
-						message = 'Using Double Shot Set'
-					elseif buffactive['Barrage'] and sets.Midcast.RA.Barrage then 
-						built_set = set_combine(built_set, sets.Midcast.RA.Barrage)
-						message = 'Using Barrage Set'
-					end
-
-					-- Variable Ammo
-					if Ammo[state.OffenseMode.value] then built_set = set_combine(built_set, { ammo = Ammo[state.OffenseMode.value] }) end
-
-					message = message..' ['..available_bullets..'x]'
-					info(message)
-				else warn('sets.Midcast.RA not found!') end
-			-- Ninjutsu
-			elseif spell.type == 'Ninjutsu' then
-				-- Defined Gear Set
-				if sets.Midcast[spell.english] then
-					built_set = set_combine(built_set, sets.Midcast[spell.english])
-					info('['..spell.english..'] Set')
-				-- Utsusemi Spells
-				elseif UtsusemiSpell:contains(spell.name) then
-					if sets.Midcast.Utsusemi then
-						built_set = set_combine(built_set, sets.Midcast.Utsusemi)
-						info('['..spell.english..'] Utsusemi Set')
-					else warn('sets.Midcast.Utsusemi not found!') end
-				-- Enhancing Magic
-				elseif spell.target.type == 'SELF' then
-					if sets.Midcast.Enhancing then
-						built_set = set_combine(built_set, sets.Midcast.Enhancing)
-						info('Enhancing set')
-					else warn('sets.Midcast.Enhancing not found!') end
-				-- Enfeebling
-				elseif Enfeebling_Ninjitsu:contains(spell.english) then
-					if sets.Midcast.Enfeebling then
-						built_set = set_combine(built_set, sets.Midcast.Enfeebling)
-						info('Enfeebling set')
-					else warn('sets.Midcast.Enfeebling not found!') end
-				-- Defaults to Nukes if not the above
-				else
-					if sets.Midcast.Nuke then
-						built_set = set_combine(built_set, sets.Midcast.Nuke)
-						info('Nuke set')
-					else warn('sets.Midcast.Nuke not found!') end
-					-- Check for an elemental set
-					built_set = elemental_check(spell, built_set)
-				end
-			-- WhiteMagic
-			elseif spell.type == 'WhiteMagic' then
-				-- Cure
-				if spell.name:contains('Cure') then
-					if sets.Midcast.Cure then
-						built_set = set_combine(built_set, sets.Midcast.Cure)
-						info('Cure Set')
-					else warn('sets.Midcast.Cure not found!') end
-					-- Check if an Obi or Orpheus is to be Equiped
-					built_set =  elemental_check(spell, built_set)
-				-- Curaga 
-				elseif spell.name:contains('Curaga') then
-					if sets.Midcast.Curaga then
-						built_set = set_combine(built_set, sets.Midcast.Curaga)
-						info('Curaga Set')
-					else warn('sets.Midcast.Curaga not found!') end
-					-- Check if an Obi or Orpheus is to be Equiped
-					built_set =  elemental_check(spell, built_set)
-				-- Cura
-				elseif spell.name:contains('Cura') then
-					if sets.Midcast.Cura then
-						built_set = set_combine(built_set, sets.Midcast.Cura)
-						info('Cura Set')
-					else warn('sets.Midcast.Cura not found!') end
-					-- Check if an Obi or Orpheus is to be Equiped
-					built_set =  elemental_check(spell, built_set)
-				-- Defined Gear Set
-				elseif sets.Midcast[spell.english] then
-					built_set = set_combine(built_set, sets.Midcast[spell.english])
-					info('['..spell.english..'] Set')
-				-- Healing Magic
-				elseif spell.name:contains('Raise') or spell.name == "Arise" or spell.name:contains('Reraise') then
-					log('No Swap Defined (Raise)')
-				-- Enhancing
-				elseif spell.skill == 'Enhancing Magic' then
-					if sets.Midcast.Enhancing then
-						built_set = set_combine(built_set, sets.Midcast.Enhancing)
-						-- Augment the set for Others if defined
-						if spell.target.type ~= 'SELF' or (spell.target.type == 'SELF' and buffactive['Accession']) then
-							if sets.Midcast.Enhancing.Others then
-								built_set = set_combine(built_set, sets.Midcast.Enhancing.Others)
-							else warn('sets.Midcast.Enhancing.Others not found!') end
-						end
-						-- Refresh
-						if spell.name:contains('Refresh') then
-							if sets.Midcast.Refresh then
-								built_set = set_combine(built_set, sets.Midcast.Refresh)
-								info('Refresh Set')
-							else warn('sets.Midcast.Refresh not found!') end
-						-- Regen
-						elseif spell.name:contains('Regen') then
-							if sets.Midcast.Regen then
-								built_set = set_combine(built_set, sets.Midcast.Regen)
-								info('Regen Set')
-							else warn('sets.Midcast.Regen not found!') end
-						elseif Storms:contains(spell.name) then
-							if sets.Storms then
-								built_set = set_combine(built_set, sets.Storms)
-								info('Storms Set')
-							else warn('sets.Storms not found!') end
-						-- Gain Spells
-						elseif spell.name:contains('Gain') then
-							if sets.Midcast.Enhancing.Gain then
-								built_set = set_combine(built_set, sets.Midcast.Enhancing.Gain)
-								info('Gain Set')
-							else warn('sets.Midcast.Enhancing.Gain not found!') end
-						-- Phalanx
-						elseif spell.name:contains('Phalanx') then
-							if sets.Midcast.Phalanx then
-								built_set = set_combine(built_set, sets.Midcast.Phalanx)
-								info('Phalanx Set')
-							else warn('sets.Midcast.Phalanx not found!') end
-						-- Bar Spells
-						elseif Elemental_Bar:contains(spell.name) then
-							if sets.Midcast.Enhancing.Elemental then
-								built_set = set_combine(built_set, sets.Midcast.Enhancing.Elemental)
-								info('Elemental Bar Element Set')
-							else warn('sets.Midcast.Enhancing.Elemental not found!') end
-						-- Bar Status
-						elseif Status_Bar:contains(spell.name) then
-							if sets.Midcast.Enhancing.Status then
-								built_set = set_combine(built_set, sets.Midcast.Enhancing.Status)
-								info('Status Bar Status Set')
-							else warn('sets.Midcast.Enhancing.Status not found!') end
-						-- Enhancing SKill
-						elseif Enhancing_Skill:contains(spell.name) then
-							if sets.Midcast.Enhancing.Skill then
-								built_set = set_combine(built_set, sets.Midcast.Enhancing.Skill)
-								info('Enhancing Skill Set')
-							else warn('sets.Midcast.Enhancing.Skill not found!') end
-						-- Enhancing
-						else info('Enhancing Magic Set') end
-					else warn('sets.Midcast.Enhancing not found!') end
-				-- Divine Spells
-				elseif Divine_Skill:contains(spell.name) then
-					if sets.Midcast.Divine then
-						built_set = set_combine(built_set, sets.Midcast.Divine)
-						info('Divine Skill Set')
-					else warn('sets.Midcast.Divine not found!') end
-				-- Enfeebling Magic
-				elseif spell.skill == 'Enfeebling Magic' then
-					if sets.Midcast.Enfeebling then
-						built_set = set_combine(built_set, sets.Midcast.Enfeebling)
-						-- Accuracy
-						if Enfeeble_Acc:contains(spell.name) then
-							if sets.Midcast.Enfeebling.MACC then
-								built_set = set_combine(built_set, sets.Midcast.Enfeebling.MACC)
-								info('Enfeebling Magic Set - Magic Accuracy')
-							else warn('sets.Midcast.Enfeebling.MACC not found!') end
-						-- Potency
-						elseif Enfeeble_Potency:contains(spell.name) then
-							if sets.Midcast.Enfeebling.Potency then
-								built_set = set_combine(built_set, sets.Midcast.Enfeebling.Potency)
-								info('Enfeebling Magic Set - Potency')
-							else warn('sets.Midcast.Enfeebling.Potency not found!') end
-						-- Duration
-						elseif Enfeeble_Duration:contains(spell.name) then
-							if sets.Midcast.Enfeebling.Duration then
-								built_set = set_combine(built_set, sets.Midcast.Enfeebling.Duration)
-								info('Enfeebling Magic Set - Duration')
-							else warn('sets.Midcast.Enfeebling.Duration not found!') end
-						-- Default
-						else info('Enfeebling Magic Set') end
-					else info('No sets.Midcast.Enfeebling defined!') end
-				end
-			-- Black Magic
-			elseif spell.type == 'BlackMagic' then
-				-- Defined Gear Set
-				if sets.Midcast[spell.english] then
-					built_set = set_combine(built_set, sets.Midcast[spell.english])
-					-- Check for an elemental set
-					if spell.skill == 'Elemental Magic' and not spell.name:contains('helix') then built_set = elemental_check(spell, built_set) end
-					info( '['..spell.english..'] Set')
-				-- Aspir Gear
-				elseif spell.name:contains('Aspir') then
-					if sets.Midcast.Aspir then
-						built_set = set_combine(built_set, sets.Midcast.Aspir)
-						info('Aspir Set')
-					else warn('sets.Midcast.Aspir not found!') end
-				-- Drain Gear
-				elseif spell.name:contains('Drain') then
-					if sets.Midcast.Drain then
-						built_set = set_combine(built_set, sets.Midcast.Drain)
-						info('Drain Set')
-					else warn('sets.Midcast.Drain not found!') end
-				-- Enfeebling Magic
-				elseif spell.skill == 'Enfeebling Magic' then
-					if sets.Midcast.Enfeebling then
-						built_set = set_combine(built_set, sets.Midcast.Enfeebling)
-						-- Accuracy
-						if Enfeeble_Acc:contains(spell.name) then
-							if sets.Midcast.Enfeebling.MACC then
-								built_set = set_combine(built_set, sets.Midcast.Enfeebling.MACC)
-								info('Enfeebling Magic Set - Magic Accuracy')
-							else warn('sets.Midcast.Enfeebling.MACC not found!') end
-						-- Potency
-						elseif Enfeeble_Potency:contains(spell.name) then
-							if sets.Midcast.Enfeebling.Potency then
-								built_set = set_combine(built_set, sets.Midcast.Enfeebling.Potency)
-								info('Enfeebling Magic Set - Potency')
-							else warn('sets.Midcast.Enfeebling.Potency not found!') end
-						-- Duration
-						elseif Enfeeble_Duration:contains(spell.name) then
-							if sets.Midcast.Enfeebling.Duration then
-								built_set = set_combine(built_set, sets.Midcast.Enfeebling.Duration)
-								info('Enfeebling Magic Set - Duration')
-							else warn('sets.Midcast.Enfeebling.Duration not found!') end
-						-- Default
-						else info('Enfeebling Magic Set') end
-					else info('No sets.Midcast.Enfeebling not found!') end
-				-- Dark Magic
-				elseif spell.skill == 'Dark Magic' then
-					if sets.Midcast.Dark then
-						built_set = set_combine(built_set, sets.Midcast.Dark)
-						-- Accuracy
-						if Dark_Acc:contains(spell.name) then
-							if sets.Midcast.Dark.MACC then
-								built_set = set_combine(built_set, sets.Midcast.Dark.MACC)
-								info('Dark Magic Set - Magic Accuracy')
-							else warn('sets.Midcast.Dark.MACC not found!') end
-						-- Absorb
-						elseif Dark_Absorb:contains(spell.name) then
-							if sets.Midcast.Dark.Absorb then
-								built_set = set_combine(built_set, sets.Midcast.Dark.Absorb)
-								info('Absorb Magic Set - Potency')
-							else warn('sets.Midcast.Dark.Absorb not found!') end
-						-- Enhancing
-						elseif Dark_Enhancing:contains(spell.name) then
-							if sets.Midcast.Dark.Enhancing then
-								built_set = set_combine(built_set, sets.Midcast.Dark.Enhancing)
-								info('Dark Enhancing Magic Set - Duration')
-							else warn('sets.Midcast.Dark.Enhancing not found!') end
-						-- Potency
-						elseif Enfeeble_Potency:contains(spell.name) then
-							if sets.Midcast.Enfeebling.Potency then
-								built_set = set_combine(built_set, sets.Midcast.Enfeebling.Potency)
-								info('Enfeebling Magic Set - Potency')
-							else warn('sets.Midcast.Enfeebling.Potency not found!') end
-						-- Duration
-						elseif Enfeeble_Duration:contains(spell.name) then
-							if sets.Midcast.Enfeebling.Duration then
-								built_set = set_combine(built_set, sets.Midcast.Enfeebling.Duration)
-								info('Enfeebling Magic Set - Duration')
-							else warn('sets.Midcast.Enfeebling.Duration not found!') end
-						-- Default
-						else info('Dark Magic Set') end
-					else info('No sets.Midcast.Dark not found!') end
-				-- Enhancing Magic
-				elseif spell.skill == 'Enhancing Magic' then
-					if sets.Midcast.Enhancing then
-						built_set = set_combine(built_set, sets.Midcast.Enhancing)
-						info('Enhancing Magic Set')
-					else warn('sets.Midcast.Enhancing not found!') end
-				-- Enfeebling Elemental Magic
-				elseif Elemental_Enfeeble:contains(spell.name) then
-					if sets.Midcast.Enfeebling then
-						built_set = set_combine(built_set, sets.Midcast.Enfeebling)
-						if sets.Midcast.Enfeebling.MACC then
-							built_set = set_combine(built_set, sets.Midcast.Enfeebling.MACC)
-							info('Enfeebling Magic Set - Magic Accuracy')
-						else warn('sets.Midcast.Enfeebling.MACC not found!') end
-					else warn('sets.Midcast.Enfeebling not found!') end
-				-- Standard Offensive Spells
-				elseif spell.skill == 'Elemental Magic' then
-					local element = res.spells[spell.id].element
-					local element_name = res.elements[element].en
-					if spell.target.id == last_skillchain_id and os.clock() - last_skillchain_time < 8 and last_skillchain_elements[element_name] then
-						info("Burst Detected!")
-						if sets.Midcast.Burst then
-							built_set = set_combine(built_set, sets.Midcast.Burst)
-						else warn('sets.Midcast.Burst not found!') end
-					else
-						if sets.Midcast.Nuke then
-							built_set = set_combine(built_set, sets.Midcast.Nuke)
-							info('Nuke Set')
-						else warnd('sets.Midcast.Nuke not found!') end
-					end
-					-- Check for Helix
-					if spell.name:contains('helix') then
-						if sets.Helix then
-							built_set = set_combine(built_set, sets.Helix)
-							if spell.element == 'Dark' then
-								if sets.Helix.Dark then
-									built_set = set_combine(built_set, sets.Helix.Dark)
-								else warn('sets.Helix.Dark not found!') end
-							elseif spell.element == 'Light' then
-								if sets.Helix.Light then
-									built_set = set_combine(built_set, sets.Helix.Light)
-								else warn('sets.Helix.Light not found!') end
-							end
-						else warn('sets.Helix not found!') end
-					else
-						if spell.element == "Earth" and sets.Midcast.Nuke.Earth then
-							built_set = set_combine(built_set, sets.Midcast.Nuke.Earth)
-							windower.add_to_chat(8,'Earth Element Detected!')
-						end
-						-- Check for an elemental set
-						built_set = elemental_check(spell, built_set)
-					end
-				end
-			-- Bard Song
-			elseif spell.type == 'BardSong' then
-				-- Song Count for Dummy Songs
-				if SongCount:contains(spell.name) then
-					if sets.Midcast.DummySongs then
-						built_set = set_combine(built_set, sets.Midcast.DummySongs)
-						info( '['..spell.english..'] Set (Song Count)')
-					else warn('sets.Midcast.DummySongs not found!') end
-					built_set = set_combine(built_set, {range=Instrument.Count})
-				-- Potency / Instruments
-				else
-					-- Defined Gear Set
-					if sets.Midcast[spell.english] then
-						built_set = set_combine(built_set, sets.Midcast[spell.english])
-						info( '['..spell.english..'] Set')
-					-- Equip Harp
-					elseif spell.name:contains('Horde') then
-						if sets.Midcast.Enfeebling then
-							built_set = set_combine(built_set, sets.Midcast.Enfeebling)
-						else warn('sets.Midcast.Enfeebling not found!') end
-						built_set = set_combine(built_set, {range=Instrument.AOE_Sleep})
-						info( '['..spell.english..'] Set (AOE Sleep)')
-					-- Normal Enfeebles
-					elseif Enfeebling_Song:contains(spell.english) then
-						if sets.Midcast.Enfeebling then
-							built_set = set_combine(built_set, sets.Midcast.Enfeebling)
-						else warn('sets.Midcast.Enfeebling not found!') end
-						built_set = set_combine(built_set, {range=Instrument.Enfeebling})
-						info( '['..spell.english..'] Set (Enfeebling)')
-					-- Augment the buff songs
-					else
-						info( '['..spell.english..'] Set (Potency)')
-						built_set = set_combine(built_set, {range=Instrument.Potency})
-					end
-					-- Augment the specific Song if set
-					built_set = set_combine(built_set, equip_song_gear(spell, built_set['range']))
-				end
-			-- BlueMagic
-			elseif spell.type == 'BlueMagic' then
-				-- Defined Set
-				if sets.Midcast[spell.english] then
-					built_set = set_combine(built_set, sets.Midcast[spell.english])
-					-- Check for an elemental set
-					if BlueNuke:contains(spell.english) then built_set = elemental_check(spell, built_set) end
-					info( '['..spell.english..'] Set')
-				else
-					if sets.Midcast.BlueMagic then
-						-- Defined Blue Nukes
-						if BlueNuke:contains(spell.english) then
-							if sets.Midcast.BlueMagic.Nuke then
-								built_set = set_combine(built_set, sets.Midcast.BlueMagic.Nuke)
-								info('Blue Nuke set')
-							else warn('sets.Midcast.BlueMagic.Nuke not found!') end
-							built_set = elemental_check(spell, built_set)
-						-- Spells that benifit from Blue Magic Skill
-						elseif BlueSkill:contains(spell.english) then
-							if sets.Midcast.BlueMagic.Skill then
-								built_set = set_combine(built_set, sets.Midcast.BlueMagic.Skill)
-								info('Blue Skill set')
-							else warn('sets.Midcast.BlueMagic.Skill not found!') end
-						elseif BlueTank:contains(spell.english) then
-							if sets.Midcast.BlueMagic.Enmity then
-								built_set = set_combine(built_set, sets.Midcast.BlueMagic.Enmity)
-								info('Blue Enmity set')
-							else warn('sets.Midcast.BlueMagic.Enmity not found!') end
-						elseif BlueHealing:contains(spell.english) then
-							if sets.Midcast.BlueMagic.Healing then
-								built_set = set_combine(built_set, sets.Midcast.BlueMagic.Healing)
-								info('Blue Cure set')
-							else warn('sets.Midcast.BlueMagic.Healing not found!') end
-						elseif BlueACC:contains(spell.english) then
-							if sets.Midcast.BlueMagic.ACC then
-								built_set = set_combine(built_set, sets.Midcast.BlueMagic.ACC)
-								info('Blue Magic Accuracy set')
-							else warn('sets.Midcast.BlueMagic.ACC not found!') end
-						-- Default Spell set
-						else info('Midcast not set') end
-						if buffactive["Diffusion"] then
-							if sets.Diffusion then
-								built_set = set_combine(built_set, sets.Diffusion)
-								info('Diffusion Augment')
-							else warn('sets.Diffusion not found!') end
-						end
-					else warn('sets.Midcast.BlueMagic not found!') end
-				end
-			-- Geomancy
-			elseif spell.type == 'Geomancy' then
-				if sets.Geomancy then
-					-- Defined Set
-					if sets.Geomancy[spell.english] then
-						built_set = set_combine(built_set, sets.Geomancy[spell.english])
-						info( '['..spell.english..'] Set')
-					-- Indi Equipment
-					elseif Indicolure_List:contains(spell.english) then
-						if sets.Geomancy.Indi then
-							built_set = set_combine(built_set, sets.Geomancy.Indi)
-							if spell.target.type ~= "SELF" then
-								if sets.Geomancy.Indi.Entrust then
-									built_set = set_combine(built_set, sets.Geomancy.Indi.Entrust)
-									info('Indicolure set - Entrust')
-								else warn('sets.Geomancy.Indi.Entrust not found!') end
-							else info('Indicolure set') end
-						else warn('sets.Geomancy.Indi not found!') end
-					-- Bubble Equipment
-					elseif Geomancy_List:contains(spell.english) then
-						if sets.Geomancy.Geo then
-							built_set = set_combine(built_set, sets.Geomancy.Geo)
-							info('Geomancy set')
-						else warn('sets.Geomancy.Geo not found!') end
-					-- Default set
-					else info('Midcast not set') end
-				else warn('sets.Geomancy not found!') end
-			-- Trust
-			elseif spell.type == 'Trust' then
-				log('Nothing Defined')
-			-- BloodPactRage and BloodPactWard
-			elseif spell.type == "BloodPactWard" or spell.type == "BloodPactRage" then
-				-- BP Timer gear needs to swap here if not under Astral Conduit
-				if not buffactive["Astral Conduit"] then
-					if sets.Midcast[spell.english] then
-						built_set = set_combine(built_set, sets.Midcast[spell.english])
-						info('['..spell.english..'] Set')
-					elseif sets.Midcast.BP then
-						built_set = set_combine(built_set, sets.Midcast.BP)
-						info('Blood Pact Set')
-					else warn('sets.Midcast.BP not found!') end
-				else
-					-- Astral Conduit active so don't swap gear
-					built_set = {}
-				end
-			-- Monster
-			elseif spell.type == 'Monster' then
-				if sets.Ready then
-					built_set = set_combine(built_set, sets.Ready)
-					info('[Ready] Set')
-				else warn('sets.Ready not found!') end
-			-- Elemental Siphon
-			elseif spell.name == "Elemental Siphon" then
-				if sets.Midcast[spell.english] then
-					built_set = set_combine(built_set, sets.Midcast[spell.english])
-					info('['..spell.english..'] Set')
-				else
-					if sets.Midcast.SummoningMagic then
-						built_set = set_combine(built_set, sets.Midcast.SummoningMagic)
-						info('Summoning Magic Set')
-					else warn('sets.Midcast.SummoningMagic not found!') end
-				end
-			-- Summon Avatar
-			elseif spell.type == "SummonerPact" then
-				if sets.Midcast[spell.english] then
-					built_set = set_combine(built_set, sets.Midcast[spell.english])
-					info('['..spell.english..'] Set')
-				else
-					if sets.Midcast.Summon then
-						built_set = set_combine(built_set, sets.Midcast.Summon)
-						info('Summon Magic Set')
-					else warn('sets.Midcast.Summon not found!') end
-				end
-			end
-		else warn('sets.Midcast not found!') end
-		-- Auto-cancel existing buffs
-		if spell.name == "Stoneskin" and buffactive["Stoneskin"] then
-			send_command('cancel 37;')
-		elseif spell.name == "Sneak" and buffactive["Sneak"] and spell.target.type == "SELF" then
-			send_command('cancel 71;')
-		elseif spell.name == "Spectral Jig" and buffactive["Sneak"] then
-			send_command('cancel 71;')
-		elseif spell.name == "Utsusemi: Ichi" and buffactive["Copy Image"] then
-			send_command('wait .5;cancel 66;')
-		end
-		-- Weapon Checks for midcast
-		-- If it set to unlocked it will not swap the weapons even if defined in the built_set job lua
-		if state.WeaponMode.value ~= "Unlocked" then
-			if spell.type == 'Geomancy' then
-				log('Swap Weapon due to Geomancy')
-			elseif state.WeaponMode.value == "Locked" then
-				built_set = set_combine(built_set, { main=player.equipment.main, sub = player.equipment.sub, range = player.equipment.range})
-				log(built_set)
-			else
-				if sets.Weapons then
-					if sets.Weapons[state.WeaponMode.value] then
-						built_set = set_combine(built_set, sets.Weapons[state.WeaponMode.value])
-					else warn('sets.Weapons.'..state.WeaponMode.value..' not found!') end
-					if not TwoHand and not DualWield then
-						if sets.Weapons.Shield then
-							built_set = set_combine(built_set, sets.Weapons.Shield)
-						else warn('sets.Weapons.Shield not found!') end
-					end
-				else warn('sets.Weapons not found!') end
-			end
-		end
-
-		--Swap in bard song weapons no matter the mode
-		if spell.type == 'BardSong' and spell.target.type ~= 'MONSTER' then
-			-- Weapons
-			if sets.Weapons.Songs then
-				built_set = set_combine(built_set, sets.Weapons.Songs)
-				if sets.Weapons.Songs.Midcast then
-					built_set = set_combine(built_set, sets.Weapons.Songs.Midcast)
-					if not DualWield and not TwoHand then
-						if sets.Weapons.Shield then
-							built_set = set_combine(built_set, sets.Weapons.Shield)
-						else warn('sets.Weapons.Shield not found!') end
-					end
-				else warn('sets.Weapons.Songs.Midcast not found!') end
-			else warn('sets.Weapons.Songs not found!') end
-
-			-- Instruments for pianissimo buffs
-			if spell.target.id ~= player.id and not SongCount:contains(spell.name) and (spell.target.type == 'PLAYER' or spell.target.type == 'NPC') then
-				log('Pianissimo Check')
-				if Instrument then
-					--Check for pianissimo Weapons
-					if Instrument.Pianissimo then
-						built_set = set_combine(built_set, {range = equip_pianissimo_gear(spell)})
-					else warn('Instrument.Pianissimo not found!') end
-				else warn('Instrument not found!') end
-			end
-		end
-		-- If TH mode is on - check if new mob and then equip TH gear
-		if 	state.TreasureMode.value ~= 'None' and spell.target.type == 'MONSTER' and not th_info.tagged_mobs[spell.target.id] and sets.TreasureHunter then
-			built_set = set_combine(built_set, sets.TreasureHunter)
-			info('['..spell.english..'] Set with Treasure Hunter')
-		end
-		-- Built built_set to return
-		return built_set
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function is called from the default GearSwap Function "aftercast" to build an built_set
-	-------------------------------------------------------------------------------------------------------------------
-
-	function aftercastequip(spell)
-		-- Dont change gear as the pet is still performing an action
-		if pet_midaction() then
-			return
-		else
-			local built_set = choose_set()
-			if choose_set_custom then
-				built_set = set_combine(built_set, choose_set_custom())
-			else info('choose_set_custom() not found!') end
-			return built_set
-		end
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function is called by gearswap for pretarget checks
-	-------------------------------------------------------------------------------------------------------------------
-
-	function pretarget(spell,action)
-		--Calls the function in the include file for basic checks
-		pretargetcheck(spell,action)
-		--Calls the job specific function
-		if pretarget_custom(spell,action) then
-			pretarget_custom(spell,action)
-		end
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function is called by gearswap for precast checks
-	-------------------------------------------------------------------------------------------------------------------
-
-	function precast(spell)
-		-- Spell timed out
-		if is_Busy and os.clock() - Spellstart > SpellCastTime then is_Busy = false SpellCastTime = 0 end
-		if not is_Busy then
-			if RecastTimers:contains(spell.type) then
-				local cast_spell = res.spells[spell.id]
-				-- assume 80% FC
-				SpellCastTime = cast_spell.cast_time *.2 + 2.5
-				-- Spell not delay set to default 2 sec
-				if buffactive["Chainspell"] or buffactive["Nightingale"] then
-					 SpellCastTime = 1
-				end
-			elseif spell.action_type == 'Ranged Attack' then
-				SpellCastTime = 1.1
-			else
-				-- Set duration of JA/WS
-				SpellCastTime = 1
-			end
-			-- Spell timer counter
-			Spellstart = os.clock()
-			is_Busy = true
-		else
-			log('Player is Busy ['..spell.english..']')
-			cancel_spell()
-			return
-		end
-		--Generate the correct set from the include file and custom function
-		local built_set = precastequip(spell)
-		-- Process a custom set if enabled
-		if precast_custom then
-			built_set = set_combine(built_set, precast_custom(spell))
-		else warn('precast_custom() not found!') end
-		-- Check the gear
-		built_set = set_combine(built_set, check_equipment_spells(spell))
-		-- Here is where gear is actually equipped
-		equip(built_set)
-	end
-
-	 -------------------------------------------------------------------------------------------------------------------
-	-- This function is called by gearswap for midcast checks
-	-------------------------------------------------------------------------------------------------------------------
-
-	function midcast(spell)
-		--Generate the correct set from the include file and custom function
-		local built_set = midcastequip(spell)
-		-- Process a custom set if enabled
-		if midcast_custom then
-			built_set = set_combine(built_set, midcast_custom(spell))
-		else warn('midcast_custom() not found!') end
-		-- Check the gear
-		built_set = set_combine(built_set, check_equipment_spells(spell))
-		-- Here is where gear is actually equipped
-		equip(built_set)
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function is called by gearswap for aftercast checks
-	-------------------------------------------------------------------------------------------------------------------
-
-	function aftercast(spell)
-		--Generate the correct set from the include file and custom function
-		local built_set = aftercastequip (spell)
-		if aftercast_custom then
-			built_set = set_combine(built_set, aftercast_custom(spell))
-		else warn('aftercast_custom() not found!') end
-		-- here is where gear is actually equipped
-		equip(built_set)
-		-- Begin Reset Process - Spells have a hard delay where the JA's have a small delay
-		if RecastTimers:contains(spell.type) then
-			SpellCastTime = 2.5
-		elseif spell.action_type == 'Ranged Attack' then
-			SpellCastTime = 1.1
-		else
-			SpellCastTime = 0
-		end
-		Spellstart = os.clock()
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function is called by gearswap for any buff changes
-	-------------------------------------------------------------------------------------------------------------------
-	
-	function buff_change(name,gain)
-		if not is_Busy then
-			--calls the include file and custom on a buff change
-			local built_set = choose_set()
-			if choose_set_custom then
-				built_set = set_combine(built_set, choose_set_custom())
-			else warn('choose_set_custom() not found!') end
-			if buff_change_custom then
-				built_set = set_combine(built_set, buff_change_custom(name,gain))
-			else warn('buff_change_custom(name,gain) not found!') end
-			-- Here is where gear is actually equipped
-			equip(built_set)
-		end
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function is called by gearswap for any player status changes
-	-------------------------------------------------------------------------------------------------------------------
-
-	function status_change(new,old)
-		--calls the include file and custom on a state change
-		local built_set = choose_set()
-		if choose_set_custom then
-			built_set = set_combine(built_set, choose_set_custom())
-		else warn('choose_set_custom() not found!') end
-		if status_change_custom then
-			built_set = set_combine(built_set, status_change_custom(new,old))
-		else warn('status_change_custom(name,gain) not found!') end
-		-- Here is where gear is actually equipped
-		equip(built_set)
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function is called by gearswap for any pet changes
-	-------------------------------------------------------------------------------------------------------------------
-
-	function pet_change(pet,gain)
-		-- A new pet is found
-		local built_set = choose_set()
-		if choose_set_custom then
-			built_set = set_combine(built_set, choose_set_custom())
-		else warn('choose_set_custom() not found!') end
-		if pet_change_custom then
-			built_set = set_combine(built_set, pet_change_custom(pet,gain))
-		else warn('pet_change_custom() not found!') end
-		-- Here is where gear is actually equipped
-		equip(built_set)
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function is called by gearswap for pet mid actions
-	-------------------------------------------------------------------------------------------------------------------
-
-	function pet_midcast(spell)
-		if sets.Pet_Midcast then
-			local built_set = sets.Pet_Midcast
-			-- Specific sets are defined
-			if sets.Pet_Midcast[spell.english] then
-				built_set = set_combine(built_set, sets.Pet_Midcast[spell.english])
-				info('['..spell.english..'] Set')
-			end
-			-- User level commands
-			if pet_midcast_custom then
-				built_set = set_combine(built_set, pet_midcast_custom(spell))
-			end
-			-- Weapon Checks for precast
-			-- If it set to unlocked it will not swap the weapons even if defined in the built_set job lua
-			if state.WeaponMode.value ~= "Unlocked" then
-				if state.WeaponMode.value == "Locked" then
-					built_set = set_combine(built_set, { main=player.equipment.main, sub = player.equipment.sub, range = player.equipment.range})
-				else
-					if sets.Weapons[state.WeaponMode.value] then
-						built_set = set_combine(built_set, sets.Weapons[state.WeaponMode.value])
-						if not TwoHand and not DualWield then
-							if sets.Weapons.Shield then
-								built_set = set_combine(built_set, sets.Weapons.Shield)
-							end
-						end
-					end
-				end
-				log('Midcast set equiping Offense Mode Gear')
-			end
-			equip(built_set)
-		else warn('sets.Pet_Midcast not found!') end
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function is called by gearswap for pet after actions
-	-------------------------------------------------------------------------------------------------------------------
-
-	function pet_aftercast(spell)
-		local built_set = choose_set()
-		if pet_aftercast_custom then
-			built_set = set_combine(built_set, pet_aftercast_custom(spell))
-		end
-		equip(built_set)
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function is called to determine if there are current buffs to be used
-	-------------------------------------------------------------------------------------------------------------------
-
-	function check_buff()
-		-- Auto Buff is on and not in a town
-		if not is_Busy and state.AutoBuff.value ~= 'OFF' and not Cities:contains(world.area) and not buffactive['Stun'] and not buffactive['Terror'] then
-			-- Set defaults
-			local command_JA = 'None'	
-			local command_SP = 'None'
-
-			-- Spells
-			if not is_moving and check_buff_SP then command_SP = check_buff_SP() end
-
-			-- Job Abilities
-			if check_buff_JA then command_JA = check_buff_JA() end
-
-			if command_JA ~= 'None' and not buffactive['Amnesia'] then
-				command_JA_execute(command_JA)
-			elseif command_SP ~= 'None' then
-				command_SP_execute(command_SP)
-			end
-		end
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- Determine whether we have sufficient ammo for the action being attempted.
-	-------------------------------------------------------------------------------------------------------------------
-
-	function do_bullet_checks(spell, built_set)
-		if spell and built_set then
-			local bullet_name = built_set.ammo
-			if bullet_name == 'empty' or not bullet_name then return end
-			log('Ammo name is: '..bullet_name)
-
-			local bullet_min_count = 1
-			if spell.action_type == 'Ranged Attack' then
-				if buffactive['Triple Shot'] then
-					bullet_min_count = 3
-				elseif buffactive['Double Shot'] then
-					bullet_min_count = 2
-				elseif buffactive['Barrage'] then
-					bullet_min_count = 8
-				end
-			end
-
-			available_bullets = 0
-
-			if player.inventory[bullet_name] then available_bullets = available_bullets + player.inventory[bullet_name].count end
-			if player.wardrobe[bullet_name] then available_bullets = available_bullets + player.wardrobe[bullet_name].count end
-			if player.wardrobe2[bullet_name] then available_bullets = available_bullets + player.wardrobe2[bullet_name].count end
-			if player.wardrobe3[bullet_name] then available_bullets = available_bullets + player.wardrobe3[bullet_name].count end
-			if player.wardrobe4[bullet_name] then available_bullets = available_bullets + player.wardrobe4[bullet_name].count end
-			if player.wardrobe5[bullet_name] then available_bullets = available_bullets + player.wardrobe5[bullet_name].count end
-			if player.wardrobe6[bullet_name] then available_bullets = available_bullets + player.wardrobe6[bullet_name].count end
-			if player.wardrobe7[bullet_name] then available_bullets = available_bullets + player.wardrobe7[bullet_name].count end
-			if player.wardrobe8[bullet_name] then available_bullets = available_bullets + player.wardrobe8[bullet_name].count end
-
-			log('Bullet Count ['..available_bullets..']')
-
-			if available_bullets == 0 then
-				-- If no ammo is available, give appropriate warning and end.
-				if spell.type == 'CorsairShot' and player.equipment.ammo ~= 'empty' then
-					add_to_chat(104, 'No Quick Draw ammo left.  Using what\'s currently equipped ('..player.equipment.ammo..').')
-					return
-				elseif spell.type == 'WeaponSkill' and player.equipment.ammo == Ammo.Bullet.RA then
-					add_to_chat(104, 'No weaponskill ammo left.  Using what\'s currently equipped (standard ranged bullets: '..player.equipment.ammo..').')
-					return
-				else
-					add_to_chat(104, 'No ammo ('..tostring(bullet_name)..') available for that action.')
-					cancel_spell()
-					return
-				end
-			end
-
-			-- Don't allow shooting or weaponskilling with ammo reserved for quick draw.
-			if spell.type ~= 'CorsairShot' and available_bullets <= bullet_min_count then
-				add_to_chat(104, 'Not enough ammo.  Cancelling.')
-				cancel_spell()
-				return
-			end
-
-			-- Low ammo warning.
-			if spell.type ~= 'CorsairShot' and state.warned.value == false and available_bullets > 1 and available_bullets <= Ammo_Warning_Limit then
-				local msg = '*****  LOW AMMO WARNING: '..tostring(available_bullets)..'x '..bullet_name..' *****'
-				local border = ""
-				for i = 2, #msg do border = border .. "*" end
-				windower.send_command('send @others input /echo '..msg..'')
-				add_to_chat(167, border)
-				add_to_chat(167, msg)
-				add_to_chat(167, border)
-				state.warned:set()
-			elseif available_bullets > Ammo_Warning_Limit and state.warned then
-				state.warned:reset()
-			end
-		end
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- Determine whether we have sufficient Shihei for the action being attempted.
-	-------------------------------------------------------------------------------------------------------------------
-
-	function do_Utsu_checks(spell)
-		if spell.name == 'Utsusemi: Ichi' or spell.name == 'Utsusemi: Ni' or spell.name == 'Utsusemi: San' then
-
-			local display_message = false
-			local warning_level = 50
-			local count = 0
-			local available_shihei = player.inventory['Shihei']
-			local available_shiki = player.inventory['Shikanofuda']
-			-- Check for levels
-			if available_shihei then
-				if available_shihei.count < warning_level then
-					display_message = true
-					count = available_shihei.count
-				end
-			elseif available_shiki then
-				if available_shiki.count < warning_level then
-					display_message = true
-					count = available_shiki.count
-				end
-			else
-				display_message = true
-			end
-			-- Notify player is low
-			if display_message then
-				local msg = '*****  LOW TOOL WARNING: '..tostring(count)..'x *****'
-				local border = "" for i = 1, #msg do border = border .. "*" end
-				windower.send_command('send @others input /echo '..msg..'')
-				add_to_chat(167, border)
-				add_to_chat(167, msg)
-				add_to_chat(167, border)
-			end
-		end
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function returns the correct equipement to perform an action
-	-------------------------------------------------------------------------------------------------------------------
-
-	function check_equipment_spells(spell)
-		local built_set = {}
-		--Equip weapon for Dispelga
-		if spell.name == "Dispelga" then
-			built_set = {main="Daybreak"}
-		-- Equip Marsyas
-		elseif spell.name == "Honor March" then
-			built_set = {range="Marsyas"}
-		-- Equip Loughnashade
-		elseif spell.name == "Aria of Passion" then
-			built_set = {range="Loughnashade"}
-		--Equip body for Impact
-		elseif spell.name == "Impact" then
-			local Crepuscular = player.inventory["Crepuscular Cloak"] or player.wardrobe["Crepuscular Cloak"] or player.wardrobe2["Crepuscular Cloak"]
-			or player.wardrobe3["Crepuscular Cloak"] or player.wardrobe4["Crepuscular Cloak"] or player.wardrobe5["Crepuscular Cloak"] 
-			or player.wardrobe6["Crepuscular Cloak"] or player.wardrobe7["Crepuscular Cloak"] or player.wardrobe8["Crepuscular Cloak"]
-			local Twilight = player.inventory["Twilight Cloak"] or player.wardrobe["Twilight Cloak"] or player.wardrobe2["Twilight Cloak"]
-			or player.wardrobe3["Twilight Cloak"] or player.wardrobe4["Twilight Cloak"] or player.wardrobe5["Twilight Cloak"] 
-			or player.wardrobe6["Twilight Cloak"] or player.wardrobe7["Twilight Cloak"] or player.wardrobe8["Twilight Cloak"]
-			-- Crepuscular Cloak Found
-			if Crepuscular then log("Crepuscular Found") built_set = {head=empty, body="Crepuscular Cloak",}
-			-- Twilight Cloak Found
-			elseif Twilight then log("Twilight Found") built_set = {head=empty, body="Twilight Cloak",} end
-		end
-		return built_set
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function is called by the user via the self command - "gs c XXXX"
-	-------------------------------------------------------------------------------------------------------------------
-
-	function self_command(cmd)
-		-- Updates the TH status
-		local command = cmd:lower()
-		if command == 'update auto' then
-			local built_set = choose_set()
-			if choose_set_custom then
-				built_set = set_combine(built_set, choose_set_custom())
-			else warn('choose_set_custom() not found!') end
-			-- Order the gear and then equip
-			equip(built_set)
-			return
-		-- Put the UI at 0,0
-		elseif command == 'zero' then
-			display_zero_command()
-		-- Toggles the TH state
-		elseif command:contains('treasurehunter') then
-			if command == "treasurehunter" then
-				state.TreasureMode:cycle()
-				info('Treasure Hunter Mode: ['..state.TreasureMode.value..']')
-				display_box_update()
-			else
-				local mode = {}
-				mode = string.split(cmd," ",2)
-				state.TreasureMode:set(mode[2])
-				info('Treasure Hunter Mode: ['..state.TreasureMode.value..']')
-				display_box_update()
-			end
-			equip_set_command()
-			return
-		-- Toggles the Auto Buff function off/on
-		elseif command:contains('autobuff') then
-			if command == 'autobuff' then
-				state.AutoBuff:cycle()
-				info('Auto Buff is ['..state.AutoBuff.value..']')
-			else
-				local mode = {}
-				mode = string.split(cmd," ",2)
-				state.AutoBuff:set(mode[2])
-				info('Auto Buff is ['..state.AutoBuff.value..']')
-			end
-			display_box_update()
-			equip_set_command()
-			return
-		-- Shuts down instnace
-		elseif command == 'shutdown' then
-			send_command('terminate')
-		-- Saves the location of HUD
-		elseif command == 'save' then
-			config.save(settings, windower.ffxi.get_player().name:lower())
-			add_to_chat(80,'Settings saved')
-		-- Toggles dispay of the HUD
-		elseif command == 'display' then
-			if settings.visible == true then
-				settings.visible = false
-				gs_status:hide()
-				add_to_chat(80,'The UI is now hidden')
-			else
-				gs_status:show()
-				settings.visible = true
-				display_box_update()
-				add_to_chat(80,'The UI is now shown')
-			end
-		elseif command == 'debug' then
-			if settings.debug == true then
-				settings.debug = false
-				gs_debug:hide()
-				windower.add_to_chat(80,'The debugging is now [OFF]')
-			else
-				settings.debug = true
-				gs_debug:show()
-				log('The debugging is now [ON]')
-			end
-		elseif command == 'warn' then
-			if settings.warn == true then
-				settings.warn = false
-				windower.add_to_chat(8,'The set warning is now [OFF]')
-			else
-				settings.warn = true
-				warn('The set warning is now [ON]')
-			end
-		elseif command == 'info' then
-			if settings.info == true then
-				settings.info = false
-				windower.add_to_chat(8,'Information is now [OFF]')
-			else
-				settings.info = true
-				info('Information is now [ON]')
-			end
-		elseif command == 'two_hand_check' then
-			two_hand_check()
-		-- Esha Temps
-		elseif command == 'temps' then
-			escha_temps()
-		-- Warp Ring
-		elseif command == 'warp' then
-			use_enchantment("Warp Ring")
-		-- Warp Club
-		elseif command == 'warp club' then
-			use_enchantment("Warp Cudgel")
-		-- Holla Teleport
-		elseif command == 'holla' then
-			use_enchantment("Dim. Ring (Holla)")
-		-- Dem Teleport
-		elseif command == 'dem' then
-			use_enchantment("Dim. Ring (Dem)")
-		-- Mea Teleport
-		elseif command == 'mea' then
-			use_enchantment("Dim. Ring (Mea)")
-		-- CP Ring
-		elseif command == 'cp' then
-			use_enchantment("Trizek Ring")
-		-- Toggles the current player stances
-		elseif command:contains('offensemode') then
-			if command == 'offensemode' then
-				for i,v in ipairs(state.OffenseMode) do
-					if state.OffenseMode.value == v then
-						if state.OffenseMode.value ~= state.OffenseMode[#state.OffenseMode] then
-							state.OffenseMode:set(state.OffenseMode[i+1])
-						else
-							state.OffenseMode:set(state.OffenseMode[1])
-						end
-						info('Offense Mode: ['..state.OffenseMode.value..']')
-						display_box_update()
-						equip_set_command()
-						return
-					end
-				end
-			else
-				local mode = {}
-				mode = string.split(cmd," ",2)
-				state.OffenseMode:set(mode[2])
-				info('Offense Mode: ['..state.OffenseMode.value..']')
-				display_box_update()
-				equip_set_command()
-				return
-			end
-		elseif command:contains('weaponmode') then
-			if command == 'weaponmode' then
-				for i,v in ipairs(state.WeaponMode) do
-					if state.WeaponMode.value == v then
-						if state.WeaponMode.value ~= state.WeaponMode[#state.WeaponMode] then
-							state.WeaponMode:set(state.WeaponMode[i+1])
-						else
-							state.WeaponMode:set(state.WeaponMode[1])
-						end
-						info('Weapon Mode: ['..state.WeaponMode.value..']')
-						display_box_update()
-						if self_command_custom then self_command_custom(command) end
-						two_hand_check()
-						equip_set_command()
-						return
-					end
-				end
-			else
-				local mode = {}
-				mode = string.split(cmd," ",2)
-				state.WeaponMode:set(mode[2])
-				info('Weapon Mode: ['..state.WeaponMode.value..']')
-				display_box_update()
-				if self_command_custom then self_command_custom(command) end
-				two_hand_check()
-				equip_set_command()
-				return
-			end
-		elseif command:contains('jobmode2') then
-			if command == 'jobmode2' then
-				for i,v in ipairs(state.JobMode2) do
-					if state.JobMode2.value == v then
-						if state.JobMode2.value ~= state.JobMode2[#state.JobMode2] then
-							state.JobMode2:set(state.JobMode2[i+1])
-						else
-							state.JobMode2:set(state.JobMode2[1])
-						end
-						info(UI_Name2..': ['..state.JobMode2.value..']')
-						display_box_update()
-						if self_command_custom then self_command_custom(command) end
-						equip_set_command()
-						return
-					end
-				end
-			else
-				local mode = {}
-				mode = string.split(cmd," ",2)
-				state.JobMode2:set(mode[2])
-				info(UI_Name2..': ['..state.JobMode2.value..']')
-				display_box_update()
-				if self_command_custom then self_command_custom(command) end
-				equip_set_command()
-				return
-			end
-		elseif command:contains('jobmode') then
-			if command == 'jobmode' then
-				for i,v in ipairs(state.JobMode) do
-					if state.JobMode.value == v then
-						if state.JobMode.value ~= state.JobMode[#state.JobMode] then
-							state.JobMode:set(state.JobMode[i+1])
-						else
-							state.JobMode:set(state.JobMode[1])
-						end
-						info(UI_Name..': ['..state.JobMode.value..']')
-						display_box_update()
-						-- Issue a command to the lua for the job specific command
-						if self_command_custom then self_command_custom(command) end
-						equip_set_command()
-						return
-					end
-				end
-			else
-				local mode = {}
-				mode = string.split(cmd," ",2)
-				state.JobMode:set(mode[2])
-				info(UI_Name..': ['..state.JobMode.value..']')
-				display_box_update()
-				-- Issue a command to the lua for the job specific command
-				if self_command_custom then self_command_custom(command) end
-				equip_set_command()
-				return
-			end
-		-- This profile mode is used to load a Silmaril profile and execute a script
-		elseif command:contains('profile') then
-			local modes = {}
-			for mode in string.gmatch(cmd, "(%w+)") do
-				table.insert(modes, mode)
-			end
-			local smModePath = table.concat(modes, '_', 2, #modes)
-			info('Profile: ['..modes[#modes] ..']')
-			windower.send_command('exec '..smModePath..'/'..player.main_job..'_'..player.sub_job..'_'..player.name)
-		elseif command == 'food' then
-			windower.chat.input('/item "'..Food..'" <me>')
-		-- Command to use any enchanted item, can use either en or enl names from resources, autodetects slot, equip timeout and cast time
-		elseif command:startswith('use') then
-			use_enchantment(command:slice(5))
-		elseif command == 'version' then
-			info('Include Version is ['..Mirdain_GS..']')
-		end
-		--use below for custom Job commands
-		if self_command_custom then self_command_custom(command) end
-	end
-
-	-- Functin used to exectue Job Abilities
-	function command_JA_execute(command_JA)
-		local cast_ability = res.job_abilities:with('en', command_JA)
-		local target = ''
-		if tostring(cast_ability.targets) == "{Self}" then
-			target = '<me>'
-		elseif tostring(cast_ability.targets) == "{Enemy}" then
-			target = '<bt>'
-		else
-			target = '<me>'
-		end
-		--log('input /ja "'..command_JA..'" '..target..'')
-		windower.chat.input('/ja "'..command_JA..'" '..target..'')
-	end
-
-	-- Functin used to exectue Spells
-	function command_SP_execute(command_SP)
-		local cast_spell = res.spells:with('en', command_SP)
-		local spell_cast_time = cast_spell.cast_time
-		local target = ''
-		if tostring(cast_spell.targets) == '{Self}' then
-			target = '<me>'
-		elseif tostring(cast_spell.targets) == '{Enemy}' then
-			target = '<bt>'
-		else
-			target = '<me>'
-		end
-		--log('input /ma "'..command_SP..'" '..target..'')
-		windower.chat.input('/ma "'..command_SP..'" '..target..'')
-	end
-
-	-- Used for Escha Temp and Zerg
-	function escha_temps()
-		info('Escha Temps')
-		windower.send_command("input /item \"Monarch's Drink\" <me>;wait 2.5;input /item \"Braver's Drink\" <me>;wait 2.5;input /item \"Fighter's Drink\" <me>;wait 2.5;input /item \"Champion's Drink\" <me>;wait 2.5;input /item \"Soldier's Drink\" <me>;wait 2.5;input /item \"Barbarian's Drink\" <me>")
-	end
-
-	-- Determines correct gear for the songs
-	function equip_song_gear(spell, instrument)
-		local song_set = {}
-			if string.find(spell.english,'Finale') and sets.Midcast.Finale then song_set = sets.Midcast.Finale
-		elseif string.find(spell.english,'Lullaby') and sets.Midcast.Lullaby then song_set = sets.Midcast.Lullaby
-		elseif string.find(spell.english,'Threnody') and sets.Midcast.Threnody then song_set = sets.Midcast.Threnody
-		elseif string.find(spell.english,'Elegy') and sets.Midcast.Elegy then song_set = sets.Midcast.Elegy
-		elseif string.find(spell.english,'Requiem') and sets.Midcast.Requiem then song_set = sets.Midcast.Requiem
-		elseif string.find(spell.english,'March') and sets.Midcast.March then song_set = sets.Midcast.March
-		elseif string.find(spell.english,'Minuet') and sets.Midcast.Minuet then song_set = sets.Midcast.Minuet
-		elseif string.find(spell.english,'Madrigal') and sets.Midcast.Madrigal then song_set = sets.Midcast.Madrigal
-		elseif string.find(spell.english,'Ballad') and sets.Midcast.Ballad then song_set = sets.Midcast.Ballad
-		elseif string.find(spell.english,'Scherzo') and sets.Midcast.Scherzo then song_set = sets.Midcast.Scherzo
-		elseif string.find(spell.english,'Mazurka') and sets.Midcast.Mazurka then song_set = sets.Midcast.Mazurka
-		elseif string.find(spell.english,'Paeon') and sets.Midcast.Paeon then song_set = sets.Midcast.Paeon
-		elseif string.find(spell.english,'Carol') and sets.Midcast.Carol then song_set = sets.Midcast.Carol
-		elseif string.find(spell.english,'Minne') and sets.Midcast.Minne then song_set = sets.Midcast.Minne
-		elseif string.find(spell.english,'Mambo') and sets.Midcast.Mambo then song_set = sets.Midcast.Mambo
-		elseif string.find(spell.english,'Etude') and sets.Midcast.Etude then song_set = sets.Midcast.Etude
-		elseif string.find(spell.english,'Prelude') and sets.Midcast.Prelude then song_set = sets.Midcast.Prelude
-		elseif string.find(spell.english,'Dirge') and sets.Midcast.Dirge then song_set = sets.Midcast.Dirge
-		elseif string.find(spell.english,'Sirvente') and sets.Midcast.Sirvente then song_set = sets.Midcast.Sirvente
-		elseif string.find(spell.english,'Aria') and sets.Midcast.Aria then song_set = sets.Midcast.Aria
-		else warn('['..spell.english..'] set not found!') end
-		song_set['range'] = instrument
-		return song_set
-	end
-
-	-- Determines correct instrument for Pianissimo
-	function equip_pianissimo_gear(spell)
-		if spell.english == "Honor March" or spell.english == "Aria of Passion" then return end
-		if Instrument then
-			if Instrument.Pianissimo then
-				log('Check Pianissimo Instrument')
-				if string.find(spell.english,'March') and Instrument.Pianissimo.March then return Instrument.Pianissimo.March
-				elseif string.find(spell.english,'Minuet') and Instrument.Pianissimo.Minuet then return Instrument.Pianissimo.Minuet
-				elseif string.find(spell.english,'Madrigal') and Instrument.Pianissimo.Madrigal then return Instrument.Pianissimo.Madrigal
-				elseif string.find(spell.english,'Ballad') and Instrument.Pianissimo.Ballad then return Instrument.Pianissimo.Ballad
-				elseif string.find(spell.english,'Scherzo') and Instrument.Pianissimo.Scherzo then return Instrument.Pianissimo.Scherzo
-				elseif string.find(spell.english,'Mazurka') and Instrument.Pianissimo.Mazurka then return Instrument.Pianissimo.Mazurka
-				elseif string.find(spell.english,'Paeon') and Instrument.Pianissimo.Paeon then return Instrument.Pianissimo.Paeon
-				elseif string.find(spell.english,'Carol') and Instrument.Pianissimo.Carol then return Instrument.Pianissimo.Carol
-				elseif string.find(spell.english,'Minne') and Instrument.Pianissimo.Minne then return Instrument.Pianissimo.Minne
-				elseif string.find(spell.english,'Mambo') and Instrument.Pianissimo.Mambo then return Instrument.Pianissimo.Mambo
-				elseif string.find(spell.english,'Etude') and Instrument.Pianissimo.Etude then return Instrument.Pianissimo.Etude
-				elseif string.find(spell.english,'Prelude') and Instrument.Pianissimo.Prelude then return Instrument.Pianissimo.Prelude
-				elseif string.find(spell.english,'Dirge') and Instrument.Pianissimo.Dirge then return Instrument.Pianissimo.Dirge
-				elseif string.find(spell.english,'Sirvente') and Instrument.Pianissimo.Sirvente then return Instrument.Pianissimo.Sirvente
-				else return Instrument.Pianissimo end
-			else warn('sets.Instrument.Pianissimo not found!') end
-		else warn('sets.Instrument not found!') end
-	end
-
-	function use_enchantment(item)
-		local SlotList = {"main","sub","range","ammo","head","body","hands","legs","feet","neck","waist","lear","rear","left_ring","right_ring","back"}
-		local item_table = res.items:with('enl',item) or res.items:with('en',item)
-		local slot =''
-
-		if item_table == nil or not item_table.targets:contains('Self') then
-			info("Invalid item.")
-			return
-		end
-		if item_table.slots:contains(0) then
-			slot = 'main'
-		else
-			for k,v in pairs(item_table.slots) do
-				if v == true then
-					slot = SlotList[k+1]
-					break
-				end
-			end
-		end
-		enable(slot)
-		equip({[slot]=item_table.en})
-		disable(slot)
-		local delay_use = item_table.cast_delay + 3
-		local delay_unlock = delay_use + item_table.cast_time + 3
-		Use_Item_Command = item_table.en
-		coroutine.schedule(Use_Item, delay_use)
-		coroutine.schedule(Unlock, delay_unlock)
-		coroutine.schedule(equip_set_command, delay_unlock)
-	end
-
-	function Use_Item()
-		log('/item "'..Use_Item_Command..'" '..player.id)
-		windower.chat.input('/item "'..Use_Item_Command..'" <me>')
-	end
-
-	-- Unbind Keys when the file is unloaded
-	function file_unload(file_name)
-		send_command('unbind ^f11')
-		send_command('unbind ^f12')
-		send_command('unbind f9')
-		send_command('unbind f10')
-		send_command('unbind f11')
-		send_command('unbind f12')
-		if user_file_unload then
-			user_file_unload()
-		else
-			info('user_file_unload() not found!')
-		end
-	end
-
-	-- Command to Lock Style and Set the correct macros
-	function jobsetup(LockStylePallet,MacroBook,MacroSet)
-		if Random_Lockstyle then
-			LockStylePallet = Lockstyle_List[ math.random( #Lockstyle_List ) ]
-		end
-
-		windower.send_command('wait 1;input /macro book '..MacroBook..';wait 1;input /macro set '..MacroSet..';gs validate;wait 3;input /lockstyleset '..LockStylePallet..';input /echo Change Complete;gs c update auto;')
-
-		send_command('bind f12 gs c OffenseMode')
-		send_command('bind f11 gs c TreasureHunter')
-		send_command('bind f10 gs c AutoBuff')
-		send_command('bind f9 gs c WeaponMode')
-		send_command('bind ^f12 gs c JobMode')
-		send_command('bind ^f11 gs c JobMode2')
-
-		local maxWidth = 40
-		windower.add_to_chat(8,'Stance - '..string.format('[%s]','F12'))
-		windower.add_to_chat(8,'TH Mode - '..string.format('[%s]','F11'))
-		windower.add_to_chat(8,'Auto Buff - '..string.format('[%s]','F10'))
-		windower.add_to_chat(8,'Weapon Mode - '..string.format('[%s]','F9')) 
-		if UI_Name ~= '' then
-			windower.add_to_chat(8,UI_Name..' - '..string.format('[%s]','Ctrl + F12'))
-		end
-		if UI_Name2 ~= '' then
-			windower.add_to_chat(8,UI_Name2..' - '..string.format('[%s]','Ctrl + F11'))
-		end
-	end
-
-	-- Called when the player's subjob changes.
-	function sub_job_change(new, old)
-		coroutine.schedule(dual_wield_check, 2)
-		coroutine.schedule(two_hand_check, 2.1)
-		coroutine.schedule(equip_set_command, 2.2)
-		if sub_job_change_custom then
-			sub_job_change_custom()
-		end
-	end
-
-	-- Check if you have the dual wield trait
-	function dual_wield_check()
-		local current_abilities = windower.ffxi.get_abilities()
-		if table.contains(current_abilities.job_traits,18) then -- Dual Wield trait
-			DualWield = true
-		else
-			DualWield = false
-		end
-	end
-
-	function two_hand_check()
-		if sets.Weapons[state.WeaponMode.value] and sets.Weapons[state.WeaponMode.value]['main'] then
-			local weapon_name = sets.Weapons[state.WeaponMode.value]['main']
-			if type(weapon_name) == "table" then weapon_name = sets.Weapons[state.WeaponMode.value]['main'].name end
-			local Main_Weapon = res.items:with('en',weapon_name)
-			if Main_Weapon then
-				--log('Weapon:['..Main_Weapon.en..']')
-				local Skill_type = Main_Weapon.skill 
-				if Skill_type == 4 or Skill_type == 6 or Skill_type == 7 or Skill_type == 8 or Skill_type == 10 or Skill_type == 12 then
-					TwoHand = true
-				else
-					TwoHand = false
-				end
-			else
-				TwoHand = false
-			end
-		end
-	end
-
-	-- On changing targets, attempt to add TH gear.
-	function on_target_change_for_th(new_index, old_index)
-		-- Only care about changing targets while we're engaged, either manually or via current target death.
-		if player.status == 'Engaged' and state.TreasureMode.value ~= 'None' then
-			-- If  the current player.target is the same as the new mob then we're actually engaged with it.
-			-- If it's different than the last known mob, then we've actually changed targets.
-			if player.target.index == new_index and new_index ~= th_info.last_player_target_index then
-				th_info.last_player_target_index = player.target.index
-				local built_set = choose_set()
-				if choose_set_custom then
-					built_set = set_combine(built_set, choose_set_custom())
-				else warn('choose_set_custom() not found!') end
-				equip(built_set)
-			end
-		end
-	end
-
-	-- This function removes mobs from our tracking table when they die.
-	function on_incoming_chunk_for_th(id, data, modified, injected, blocked)
-		-- Action Packet
-		if id == 0x29 and state.TreasureMode.value ~= 'None' then
-			local target_id = data:unpack('I',0x09)
-			local message_id = data:unpack('H',0x19)%32768
-			-- Remove mobs that die from our tagged mobs list.
-			if th_info.tagged_mobs[target_id] then
-				-- 6 == actor defeats target
-				-- 20 == target falls to the ground
-				if message_id == 6 or message_id == 20 then
-					if settings.debug then add_to_chat(123,'Mob '..target_id..' died. Removing from tagged mobs table.') end
-					th_info.tagged_mobs[target_id] = nil
-				end
-			end
-		end
-	end
-
-	-- Clear out the entire tagged mobs table when zoning.
-	function on_zone_change_for_th(new_zone, old_zone)
-		Unlock()
-		if settings.debug then windower.add_to_chat(123,'Zoning. Clearing tagged mobs table.') end
-		th_info.tagged_mobs:clear()
-		-- Turn off for zones
-		state.AutoBuff:set('OFF')
-	end
-
-	-- Remove mobs that we've marked as tagged with TH if we haven't seen any activity from or on them
-	-- for over 3 minutes.  This is to handle deagros, player deaths, or other random stuff where the
-	-- mob is lost, but doesn't die.
-	function cleanup_tagged_mobs()
-		-- If it's been more than 3 minutes since an action on or by a tagged mob,
-		-- remove them from the tagged mobs list.
-		local current_time = os.clock()
-		local remove_mobs = S{}
-
-		--log('The TH table contains ['..tostring(#th_info.tagged_mobs)..'] entries.')
-
-		-- Search list and flag old entries.
-		for target_id, action_time in pairs(th_info.tagged_mobs) do
-			local time_since_last_action = current_time - action_time
-			if time_since_last_action > 180 then
-				remove_mobs:add(target_id)
-				if settings.debug then windower.add_to_chat(123,'Over 3 minutes since last action on mob '..target_id..'. Removing from tagged mobs list.') end
-			end
-		end
-
-		-- Clean out mobs flagged for removal.
-		for mob_id,_ in pairs(remove_mobs) do
-			th_info.tagged_mobs[mob_id] = nil
-		end
-	end
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- BELOW IS FROM THE CANCEL ADDON
-	-- ADDING DUE TO FACT SOME PEOPLE MAY NOT HAVE IT INSTALLED
-	-- ALLOWS CANCELING OF BUFFS EASIER
-	-------------------------------------------------------------------------------------------------------------------
-
-	function cancel(...)
-		local command = table.concat({...},' ')
-		if not command then return end
-		local status_id_tab = command:split(',')
-		status_id_tab.n = nil
-		local ids = {}
-		local buffs = {}
-		for _,v in pairs(windower.ffxi.get_player().buffs) do
-			for _,r in pairs(status_id_tab) do
-				if windower.wc_match(res.buffs[v][Language],r) or windower.wc_match(tostring(v),r) then
-					cancel_buff(v)
-					break
-				end
-			end
-		end
-	end
-
-	function cancel_buff(id)
-		windower.packets.inject_outgoing(0xF1,string.char(0xF1,0x04,0,0,id%256,math.floor(id/256),0,0)) -- Inject the cancel packet
-	end
-
-	function Unlock()
-		log('Unlock Called')
-		enable('main','sub','range','ammo','head','neck','lear','rear','body','hands','lring','rring','waist','legs','feet')
-	end
-
-	function Lock()
-		log('Lock Called')
-		disable('main','sub','range','ammo','head','neck','lear','rear','body','hands','lring','rring','waist','legs','feet')
-	end
-
-	-- UI for displaying the current states
-	function display_box_update()
-		local width = 20
-		local dialog = {}
-		dialog[1] = {description = 'Stance', value = state.OffenseMode.value}
-		dialog[2] = {description = 'TH Mode', value = state.TreasureMode.value}
-		dialog[3] = {description = 'Auto Buff', value = state.AutoBuff.value}
-		dialog[4] = {description = 'DPS', value = state.WeaponMode.value}
-		if UI_Name ~= "" then
-			dialog[5] = {description = UI_Name, value = state.JobMode.value}
-		end
-		if UI_Name2 ~= "" then
-			dialog[6] = {description = UI_Name2, value = state.JobMode2.value}
-		end
-		local lines = T{}
-		for k, v in next, dialog do
-			lines:insert(v.description ..string.format('[%s]',tostring(v.value)):lpad(' ',width-string.len(tostring(v.description))))
-		end
-		local maxWidth = math.max(1, table.reduce(lines, function(a, b) return math.max(a, #b) end, '1'))
-		-- Pad each entry
-		for i,line in ipairs(lines) do lines[i] = lines[i]:rpad(' ', maxWidth) end
-		gs_status:text(lines:concat('\n'))
-	end
-
-	-- Zero the display window
-	function display_zero_command()
-		gs_status:pos_x(0)
-		gs_status:pos_y(0)
-		config.save(settings, windower.ffxi.get_player().name:lower())
-	end
-
-	-- Used to help debug issues
-	function debug_box_update()
-		local lines = T{}
-		lines:insert('is_Busy' ..string.format('[%s]',tostring(is_Busy)):lpad(' ',12))
-		lines:insert('is_Moving' ..string.format('[%s]',tostring(is_moving)):lpad(' ',10))
-		lines:insert('DualWield' ..string.format('[%s]',tostring(DualWield)):lpad(' ',10))
-		lines:insert('TwoHand' ..string.format('[%s]',tostring(TwoHand)):lpad(' ',12))
-		local maxWidth = math.max(1, table.reduce(lines, function(a, b) return math.max(a, #b) end, '1'))
-		for i,line in ipairs(lines) do lines[i] = lines[i]:rpad(' ', maxWidth) end
-		gs_debug:text(lines:concat('\n'))
-	end
-
-	function log (msg)
-		if settings.debug then print(80, msg) end
-	end
-
-	function info (msg)
-		if settings.info then print(8, msg) end
-	end
-
-	function warn (msg)
-		if settings.warn then print(12, msg) end
-	end
-
-	function print(mode, msg)
-		if msg == nil then
-			windower.add_to_chat(mode,'Value is Nil')
-		elseif type(msg) == "table" then
-			for index, value in pairs(msg) do
-				if type(value) == "table" then
-					for index2, value2 in pairs(value) do
-						if type(value2) == "table" then
-							for index3, value3 in pairs(value2) do
-								if type(value3) == "table" then
-									for index4, value4 in pairs(value3) do
-										windower.add_to_chat(mode,'---- ['..tostring(index)..'] ['..tostring(index2)..'] ['..tostring(index3)..'] ['..tostring(index4)..'] '..tostring(value4)..' ----')
-									end
-								else
-									windower.add_to_chat(mode,'---- ['..tostring(index)..'] ['..tostring(index2)..'] ['..tostring(index3)..'] '..tostring(value3)..' ----')
-								end
-							end
-						else
-							windower.add_to_chat(mode,'---- ['..tostring(index)..'] ['..tostring(index2)..'] '..tostring(value2)..' ----')
-						end
-					end
-				else
-					windower.add_to_chat(mode,'---- ['..tostring(index)..'] '..tostring(value)..' ----')
-				end
-			end
-		elseif type(msg) == "number" then
-			windower.add_to_chat(mode,tostring(msg))
-		elseif type(msg) == "string" then
-			windower.add_to_chat(mode,msg)
-		elseif type(msg) == "boolean" then
-			windower.add_to_chat(mode,tostring(msg))
-		else
-			windower.add_to_chat(mode,'Unknown Message')
-		end
-	end
-
-	function elemental_check(spell, built_set)
-		-- Rule for Cures
-		if spell.name:contains('Cure') or spell.name:contains('Cura') then
-			if world.weather_element == spell.element or spell.element == world.day_element then
-
-				-- Verify player has the gear
-				local Obi = player.inventory["Hachirin-no-Obi"] or player.wardrobe["Hachirin-no-Obi"] or player.wardrobe2["Hachirin-no-Obi"]
-				or player.wardrobe3["Hachirin-no-Obi"] or player.wardrobe4["Hachirin-no-Obi"] or player.wardrobe5["Hachirin-no-Obi"] 
-				or player.wardrobe6["Hachirin-no-Obi"] or player.wardrobe7["Hachirin-no-Obi"] or player.wardrobe8["Hachirin-no-Obi"]
-
-				local Staff = player.inventory["Chatoyant Staff"] or player.wardrobe["Chatoyant Staff"] or player.wardrobe2["Chatoyant Staff"]
-				or player.wardrobe3["Chatoyant Staff"] or player.wardrobe4["Chatoyant Staff"] or player.wardrobe5["Chatoyant Staff"] 
-				or player.wardrobe6["Chatoyant Staff"] or player.wardrobe7["Chatoyant Staff"] or player.wardrobe8["Chatoyant Staff"]
-
-				-- Check for bonus
-				if spell.element == world.day_element then
-					if Obi then built_set = set_combine(built_set, {waist="Hachirin-no-Obi"}) end
-					if Staff then built_set = set_combine(built_set, sets.Weapons['Light Bonus'], {main="Chatoyant Staff"}) end
-					windower.add_to_chat(8,'[' ..world.day_element.. '] day - using Bonus Gear')
-
-				elseif world.weather_element == spell.element then
-					if Obi then built_set = set_combine(built_set, {waist="Hachirin-no-Obi"}) end
-					if Staff then built_set = set_combine(built_set, sets.Weapons['Light Bonus'], {main="Chatoyant Staff"}) end
-					windower.add_to_chat(8,'Weather is ['.. world.weather_element .. '] - using Bonus Gear')
-				end
-			end
-		-- This function swaps in the Orpheus or Hachirin as needed
-		else
-
-			-- Check for player gear
-			local Osash = player.inventory["Orpheus's Sash"] or player.wardrobe["Orpheus's Sash"] or player.wardrobe2["Orpheus's Sash"]
-			or player.wardrobe3["Orpheus's Sash"] or player.wardrobe4["Orpheus's Sash"] or player.wardrobe5["Orpheus's Sash"] 
-			or player.wardrobe6["Orpheus's Sash"] or player.wardrobe7["Orpheus's Sash"] or player.wardrobe8["Orpheus's Sash"]
-			local Obi = player.inventory["Hachirin-no-Obi"] or player.wardrobe["Hachirin-no-Obi"] or player.wardrobe2["Hachirin-no-Obi"]
-			or player.wardrobe3["Hachirin-no-Obi"] or player.wardrobe4["Hachirin-no-Obi"] or player.wardrobe5["Hachirin-no-Obi"] 
-			or player.wardrobe6["Hachirin-no-Obi"] or player.wardrobe7["Hachirin-no-Obi"] or player.wardrobe8["Hachirin-no-Obi"]
-
-			-- Matching double weather (w/o day conflict).
-			if spell.element == world.weather_element and world.weather_intensity == 2 and Obi then
-				built_set = set_combine(built_set, {waist="Hachirin-no-Obi"})
-				info('Weather is Double ['.. world.weather_element .. '] - using Hachirin-no-Obi')
-			-- Matching day and weather.
-			elseif spell.element == world.day_element and spell.element == world.weather_element and Obi then
-				built_set = set_combine(built_set, {waist="Hachirin-no-Obi"})
-				info('[' ..world.day_element.. '] day and weather is ['.. world.weather_element .. '] - using Hachirin-no-Obi')
-			-- Target distance less than 6 yalms
-			elseif spell.target.distance < (6 + spell.target.model_size) and Osash then
-				built_set = set_combine(built_set, {waist="Orpheus's Sash"})
-				info('Distance is ['.. round(spell.target.distance,2) .. '] using Orpheus Sash')
-			-- Match day or weather.
-			elseif spell.element == world.day_element or spell.element == world.weather_element and Obi then
-				built_set = set_combine(built_set, {waist="Hachirin-no-Obi"})
-				info('[' ..world.day_element.. '] day and weather is ['.. world.weather_element .. '] - using Hachirin-no-Obi')
-			end
-
-		end
-		return built_set
-	end
-
-	function round(num, numDecimalPlaces)
-		if num ~= nil then
-		  local mult = 10^(numDecimalPlaces or 0)
-		  return math.floor(num * mult + 0.5) / mult
-		end
-	end
-
-	function run_burst(data)
-		local action = data.targets[1].actions[1]
-		if (action.add_effect_message > 287 and action.add_effect_message < 302) -- Normal SC DMG
-		or (action.add_effect_message > 384 and action.add_effect_message < 399) -- SC Heals
-		or (action.add_effect_message > 766 and action.add_effect_message < 771) -- Umbra/Radiance
-		then
-			log('There was a skillchain')
-			local t = windower.ffxi.get_mob_by_id(data.targets[1].id)
-			-- valid party target and within range
-			if t and t.spawn_type == 16 and t.distance:sqrt() < 21 then
-				-- Update the enemy to track
-				last_skillchain_id = t.id
-				last_skillchain_time = os.clock()
-				last_skillchain_elements = {}
-				log('Skillchain detected')
-				-- get the type of skillchain
-				local skillchain = skillchains[action.add_effect_message]
-				-- Find the elements
-				for index, element in pairs(skillchain.elements) do
-					last_skillchain_elements[element] = element
-				end
-				log(last_skillchain_elements)
-			end
-		-- This is used to stop bursting if a ws happened to close the window
-		elseif data.category == 3 and data.param ~= 0 then
-			local t = windower.ffxi.get_mob_by_id(data.targets[1].id)
-			if t and t.id == last_skillchain_id then
-				log('Skillchain is closed for ['..last_skillchain_id..']')
-				last_skillchain_elements = {}
-				last_skillchain_id = 0
-				last_skillchain_time = 0
-			end
-		end
-	end
-
-	function main_engine()
-		local now = os.clock()
-		-- Spell timed out
-		if is_Busy and now - Spellstart > SpellCastTime then is_Busy = false SpellCastTime = 0 end
-		-- Make sure not update faster than .1 seconds
-		if now - main_engine_time < .1 then return end
-		-- Update the debug UI if visible
-		if settings.debug then debug_box_update() end
-		-- Go no farther as you are dead
-		if not player or player.status == "Dead" or player.status == "Engaged dead" or buffactive['Charm'] or buffactive['Sleep'] then return end
-		-- Status Ailment Check
-		if not buffactive['Paralysis'] and not buffactive['Silence'] and not buffactive['Muddle'] then
-			check_buff()
-		end		
-		local position = windower.ffxi.get_mob_by_id(player.id)
-		if position and not buffactive['Mounted'] and not is_Busy then
-			local movement = math.sqrt( (position.x-Location.x)^2 + (position.y-Location.y)^2 + (position.z-Location.z)^2 ) > 0.5
-			if movement and not is_moving then
-				if player.status ~= "Engaged" then
-					is_moving = true
-					Require_Update = true
-					--windower.chat.input('/echo Moving! Status: '..player.status..'')
-				end
-			elseif not movement and is_moving then
-				is_moving = false
-				Require_Update = true
-				--windower.chat.input('/echo Stopped Moving! Status: '..player.status..'')
-			end
-			Location.x = position.x
-			Location.y = position.y
-			Location.z = position.z
-		end
-
-		if Require_Update and not is_busy then equip_set_command() Require_Update = false end
-
-		-- 30 second cycle timer
-		if now - UpdateTime1 > 30 then
-			dual_wield_check()
-			cleanup_tagged_mobs()
-			UpdateTime1 = now
-		end
-
-		-- function used for periodic updates - feature
-		if Cycle_Timer and now - UpdateTime2 > 2 and not is_busy then
-			Cycle_Timer()
-			UpdateTime2 = now
-		end
-
-		main_engine_time = os.clock()
-	end
-
-	-- Register event section
-	windower.register_event('target change', on_target_change_for_th)
-	windower.raw_register_event('incoming chunk', on_incoming_chunk_for_th)
-	windower.raw_register_event('outgoing chunk', main_engine)
-	windower.raw_register_event('zone change', on_zone_change_for_th)
-
-	windower.register_event('gain buff', function(id)
-		local name = res.buffs[id].en
-		if id == 6 and (Mage_Job:contains(player.main_job) or Mage_Job:contains(player.sub_job)) then
-			if player.inventory['Remedy'] ~= nil then
-				if AutoItem == true then
-					windower.chat.input('/item "Remedy" <me>')
-				end
-			else info('No Remedies in inventory.') end
-		elseif id == 4 then
-			if player.inventory['Remedy'] ~= nil then
-				if AutoItem == true then
-					windower.chat.input('/item "Remedy" <me>')
-				end
-			else info('No Remedies in inventory.') end
-		elseif id == 2 then
-			local built_set = {}
-			if sets.Idle then
-				built_set = sets.Idle
-			else warn('sets.Idle not found!') end
-			if sets.Weapons then
-				if sets.Weapons.Sleep then
-					info('Locking Sleep Gear')
-					built_set = set_combine(built_set, sets.Weapons.Sleep)
-				else warn('sets.Weapons.Sleep not found!') end
-			else warn('sets.Weapons not found!') end
-			equip(built_set)
-			disable('main','range')
-			-- Used to wake up during sleep
-			-- Cancel stoneskin
-			if buffactive['Stoneskin'] then
-	  	 		info('Cancel Stoneskin')
-				cancel('Stoneskin')
-			end
-		elseif id == 7 then
-			log("Petrification - Checking Gear")
-			if choose_set_custom then
-				equip(set_combine(choose_set(), choose_set_custom()))
-			else
-				equip(set_combine(choose_set()))
-			end
-		elseif id == 10 then
-			log("Stunned - Checking Gear")
-			if choose_set_custom then
-				equip(set_combine(choose_set(), choose_set_custom()))
-			else
-				equip(set_combine(choose_set()))
-			end
-		elseif id == 15 then
-			info('DOOOOOOM!!!')
-			if sets.Cursna_Received then
-				equip(sets.Cursna_Received)
-				disable('neck','lring','rring','waist')
-				info('Locking Cursna Received Gear')
-			else warn('sets.Cursna_Received not found!') end
-			if AutoItem then
-				if player.inventory['Holy Water'] ~= nil then -- Only here to notify player about Doom status and potential lack of Holy Waters
-					windower.chat.input('/item "Holy Water" <me>')
-				else 
-					info('No Holy Waters in inventory. Unable to cure DOOM status!')
-				end
-			end
-		end 
-	end)
-
-	windower.register_event('lose buff', function(id)
-		local name = res.buffs[id].en
-		local gain = false
-		if id == 15 then -- Doom
-			if Divergence_Zones:contains(world.area) then
-				-- Skip unlocking neck if need to RP
-				enable('main','sub','range','ammo','head','lear','rear','body','hands','lring','rring','waist','legs','feet')
-			else
-				Unlock()
-			end
-			if choose_set_custom then
-				if buff_change_custom then
-					equip(set_combine(choose_set(), choose_set_custom(), buff_change_custom(name,gain)))
-				else
-					equip(set_combine(choose_set(), choose_set_custom()))
-				end
-			else
-				equip(set_combine(choose_set()))
-			end
-			info('Unlocking Cursna Received Gear')
-		elseif id == 2 then -- sleep
-			if Divergence_Zones:contains(world.area) then
-				-- Skip unlocking neck if need to RP
-				enable('main','sub','range','ammo','head','lear','rear','body','hands','lring','rring','waist','legs','feet')
-			else
-				Unlock()
-			end
-			if choose_set_custom then
-				if buff_change_custom then
-					equip(set_combine(choose_set(), choose_set_custom(), buff_change_custom(name,gain)))
-				else
-					equip(set_combine(choose_set(), choose_set_custom()))
-				end
-			else
-				equip(set_combine(choose_set()))
-			end
-			info('Unlocking Sleep Gear')
-		end 
-	end)
-
-	windower.register_event('chat message', function(message,sender,mode,gm)
-		--Future Hooks for PT chat or tells
-		-- Mode 3 is tell
-		-- Mode 4 is party
-		--Ignore it if it's not party chat or a tell
-		if mode ~= 3 or mode ~= 4 then 
-			return
-		end
-		message = message:lower()
-		-- Example Use
-		if message:contains('hqzerg') then
-			windower.send_command('sm on')
-		end 
-	end)
-
-	-- Section used to determine if player is performing an action
-	windower.register_event('action', function (data)
-		if data ~= nil then
-			--log('cat='..data.category..',param='..data.param)
-			if data.actor_id == player.id then
-				-- Ranged attack finish
-				if data.category == 2 then
-					if data.param == 26739 then 
-						log('Player finished Shooting') 
-					end
-				--Casting finish
-				elseif data.category == 4 then
-					log('Casting Finished')
-				-- Item Use
-				elseif data.category == 9 then
-					if data.param == 24931 then
-						log('Item use')
-					elseif data.param == 28787 then
-						log('Item Use Interupted')
-						if Divergence_Zones:contains(world.area) then
-							enable('range','ammo','head','lear','rear','body','hands','lring','rring','waist','legs','feet')
-						else
-							Unlock()
-						end
-						if choose_set_custom then
-							equip(set_combine(choose_set(), choose_set_custom()))
-						else
-							equip(set_combine(choose_set()))
-						end
-					end
-				-- Item use Finished
-				elseif data.category == 5 then
-					if data.param == 4154 then
-						log('Item Use Finished')
-						if Divergence_Zones:contains(world.area) then
-							enable('range','ammo','head','lear','rear','body','hands','lring','rring','waist','legs','feet')
-						else
-							Unlock()
-						end
-						if choose_set_custom then
-							equip(set_combine(choose_set(), choose_set_custom()))
-						else
-							equip(set_combine(choose_set()))
-						end
-					end
-				-- Casting Start
-				elseif data.category == 8 then
-					if data.param == 28787 then
-						log('Spell Interupt')
-						if choose_set_custom then
-							equip(set_combine(choose_set(), choose_set_custom()))
-						else
-							equip(set_combine(choose_set()))
-						end
-					elseif data.param == 24931 then
-						log('Casting Spell')
-					end
-				-- Ranged attack start
-				elseif data.category == 12 then
-					if data.param == 24931 then
-						log(''..player.name ..' is Shooting')
-					elseif data.param == 28787 then
-						log('Shooting is interrupted')
-					end
-				end
-				-- If player takes action, adjust TH tagging information
-				if state.TreasureMode.value ~= 'None' and TaggingCategories:contains(data.category) then
-					if windower.ffxi.get_mob_by_id(data.targets[1].id).is_npc then
-						th_info.tagged_mobs[data.targets[1].id] = os.clock()
-						if state.TreasureMode.value ~= 'Full Time' then 
-							if choose_set_custom then
-								equip(set_combine(choose_set(), choose_set_custom()))
-							else
-								equip(set_combine(choose_set()))
-							end
-						end
-					elseif th_info.tagged_mobs[data.actor_id] then
-						th_info.tagged_mobs[data.actor_id] = os.clock()
-					else
-						if th_info.tagged_mobs[data.targets[1].id] then
-							th_info.tagged_mobs[data.targets[1].id] = os.clock()
-						end
-					end
-				end
-			end
-			-- Casting Spell
-			if data.category == 8 then
-				if data.param == 24931 then
-					if data.targets[1].actions[1].param ~= 0 then
-						-- Get the ability
-						-- local ability = res.spells[targets[1].actions[1].param]
-					end
-				-- Spell inturpted
-				elseif data.param == 28787 then end
-			-- Weaponskill Finished
-			elseif data.category == 3 and data.param ~= 0 then
-				run_burst(data)
-			-- Casting finish
-			elseif data.category == 4 then
-				run_burst(data)
-			end
-		end
-	end)
-
-	-------------------------------------------------------------------------------------------------------------------
-	-- This function is called to determine correct sets and not a built in gearswap call
-	-------------------------------------------------------------------------------------------------------------------
-
-	function choose_set()
-		if buffactive['Sleep'] then return end
-		local built_set = {}
-		-- Combat Checks
-		if player.status == "Engaged" then
-			if sets.OffenseMode then
-				built_set = sets.OffenseMode
-				if sets.OffenseMode[state.OffenseMode.value] then
-					built_set = set_combine(built_set, sets.OffenseMode[state.OffenseMode.value])
-					-- Check the weapons
-					if state.WeaponMode.value ~= "Locked" then
-						if sets.Weapons then
-							if sets.Weapons[state.WeaponMode.value] then
-								built_set = set_combine(built_set, sets.Weapons[state.WeaponMode.value])
-							else warn('sets.Weapons.'..state.WeaponMode.value..' not found!') end
-						else warn('sets.Weapons not found!') end
-						-- Equip sub weapon based off mode
-						if not DualWield and not TwoHand then
-							if sets.Weapons.Shield then
-								built_set = set_combine(built_set, sets.Weapons.Shield)
-							else warn('sets.Weapons.Shield not found!') end
-						elseif DualWield then
-							if sets.DualWield then
-								built_set = set_combine(built_set, sets.DualWield)
-							else warn('sets.DualWield not found!') end
-						end
-					end
-					-- Ranged Mode
-					if state.JobMode.value == "Ranged" then
-						log('Ranged Mode')
-						if sets.Idle and sets.Idle[state.OffenseMode.value] then
-							built_set = set_combine(built_set, sets.Idle[state.OffenseMode.value])
-						else warn('sets.Idle.'..state.OffenseMode.value..' not found!') end
-					end
-					-- Check if AM3 is active
-					if buffactive['Aftermath: Lv.3'] and sets.OffenseMode.AM3 and sets.OffenseMode.AM3[state.WeaponMode.value] then
-						built_set = set_combine(built_set, sets.OffenseMode.AM3[state.WeaponMode.value])
-
-					elseif buffactive['Aftermath: Lv.2'] and sets.OffenseMode.AM2 and sets.OffenseMode.AM2[state.WeaponMode.value] then
-						built_set = set_combine(built_set, sets.OffenseMode.AM2[state.WeaponMode.value])
-
-					elseif buffactive['Aftermath: Lv.1'] and sets.OffenseMode.AM1 and sets.OffenseMode.AM1[state.WeaponMode.value] then
-						built_set = set_combine(built_set, sets.OffenseMode.AM1[state.WeaponMode.value])
-
-					elseif buffactive['Aftermath'] and sets.OffenseMode.AM and sets.OffenseMode.AM[state.WeaponMode.value] then
-						built_set = set_combine(built_set, sets.OffenseMode.AM[state.WeaponMode.value])
-					end
-					-- Check if TreasureMode is activew
-					if state.TreasureMode.value ~= 'None' then
-						if sets.TreasureHunter then
-							-- Equip TH gear if mob is not marked as tagged
-							if not th_info.tagged_mobs[player.target.id] then
-								built_set = set_combine(built_set, sets.TreasureHunter)
-
-							-- Equip TH gear if TreasureMode is Full Time
-							elseif state.TreasureMode.value == 'Full Time' then
-								built_set = set_combine(built_set, sets.TreasureHunter)
-
-							-- Equip TH gear if TreasureMode is SATA and either SA, TA or Feint is active
-							elseif state.TreasureMode.value == 'SATA' and (buffactive['Sneak Attack'] or buffactive['Trick Attack'] or buffactive['Feint']) then
-								built_set = set_combine(built_set, sets.TreasureHunter)
-							end
-						else warn('sets.TreasureHunter not found!') end
-					end
-				else warn('sets.OffenseMode.'..state.OffenseMode.value..' not found!') end
-			else warn('sets.OffenseMode not found!') end
-		-- Idle sets
-		else
-			if sets.Idle then
-				built_set = sets.Idle
-
-				-- Idle state
-				if sets.Idle[state.OffenseMode.value] then
-					built_set = set_combine(built_set, sets.Idle[state.OffenseMode.value])
-				else warn('sets.Idle.'..state.OffenseMode.value..' not found!') end	
-				
-				-- Resting condition
-				if player.status == "Resting" then
-					if sets.Idle.Resting then
-						built_set = set_combine(built_set, sets.Idle.Resting)
-					else warn('sets.Idle.Resting not found!') end
-				end
-
-				-- Check the weapons
-				if state.WeaponMode.value == "Locked" then
-					built_set = set_combine(built_set, { main=player.equipment.main, sub = player.equipment.sub, range = player.equipment.range})
-					log(built_set)
-				else
-					if sets.Weapons then
-						if sets.Weapons[state.WeaponMode.value] then
-							built_set = set_combine(built_set, sets.Weapons[state.WeaponMode.value])
-						else warn('sets.Weapons.'..state.WeaponMode.value..' not found!') end
-					else warn('sets.Weapons not found!') end
-
-					-- Check for sub weapon
-					if not TwoHand and not DualWield then
-						if sets.Weapons.Shield then
-							built_set = set_combine(built_set, sets.Weapons.Shield)
-						else warn('sets.Weapons.Shield not found!') end
-					end
-				end
-
-				--Pet specific checks
-				if pet.isvalid then
-					if sets.Idle.Pet then
-						built_set = set_combine(built_set, sets.Idle.Pet)
-					else warn('sets.Idle.Pet not found!') end
-				end
-				-- Equip Sublimation gear
-				if buffactive[187] then
-					if sets.Idle.Sublimation then
-						built_set = set_combine(built_set, sets.Idle.Sublimation)
-					else warn('sets.Idle.Sublimation not found!') end
-				end
-				-- Equip movement gear
-				if is_moving then
-					if sets.Movement then
-						built_set = set_combine(built_set, sets.Movement)
-					else warn('sets.Movement not found!') end
-				end
-			else warn('sets.Idle not found!') end
-		end
-
-		-- Variable Ammo
-		if Ammo and Ammo[state.OffenseMode.value] then built_set = set_combine(built_set, { ammo = Ammo[state.OffenseMode.value] }) end
-
-		return built_set
-	end
-
-	function equip_set_command()
-		windower.send_command("gs c update auto")
-	end
-
-	-- Start the engine with a 5 sec delay
-	coroutine.schedule(display_box_update, 2)
-	coroutine.schedule(dual_wield_check, 2.1)
-	coroutine.schedule(two_hand_check, 2.2)
-	coroutine.schedule(equip_set_command, 2.3)
-	coroutine.schedule(main_engine, 2.4)
+    -- Used to save the user specific settings
+    local config = require('config')
+    local res = require('resources')
+    local socket = require('socket')
+    local packets = require('packets')
+
+    local default = {
+        visible = true,
+        oneline = true,
+        debug = false,
+        info = true,
+        warn = true,
+        Display_Box = { text = { size = 11, font = 'Consolas', red = 255, green = 255, blue = 255, alpha = 255 }, pos = { x = 0, y = 0 }, bg = { visible = true, red = 0, green = 0, blue = 0, alpha = 150 }, flags = { bold = true } },
+        Debug_Box = { text = { size = 11, font = 'Consolas', red = 255, green = 255, blue = 255, alpha = 255 }, pos = { x = 0, y = 50 }, bg = { visible = true, red = 0, green = 0, blue = 0, alpha = 150 }, flags = { bold = true } },
+        delay = 3,
+    }
+
+    local buttons = { 'State', 'TH Mode', 'Auto Buff', 'Weapon', 'Job Mode' }
+
+    local Storms = S { "Aurorastorm", "Voidstorm", "Firestorm", "Sandstorm", "Rainstorm", "Windstorm", "Hailstorm", "Thunderstorm",
+        "Aurorastorm II", "Voidstorm II", "Firestorm II", "Sandstorm II", "Rainstorm II", "Windstorm II", "Hailstorm II", "Thunderstorm II" }
+
+    local UtsusemiSpell = S { 'Utsusemi: Ichi', 'Utsusemi: Ni', 'Utsusemi: San' }
+    local RecastTimers = {
+        ['WhiteMagic'] = true,
+        ['BlackMagic'] = true,
+        ['Ninjutsu'] = true,
+        ['BardSong'] = true,
+        ['Geomancy'] = true
+    }
+    local SleepSongs = S { 'Foe Lullaby', 'Foe Lullaby II', 'Horde Lullaby', 'Horde Lullaby II', }
+
+    local Divergence_Zones = S { "Dynamis - San d'Oria [D]", "Dynamis - Bastok [D]", "Dynamis - Windurst [D]", "Dynamis - Jeuno [D]" }
+
+    local settings = config.load(default)
+
+    local gs_status = texts.new("", settings.Display_Box)
+    if settings.visible then gs_status:show() end
+
+    local gs_debug = texts.new("", settings.Debug_Box)
+    if settings.debug then gs_debug:show() end
+
+    local DualWield = false
+    local TwoHand = false
+
+    local SpellCastTime = 0
+    local Spellstart = os.clock()
+
+    local is_moving = false
+    local is_first_time_load = true
+
+    local last_skillchain_id = 0
+    local last_skillchain_time = 0
+    local last_skillchain_elements = {}
+
+    local UpdateTime1 = os.clock()
+    local UpdateTime2 = os.clock()
+    local Location = { x = 0, y = 0, z = 0 }
+    local main_engine_time = os.clock()
+
+    local Require_Update = false
+    local Use_Item_Command = ''
+    local available_bullets = 0
+
+    -- Spell-Received Gear Tracking. Cache heavy API endpoints and immutable configurations outside the function scope.
+    local outgoing_cast_active = false
+    local accession_predicted = false
+    local divine_seal_predicted = false
+    local active_incoming_casters = {}
+    local cast_start_time = 0
+    local failsafe_active = false
+    local failsafe_trigger_time = 0
+    local ffxi = windower.ffxi
+    local get_ability_recasts = ffxi.get_ability_recasts
+    local get_spell_recasts = ffxi.get_spell_recasts
+    local get_mob_by_id = ffxi.get_mob_by_id
+    local get_mob_by_name = ffxi.get_mob_by_name
+    local get_party = ffxi.get_party
+    local send_ipc = windower.send_ipc_message
+    local NEARBY_MEMBERS_BUFFER = {}
+
+    -- Static string buffers to be reused to eliminate runtime GC string allocations
+    local BUFF_SLEEP, BUFF_STUN, BUFF_KO = 'Sleep', 'Stun', 'KO'
+    local BUFF_PETRI, BUFF_CHARM, BUFF_TERROR = 'Petrification', 'Charm', 'Terror'
+    local TYPE_JA, TYPE_WS, TYPE_MS, TYPE_SCH = 'JobAbility', 'WeaponSkill', 'Magic', 'Scholar'
+    local TARGET_SELF, TARGET_ENEMY = '{Self}', '{Enemy}'
+    local TARGET_PARTY1 = '{Self, Party}'
+    local TARGET_PARTY2 = '{Self, Party, Ally, NPC}'
+
+    -- Reusable persistent arrays to prevent table generation churn
+    local NEARBY_MEMBERS_BUFFER = {}
+
+    -- Tracking vars for TH
+    local th_info = {}
+    th_info.tagged_mobs = T {}
+    th_info.last_player_target_index = 0
+
+    -- For TH handling, which event IDs to register for tagging
+    local TaggingCategories = S { 1, 2, 3, 4, 6, 11, 14 }
+
+    local Mage_Job = S { 'BLM', 'RDM', 'WHM', 'BRD', 'BLU', 'GEO', 'SCH', 'NIN', 'PLD', 'RUN', 'DRK', 'SMN' }
+
+    -- City areas for town gear and behavior.
+    local Cities = S { "Ru'Lude Gardens", "Upper Jeuno", "Lower Jeuno", "Port Jeuno", "Port Windurst", "Windurst Waters", "Windurst Woods", "Windurst Walls", "Heavens Tower", "Port San d'Oria", "Northern San d'Oria",
+        "Southern San d'Oria", "Chateau d'Oraguille", "Port Bastok", "Bastok Markets", "Bastok Mines", "Metalworks", "Aht Urhgan Whitegate", "The Colosseum", "Tavnazian Safehold", "Nashmau", "Selbina",
+        "Mhaura", "Rabao", "Norg", "Kazham", "Eastern Adoulin", "Western Adoulin", "Celennia Memorial Library", "Mog Garden", "Leafallia" }
+
+    local Language = windower.ffxi.get_info().language:lower()
+
+    local skillchains = {
+        [288] = { id = 288, english = 'Light', elements = { 'Light', 'Lightning', 'Wind', 'Fire' } },
+        [289] = { id = 289, english = 'Darkness', elements = { 'Dark', 'Ice', 'Water', 'Earth' } },
+        [290] = { id = 290, english = 'Gravitation', elements = { 'Dark', 'Earth' } },
+        [291] = { id = 291, english = 'Fragmentation', elements = { 'Lightning', 'Wind' } },
+        [292] = { id = 292, english = 'Distortion', elements = { 'Ice', 'Water' } },
+        [293] = { id = 293, english = 'Fusion', elements = { 'Light', 'Fire' } },
+        [294] = { id = 294, english = 'Compression', elements = { 'Dark' } },
+        [295] = { id = 295, english = 'Liquefaction', elements = { 'Fire' } },
+        [296] = { id = 296, english = 'Induration', elements = { 'Ice' } },
+        [297] = { id = 297, english = 'Reverberation', elements = { 'Water' } },
+        [298] = { id = 298, english = 'Transfixion', elements = { 'Light' } },
+        [299] = { id = 299, english = 'Scission', elements = { 'Earth' } },
+        [300] = { id = 300, english = 'Detonation', elements = { 'Wind' } },
+        [301] = { id = 301, english = 'Impaction', elements = { 'Lightning' } },
+        [385] = { id = 385, english = 'Light', elements = { 'Light', 'Lightning', 'Wind', 'Fire' } },
+        [386] = { id = 386, english = 'Darkness', elements = { 'Dark', 'Ice', 'Water', 'Earth' } },
+        [387] = { id = 387, english = 'Gravitation', elements = { 'Dark', 'Earth' } },
+        [388] = { id = 388, english = 'Fragmentation', elements = { 'Lightning', 'Wind' } },
+        [389] = { id = 389, english = 'Distortion', elements = { 'Ice', 'Water' } },
+        [390] = { id = 390, english = 'Fusion', elements = { 'Light', 'Fire' } },
+        [391] = { id = 391, english = 'Compression', elements = { 'Dark' } },
+        [392] = { id = 392, english = 'Liquefaction', elements = { 'Fire' } },
+        [393] = { id = 393, english = 'Induration', elements = { 'Ice' } },
+        [394] = { id = 394, english = 'Reverberation', elements = { 'Water' } },
+        [395] = { id = 395, english = 'Transfixion', elements = { 'Light' } },
+        [396] = { id = 396, english = 'Scission', elements = { 'Earth' } },
+        [397] = { id = 397, english = 'Detonation', elements = { 'Wind' } },
+        [398] = { id = 398, english = 'Impaction', elements = { 'Lightning' } },
+        [767] = { id = 767, english = 'Radiance', elements = { 'Light', 'Lightning', 'Wind', 'Fire' } },
+        [768] = { id = 768, english = 'Umbra', elements = { 'Dark', 'Ice', 'Water', 'Earth' } },
+        [769] = { id = 769, english = 'Radiance', elements = { 'Light', 'Lightning', 'Wind', 'Fire' } },
+        [770] = { id = 770, english = 'Umbra', elements = { 'Dark', 'Ice', 'Water', 'Earth' } },
+    }
+
+    -- Spell definitions with metadata to dictate equipment categories and AoE rules
+    local spell_info = {
+        -- Cursna
+        [20] = { name = "Cursna", category = 'track_cursna', equip = "cursna_set", aoe = false, majesty = false, accession = true, divine = true },                       --Cursna
+        -- Phalanx
+        [106] = { name = "Phalanx", category = 'track_phalanx', equip = "phalanx_set", aoe = false, majesty = false, accession = true, divine = false },                  --Phalanx
+        [107] = { name = "Phalanx II", category = 'track_phalanx', equip = "phalanx_set", aoe = false, majesty = false, accession = false, divine = false },              --Phalanx II
+        -- Regen
+        [108] = { name = "Regen", category = 'track_regen', equip = "regen_set", aoe = false, majesty = false, accession = true, divine = false },                        --Regen
+        [110] = { name = "Regen II", category = 'track_regen', equip = "regen_set", aoe = false, majesty = false, accession = true, divine = false },                     --Regen II
+        [111] = { name = "Regen III", category = 'track_regen', equip = "regen_set", aoe = false, majesty = false, accession = true, divine = false },                    --Regen III
+        [477] = { name = "Regen IV", category = 'track_regen', equip = "regen_set", aoe = false, majesty = false, accession = true, divine = false },                     --Regen IV
+        [504] = { name = "Regen V", category = 'track_regen', equip = "regen_set", aoe = false, majesty = false, accession = true, divine = false },                      --Regen V
+        -- Protect
+        [43] = { name = "Protect", category = 'track_protect_shell', equip = "protect_shell_set", aoe = false, majesty = true, accession = true, divine = false },        --Protect
+        [44] = { name = "Protect II", category = 'track_protect_shell', equip = "protect_shell_set", aoe = false, majesty = true, accession = true, divine = false },     --Protect II
+        [45] = { name = "Protect III", category = 'track_protect_shell', equip = "protect_shell_set", aoe = false, majesty = true, accession = true, divine = false },    --Protect III
+        [46] = { name = "Protect IV", category = 'track_protect_shell', equip = "protect_shell_set", aoe = false, majesty = true, accession = true, divine = false },     --Protect IV
+        [47] = { name = "Protect V", category = 'track_protect_shell', equip = "protect_shell_set", aoe = false, majesty = true, accession = true, divine = false },      --Protect V
+        [125] = { name = "Protectra", category = 'track_protect_shell', equip = "protect_shell_set", aoe = true, majesty = true, accession = false, divine = false },     --Protectra
+        [126] = { name = "Protectra II", category = 'track_protect_shell', equip = "protect_shell_set", aoe = true, majesty = true, accession = false, divine = false },  --Protectra II
+        [127] = { name = "Protectra III", category = 'track_protect_shell', equip = "protect_shell_set", aoe = true, majesty = true, accession = false, divine = false }, --Protectra III
+        [128] = { name = "Protectra IV", category = 'track_protect_shell', equip = "protect_shell_set", aoe = true, majesty = true, accession = false, divine = false },  --Protectra IV
+        [129] = { name = "Protectra V", category = 'track_protect_shell', equip = "protect_shell_set", aoe = true, majesty = true, accession = false, divine = false },   --Protectra V
+        -- Shell
+        [48] = { name = "Shell", category = 'track_protect_shell', equip = "protect_shell_set", aoe = false, majesty = false, accession = true, divine = false },         --Shell
+        [49] = { name = "Shell II", category = 'track_protect_shell', equip = "protect_shell_set", aoe = false, majesty = false, accession = true, divine = false },      --Shell II
+        [50] = { name = "Shell III", category = 'track_protect_shell', equip = "protect_shell_set", aoe = false, majesty = false, accession = true, divine = false },     --Shell III
+        [51] = { name = "Shell IV", category = 'track_protect_shell', equip = "protect_shell_set", aoe = false, majesty = false, accession = true, divine = false },      --Shell IV
+        [52] = { name = "Shell V", category = 'track_protect_shell', equip = "protect_shell_set", aoe = false, majesty = false, accession = true, divine = false },       --Shell V
+        [130] = { name = "Shellra", category = 'track_protect_shell', equip = "protect_shell_set", aoe = true, majesty = false, accession = false, divine = false },      --Shellra
+        [131] = { name = "Shellra II", category = 'track_protect_shell', equip = "protect_shell_set", aoe = true, majesty = false, accession = false, divine = false },   --Shellra II
+        [132] = { name = "Shellra III", category = 'track_protect_shell', equip = "protect_shell_set", aoe = true, majesty = false, accession = false, divine = false },  --Shellra III
+        [133] = { name = "Shellra IV", category = 'track_protect_shell', equip = "protect_shell_set", aoe = true, majesty = false, accession = false, divine = false },   --Shellra IV
+        [134] = { name = "Shellra V", category = 'track_protect_shell', equip = "protect_shell_set", aoe = true, majesty = false, accession = false, divine = false },    --Shellra V
+        -- Cure
+        [1] = { name = "Cure", category = 'track_cure', equip = "cure_set", aoe = false, majesty = true, accession = true, divine = false },                              --Cure
+        [2] = { name = "Cure II", category = 'track_cure', equip = "cure_set", aoe = false, majesty = true, accession = true, divine = false },                           --Cure II
+        [3] = { name = "Cure III", category = 'track_cure', equip = "cure_set", aoe = false, majesty = true, accession = true, divine = false },                          --Cure III
+        [4] = { name = "Cure IV", category = 'track_cure', equip = "cure_set", aoe = false, majesty = true, accession = true, divine = false },                           --Cure IV
+        [5] = { name = "Cure V", category = 'track_cure', equip = "cure_set", aoe = false, majesty = true, accession = false, divine = false },                           --Cure V
+        [6] = { name = "Cure VI", category = 'track_cure', equip = "cure_set", aoe = false, majesty = true, accession = false, divine = false },                          --Cure VI
+        -- Curaga / Cura
+        [7] = { name = "Curaga", category = 'track_cure', equip = "cure_set", aoe = true, majesty = false, accession = false, divine = false },                           --Curaga
+        [8] = { name = "Curaga II", category = 'track_cure', equip = "cure_set", aoe = true, majesty = false, accession = false, divine = false },                        --Curaga II
+        [9] = { name = "Curaga III", category = 'track_cure', equip = "cure_set", aoe = true, majesty = false, accession = false, divine = false },                       --Curaga III
+        [10] = { name = "Curaga IV", category = 'track_cure', equip = "cure_set", aoe = true, majesty = false, accession = false, divine = false },                       --Curaga IV
+        [11] = { name = "Curaga V", category = 'track_cure', equip = "cure_set", aoe = true, majesty = false, accession = false, divine = false },                        --Curaga V
+        [93] = { name = "Cura", category = 'track_cure', equip = "cure_set", aoe = true, majesty = false, accession = false, divine = false },                            --Cura
+        [474] = { name = "Cura II", category = 'track_cure', equip = "cure_set", aoe = true, majesty = false, accession = false, divine = false },                        --Cura II
+        [475] = { name = "Cura III", category = 'track_cure', equip = "cure_set", aoe = true, majesty = false, accession = false, divine = false },                       --Cura III
+        --Refresh
+        [109] = { name = "Refresh", category = 'track_refresh', equip = "refresh_set", aoe = false, majesty = false, accession = true, divine = false },                  --Refresh
+        [473] = { name = "Refresh II", category = 'track_refresh', equip = "refresh_set", aoe = false, majesty = false, accession = false, divine = false },              --Refresh II
+        [894] = { name = "Refresh III", category = 'track_refresh', equip = "refresh_set", aoe = false, majesty = false, accession = false, divine = false },             --Refresh III
+    }
+
+    -- Consolidated abilities mapping
+    local ability_info = {
+        [190] = { name = "Curing Waltz", category = 'track_waltz', equip = "waltz_set", aoe = false, accession = false },     --Curing Waltz
+        [191] = { name = "Curing Waltz II", category = 'track_waltz', equip = "waltz_set", aoe = false, accession = false },  --Curing Waltz II
+        [192] = { name = "Curing Waltz III", category = 'track_waltz', equip = "waltz_set", aoe = false, accession = false }, --Curing Waltz III
+        [193] = { name = "Curing Waltz IV", category = 'track_waltz', equip = "waltz_set", aoe = false, accession = false },  --Curing Waltz IV
+        [311] = { name = "Curing Waltz V", category = 'track_waltz', equip = "waltz_set", aoe = false, accession = false },   --Curing Waltz V
+        [195] = { name = "Divine Waltz", category = 'track_waltz', equip = "waltz_set", aoe = true, accession = false },      --Divine Waltz
+        [262] = { name = "Divine Waltz II", category = 'track_waltz', equip = "waltz_set", aoe = true, accession = false },   --Divine Waltz II
+    }
+
+    --Unlock any previously locked gear
+    enable('main', 'sub', 'range', 'ammo', 'head', 'neck', 'lear', 'rear', 'body', 'hands', 'lring', 'rring', 'waist',
+        'legs', 'feet')
+
+    --Get the time in milliseconds from socket to provide synchronous time for all clients.
+    --Must use socket instead of os.clock() for this purpose
+    local function get_time()
+        return math.floor(socket.gettime() * 1000)
+    end
+
+    --Used to display timestamped debug messages when debug mode is on
+    local function debug(message)
+        if not settings.debug then return end
+        windower.add_to_chat(121, "[Mirdain Debug] " .. message)
+    end
+
+    --Check if a set has a slot/gear combo defined
+    --Return the item name for a given slot within a set or nil if it isn't defined
+    local function get_slot_item_name(gear_set, slot)
+        if not gear_set or not gear_set[slot] then
+            return nil
+        end
+
+        local slot_data = gear_set[slot]
+
+        if type(slot_data) == 'table' then
+            return slot_data.name
+        elseif type(slot_data) == 'string' then
+            return slot_data
+        end
+
+        return nil
+    end
+
+    --Check if a name is currently in the character's party.
+    --Return true if target is in party
+    local function is_target_in_party(target_name)
+        if not target_name then return false end
+
+        local party_info = get_party()
+        if not party_info then return false end
+
+        for i = 0, 5 do
+            local member = party_info['p' .. i]
+            if member and member.name == target_name then
+                return true
+            end
+        end
+
+        return false
+    end
+
+    --Calculate and return how many strategems are off cooldown.
+    local function get_current_stratagem_count()
+        local charge_cooldown = windower.ffxi.get_ability_recasts()[231] or 0
+
+        local max_charges = 1
+        local charge_regen_time = 240
+
+        local sch_level = 0
+        if player.main_job == 'SCH' then
+            sch_level = player.main_job_level
+        elseif player.sub_job == 'SCH' then
+            sch_level = player.sub_job_level
+        end
+
+        if sch_level >= 90 then
+            max_charges = 5
+            charge_regen_time = 48
+        elseif sch_level >= 70 then
+            max_charges = 4
+            charge_regen_time = 60
+        elseif sch_level >= 50 then
+            max_charges = 3
+            charge_regen_time = 80
+        elseif sch_level >= 30 then
+            max_charges = 3
+            charge_regen_time = 120
+        elseif sch_level >= 10 then
+            max_charges = 2
+            charge_regen_time = 240
+        end
+
+        if charge_cooldown == 0 then return max_charges end
+
+        local full_recharge_window = max_charges * charge_regen_time
+        local current_charges = math.floor((full_recharge_window - charge_cooldown) / charge_regen_time)
+
+        return math.max(0, current_charges)
+    end
+
+    --Helper function to count and return the number of entries in the top level of a table.
+    local function count_keys(tbl)
+        local count = 0
+        for _ in pairs(tbl) do
+            count = count + 1
+        end
+        return count
+    end
+
+    local function equip_spell_received_gear(spell_id, spell_type)
+        debug("Equip gear function triggered: " .. spell_id .. ", " .. spell_type)
+        local s_info = {}
+        if spell_type == "spell" then
+            s_info = spell_info[spell_id]
+        elseif spell_type == "ability" then
+            s_info = ability_info[spell_id]
+        end
+
+        --Calculate delta since cast start time in milliseconds
+        local elapsed_ms = get_time() - cast_start_time
+
+        local spell_received_set = {}
+        if s_info.equip == "cure_set" then
+            if sets.Cure_Received then
+                spell_received_set = sets.Cure_Received
+                info("Cure Received set")
+            else
+                warn("sets.Cure_Received not found!")
+            end
+        elseif s_info.equip == "cursna_set" then
+            if sets.Cursna_Received then
+                spell_received_set = sets.Cursna_Received
+                info("Cursna Received set")
+            else
+                warn("sets.Cursna_Received not found!")
+            end
+        elseif s_info.equip == "phalanx_set" then
+            if sets.Phalanx_Received then
+                spell_received_set = sets.Phalanx_Received
+                info("Phalanx Received set")
+            else
+                warn("sets.Phalanx_Received not found!")
+            end
+        elseif s_info.equip == "protect_shell_set" then
+            if sets.Protect_Shell_Received then
+                spell_received_set = sets.Protect_Shell_Received
+                info("Protect and Shell Received set")
+            else
+                warn("sets.Protect_Shell_Received not found!")
+            end
+        elseif s_info.equip == "regen_set" then
+            if sets.Regen_Received then
+                spell_received_set = sets.Regen_Received
+                info("Regen Received set")
+            else
+                warn("sets.Regen_Received not found!")
+            end
+        elseif s_info.equip == "refresh_set" then
+            if sets.Refresh_Received then
+                spell_received_set = sets.Refresh_Received
+                info("Refresh Received set")
+            else
+                warn("sets.Refresh_Received not found!")
+            end
+        elseif s_info.equip == "waltz_set" then
+            if sets.Waltz_Received then
+                spell_received_set = sets.Waltz_Received
+                info("Waltz Received set")
+            else
+                warn("sets.Waltz_Received not found!")
+            end
+        else
+            warn("Unknown Spell for Spell Received Gear")
+        end
+
+        if type(spell_received_set) == 'table' then
+            equip(spell_received_set)
+            if state.SpellReceived.value == "ON-Locked" then
+                --Lock the slots of items from the spell received set to prevent other
+                --actions from overwriting until cast completion
+                for slot, item in pairs(spell_received_set) do
+                    disable(slot)
+
+                    debug("Locking " .. tostring(slot))
+                    active_external_locks[slot] = true
+                end
+            end
+        end
+    end
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called from the default GearSwap Function "pretarget" to validate the user action
+    -------------------------------------------------------------------------------------------------------------------
+
+    function pretargetcheck(spell, action)
+        if pet.isvalid and pet_midaction() then
+            cancel_spell()
+            return
+        end
+
+        local active_buffs = buffactive
+        if active_buffs[BUFF_SLEEP] then
+            cancel_spell()
+            if sets.Idle then equip(sets.Idle) else warn('sets.Idle not found!') end
+            if sets.Weapons then
+                if sets.Weapons.Sleep then equip(sets.Weapons.Sleep) else warn('sets.Weapons.Sleep not found!') end
+            else
+                warn('sets.Weapons not found!')
+            end
+            return
+        elseif active_buffs[BUFF_STUN] or active_buffs[BUFF_PETRI] or active_buffs[BUFF_TERROR] then
+            cancel_spell()
+            if sets.Idle then equip(sets.Idle) else warn('sets.Idle not found!') end
+            return
+        elseif active_buffs[BUFF_KO] or active_buffs[BUFF_CHARM] then
+            cancel_spell()
+            return
+        end
+
+        if AutoItem and not active_buffs['Muddle'] then
+            local inv = player.inventory
+            if (active_buffs['Paralysis'] and spell.type == TYPE_JA) or (spell.action_type == TYPE_MS and active_buffs['Silence']) then
+                if inv['Remedy'] then
+                    cancel_spell()
+                    windower.chat.input('/item "Remedy" <me>')
+                    return
+                end
+            end
+        end
+
+        -- Weapon Skill Checks
+        local s_type = spell.type
+        if s_type == TYPE_WS then
+            if player.tp < 1000 then
+                cancel_spell()
+                return
+            elseif active_buffs['Amnesia'] then
+                cancel_spell()
+                info("Can't Weapon Skill due to amnesia.")
+                return
+            end
+
+            -- Abilities Handling
+        elseif s_type == TYPE_JA or s_type == 'Waltz' or s_type == 'BloodPactWard' or s_type == 'BloodPactRage' or s_type == 'PetCommand' then
+            local recast_time = get_ability_recasts()[spell.recast_id]
+            if recast_time and recast_time > 0 then
+                local total_sec = recast_time / 60
+                info(spell.name ..
+                    ' [' .. math.floor(total_sec / 60) .. ':' .. string.format("%02d", total_sec % 60) .. ']')
+                cancel_spell()
+                return
+            end
+            if spell.type == 'Waltz' then
+                local ja_resource = res.job_abilities[spell.id]
+                if ja_resource and ja_resource.tp_cost then
+                    if player.tp < ja_resource.tp_cost then
+                        cancel_spell()
+                        info('Insufficient TP for ' ..
+                            spell.name .. ' [' .. player.tp .. '/' .. ja_resource.tp_cost .. ']')
+                        return
+                    end
+                end
+            end
+
+            --Check for ability casts that are tracked for spell-received gear swapping
+            --Notify eligible targets via IPC that a tracked spell is incoming
+            if state.SpellReceived.value ~= "OFF" then
+                if spell.name == "Divine Seal" then
+                    divine_seal_predicted = true
+                    debug("Divine Seal detected while tracking. Divine_Seal_Predicted = True")
+                end
+                local a_info = ability_info[spell.id]
+                if a_info then
+                    local target_mob = get_mob_by_id(spell.target.id)
+                    if not player or not target_mob then return end
+
+                    local target_name = spell.target.name
+                    outgoing_cast_active = true
+                    debug(player.name .. ' is using tracked ability measured at pretarget: ' ..
+                        spell.name .. ' on ' .. target_name .. ' at ' .. get_time())
+
+                    --AoE Checks
+                    if a_info.aoe and is_target_in_party(target_name) then
+                        debug("AoE Ability Cast Detected.  Calculating targets.")
+                        local party = get_party()
+                        if party then
+                            local count = 0
+                            for k, v in pairs(NEARBY_MEMBERS_BUFFER) do NEARBY_MEMBERS_BUFFER[k] = nil end
+
+                            for slot, member in pairs(party) do
+                                if type(member) == 'table' and member.name then
+                                    local m_mob = get_mob_by_name(member.name)
+                                    if m_mob then
+                                        local dx, dy, dz = m_mob.x - target_mob.x, m_mob.y - target_mob.y,
+                                            m_mob.z - target_mob.z
+                                        if ((dx * dx) + (dy * dy) + (dz * dz)) <= 100 then
+                                            debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name)
+                                            count = count + 1
+                                            NEARBY_MEMBERS_BUFFER[count] = member.name
+                                        else
+                                            debug(member.name .. " is OUT of aoe range from " .. target_mob.name)
+                                        end
+                                    else
+                                        debug(member.name .. " data unavailable (Too far away).")
+                                    end
+                                end
+                            end
+                            if count > 0 then target_name = table.concat(NEARBY_MEMBERS_BUFFER, ",") end
+                        end
+                    end
+                    debug(string.format("IPC message sent: MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name,
+                        spell.id, get_time()))
+                    send_ipc(string.format("MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name, spell.id,
+                        get_time()))
+                end
+            end
+        elseif RecastTimers[s_type] then
+            local recast_time = get_spell_recasts()[spell.recast_id]
+            if recast_time and recast_time > 0 then
+                local total_sec = recast_time / 60
+                info(spell.name ..
+                    ' [' .. math.floor(total_sec / 60) .. ':' .. string.format("%02d", total_sec % 60) .. ']')
+                cancel_spell()
+                return
+            end
+            if target_assist then
+                local t_type = spell.target.type
+
+                if not t_type and s_type == 'BardSong' then
+                    if active_buffs['Pianissimo'] then
+                        cancel_spell()
+                        windower.chat.input('/ma "' .. spell.name .. '" ' .. (not is_Pianissimo and '<stpc>' or '<me>'))
+                        is_Pianissimo = not is_Pianissimo
+                    else
+                        change_target('<me>')
+                    end
+                elseif t_type then
+                    local cast_spell = res.spells[spell.id]
+                    if not cast_spell or not cast_spell.targets then
+                        info('Unable to find spell [' .. spell.name .. ']')
+                    else
+                        local s_targets = cast_spell.targets
+
+                        if s_targets[TARGET_SELF] and t_type ~= 'SELF' then
+                            change_target('<me>')
+                        elseif s_targets[TARGET_ENEMY] then
+                            if t_type ~= 'MONSTER' and not spell.name:contains('Lullaby') and not spell.name:contains('Sleep') then
+                                cancel_spell()
+                                return
+                            end
+                        elseif s_targets[TARGET_PARTY1] or s_targets[TARGET_PARTY2] then
+                            if t_type == 'MONSTER' then
+                                if s_type == 'BardSong' then
+                                    if active_buffs['Pianissimo'] then
+                                        cancel_spell()
+                                        windower.chat.input('/ma "' ..
+                                            spell.name .. '" ' .. (not is_Pianissimo and '<stpc>' or '<me>'))
+                                        is_Pianissimo = not is_Pianissimo
+                                    else
+                                        change_target('<me>')
+                                    end
+                                else
+                                    cancel_spell()
+                                    return
+                                end
+                            elseif s_type == 'BardSong' and t_type == 'SELF' and active_buffs['Pianissimo'] then
+                                cancel_spell()
+                                windower.chat.input('/ma "' .. spell.name .. '" <stpc>')
+                                return
+                            end
+                        end
+                    end
+                end
+            end
+
+            --Check for spell casts that are tracked for spell-received gear swapping
+            --Notify eligible targets via IPC that a tracked spell is incoming
+            local s_info = spell_info[spell.id]
+            if s_info and state.SpellReceived.value ~= "OFF" then
+                local target_mob = get_mob_by_id(spell.target.id)
+                if not target_mob then return end
+
+                local target_name = spell.target.name
+                outgoing_cast_active = true
+
+                debug(player.name ..
+                    ' is using tracked spell measured at pretarget: ' ..
+                    spell.name .. ' on ' .. target_name .. ' at ' .. get_time())
+
+                local accession_active = active_buffs[366] or active_buffs['Accession']
+                local majesty_active = active_buffs[621] or active_buffs['Majesty']
+                local divine_veil_active = active_buffs[78] or active_buffs['Divine Seal']
+
+                --AoE checks
+                local has_yagrush = (s_info.divine and get_slot_item_name(sets.Midcast["Cursna"], 'main') == "Yagrush")
+                if is_target_in_party(target_name) and (s_info.aoe or ((accession_predicted or accession_active) and s_info.accession) or (majesty_active and s_info.majesty) or ((divine_seal_predicted or divine_veil_active or has_yagrush) and s_info.divine)) then
+                    debug("AoE Spell Cast Detected. Calculating targets.")
+                    local party = get_party()
+                    if party then
+                        local count = 0
+                        for k in pairs(NEARBY_MEMBERS_BUFFER) do NEARBY_MEMBERS_BUFFER[k] = nil end
+
+                        for slot, member in pairs(party) do
+                            if type(member) == 'table' and member.name then
+                                local m_mob = get_mob_by_name(member.name)
+                                if m_mob then
+                                    local dx = m_mob.x - target_mob.x
+                                    local dy = m_mob.y - target_mob.y
+                                    local dz = m_mob.z - target_mob.z
+                                    if ((dx * dx) + (dy * dy) + (dz * dz)) <= 100 then
+                                        debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name)
+                                        count = count + 1
+                                        NEARBY_MEMBERS_BUFFER[count] = member.name
+                                    else
+                                        debug(member.name .. " is OUT of aoe range from " .. target_mob.name)
+                                    end
+                                else
+                                    debug(member.name .. " data unavailable (Too far away).")
+                                end
+                            end
+                        end
+
+                        if count > 0 then
+                            target_name = table.concat(NEARBY_MEMBERS_BUFFER, ",")
+                        end
+                    end
+                end
+                debug(string.format("IPC message sent: MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id,
+                    get_time()))
+                send_ipc(string.format("MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id, get_time()))
+            end
+        elseif s_type == TYPE_SCH then
+            available_charges = get_current_stratagem_count()
+            if available_charges == 0 then
+                cancel_spell()
+                info("Unable to use strategems. Available charges = 0")
+            elseif spell.name == "Accession" then
+                accession_predicted = true
+                debug("Accession detected while tracking. Accession_Predicted = True")
+            end
+        end
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called from the default GearSwap Function "precast" to build an built_set
+    -------------------------------------------------------------------------------------------------------------------
+
+    function precastequip(spell)
+        log('precastequip Called')
+        debug("spell.type = " ..
+            spell.type ..
+            " , spell.action_type = " ..
+            spell.action_type .. " , spell.english = " .. spell.english .. " , spell.name = " .. spell.name)
+        --Cancel for SMN if Avatar is mid action
+        if pet.isvalid and pet_midaction() then return end
+        --Default gearset
+        local built_set = {}
+        -- Merge the Idle incase a midcast is not set
+        if sets.Idle then built_set = set_combine(built_set, sets.Idle) end
+        -- WeaponSkill
+        if spell.type == 'WeaponSkill' then
+            if sets.WS then
+                built_set = set_combine(built_set, sets.WS)
+                local message = ''
+                if spell.skill == "Marksmanship" or spell.skill == "Archery" then
+                    -- Try to equip a generic ranged WS set
+                    if sets.WS.RA then
+                        built_set = set_combine(built_set, sets.WS.RA)
+                    else
+                        warn('sets.WS.RA not found!')
+                    end
+
+                    -- Set is defined
+                    if sets.WS[spell.english] then
+                        built_set = set_combine(built_set, sets.WS[spell.english])
+                        -- Example would be WS[Savage Blade]['PDL']
+                        if sets.WS[spell.english][state.OffenseMode.value] then
+                            built_set = set_combine(built_set, sets.WS[spell.english][state.OffenseMode.value])
+                            message = '[' .. spell.english .. '] Set (Augmented)'
+                            -- Example would be WS.RA.ACC
+                        elseif state.OffenseMode.value ~= 'TP' and sets.WS.RA and sets.WS.RA[state.OffenseMode.value] then
+                            built_set = set_combine(built_set, sets.WS.RA[state.OffenseMode.value])
+                            -- Augment the specified WS
+                            if state.OffenseMode.value == 'ACC' then
+                                message = '[' .. spell.english .. '] Set with Accuracy'
+                            elseif state.OffenseMode.value == 'PDL' then
+                                message = '[' .. spell.english .. '] Set with Physical Damage Limit'
+                            elseif state.OffenseMode.value == 'SB' then
+                                message = '[' .. spell.english .. '] Set with Subtle Blow'
+                            elseif state.OffenseMode.value == 'MEVA' then
+                                message = '[' .. spell.english .. '] Set with Magic Evasion'
+                            elseif state.OffenseMode.value == 'CRIT' then
+                                message = '[' .. spell.english .. '] Set with Critical Hit'
+                            end
+                        else
+                            message = '[' .. spell.english .. '] Set'
+                        end
+
+                        -- Generic
+                    else
+                        if state.OffenseMode.value ~= 'TP' and sets.WS.RA and sets.WS.RA[state.OffenseMode.value] then
+                            built_set = set_combine(built_set, sets.WS.RA[state.OffenseMode.value])
+                            if state.OffenseMode.value == 'ACC' then
+                                message = 'Using Default WS Set with Accuracy'
+                            elseif state.OffenseMode.value == 'PDL' then
+                                message = 'Using Default WS Set with Physical Damage Limit'
+                            elseif state.OffenseMode.value == 'SB' then
+                                message = 'Using Default WS Set with Subtle Blow'
+                            elseif state.OffenseMode.value == 'MEVA' then
+                                message = 'Using Default WS Set with Magic Evasion'
+                            elseif state.OffenseMode.value == 'CRIT' then
+                                message = 'Using Default WS Set with Critical Hit'
+                            end
+                        else
+                            message = 'Using Default WS Set'
+                        end
+                    end
+
+                    -- Check if Aftermath is active
+                    if sets.WS.RA then
+                        if buffactive['Aftermath: Lv.3'] and sets.WS.RA.AM3 and sets.WS.RA.AM3[state.WeaponMode.value] then
+                            built_set = set_combine(built_set, sets.WS.RA.AM3[state.WeaponMode.value])
+                            message = message .. ' and Level 3 Aftermath [' .. state.WeaponMode.value .. ']'
+                        elseif buffactive['Aftermath: Lv.2'] and sets.WS.RA.AM2 and sets.WS.RA.AM2[state.WeaponMode.value] then
+                            built_set = set_combine(built_set, sets.WS.RA.AM2[state.WeaponMode.value])
+                            message = message .. ' and Level 2 Aftermath [' .. state.WeaponMode.value .. ']'
+                        elseif buffactive['Aftermath: Lv.1'] and sets.WS.RA.AM1 and sets.WS.RA.AM1[state.WeaponMode.value] then
+                            built_set = set_combine(built_set, sets.WS.RA.AM1[state.WeaponMode.value])
+                            message = message .. ' and Level 1 Aftermath [' .. state.WeaponMode.value .. ']'
+                        elseif buffactive['Aftermath'] and sets.WS.RA.AM and sets.WS.RA.AM[state.WeaponMode.value] then
+                            built_set = set_combine(built_set, sets.WS.RA.AM[state.WeaponMode.value])
+                            message = message .. ' and Aftermath [' .. state.WeaponMode.value .. ']'
+                        end
+                    end
+
+                    -- Bullet Check
+                    do_bullet_checks(spell, built_set)
+
+                    -- Variable Ammo
+                    if Ammo and Ammo[state.OffenseMode.value] then
+                        built_set = set_combine(built_set,
+                            { ammo = Ammo[state.OffenseMode.value] })
+                    end
+
+                    message = message .. ' [' .. available_bullets .. 'x]'
+                else
+                    -- Set is defined
+                    if sets.WS[spell.english] then
+                        built_set = set_combine(built_set, sets.WS[spell.english])
+                        -- Example would be WS[Savage Blade]['PDL']
+                        if sets.WS[spell.english][state.OffenseMode.value] then
+                            built_set = set_combine(built_set, sets.WS[spell.english][state.OffenseMode.value])
+                            message = '[' .. spell.english .. '] Set (Augmented)'
+                            -- Example would be WS.ACC
+                        elseif state.OffenseMode.value ~= 'TP' and sets.WS[state.OffenseMode.value] then
+                            built_set = set_combine(built_set, sets.WS[state.OffenseMode.value])
+                            -- Augment the specified WS
+                            if state.OffenseMode.value == 'ACC' then
+                                message = '[' .. spell.english .. '] Set with Accuracy'
+                            elseif state.OffenseMode.value == 'PDL' then
+                                message = '[' .. spell.english .. '] Set with Physical Damage Limit'
+                            elseif state.OffenseMode.value == 'SB' then
+                                message = '[' .. spell.english .. '] Set with Subtle Blow'
+                            elseif state.OffenseMode.value == 'MEVA' then
+                                message = '[' .. spell.english .. '] Set with Magic Evasion'
+                            elseif state.OffenseMode.value == 'CRIT' then
+                                message = '[' .. spell.english .. '] Set with Critical Hit'
+                            end
+                        else
+                            message = '[' .. spell.english .. '] Set'
+                        end
+
+                        -- Generic
+                    else
+                        if state.OffenseMode.value ~= 'TP' and sets.WS[state.OffenseMode.value] then
+                            built_set = set_combine(built_set, sets.WS[state.OffenseMode.value])
+                            -- Augment the specified WS
+                            if state.OffenseMode.value == 'ACC' then
+                                message = 'Using Default WS Set with Accuracy'
+                            elseif state.OffenseMode.value == 'PDL' then
+                                message = 'Using Default WS Set with Physical Damage Limit'
+                            elseif state.OffenseMode.value == 'SB' then
+                                message = 'Using Default WS Set with Subtle Blow'
+                            elseif state.OffenseMode.value == 'MEVA' then
+                                message = 'Using Default WS Set with Magic Evasion'
+                            elseif state.OffenseMode.value == 'CRIT' then
+                                message = 'Using Default WS Set with Critical Hit'
+                            end
+                        else
+                            message = 'Using Default WS Set'
+                        end
+                    end
+
+                    -- Check if Aftermath is active
+                    if buffactive['Aftermath: Lv.3'] and sets.WS.AM3 and sets.WS.AM3[state.WeaponMode.value] then
+                        built_set = set_combine(built_set, sets.WS.AM3[state.WeaponMode.value])
+                        message = message .. ' and Level 3 Aftermath'
+                    elseif buffactive['Aftermath: Lv.2'] and sets.WS.AM2 and sets.WS.AM2[state.WeaponMode.value] then
+                        built_set = set_combine(built_set, sets.WS.AM2[state.WeaponMode.value])
+                        message = message .. ' and Level 2 Aftermath'
+                    elseif buffactive['Aftermath: Lv.1'] and sets.WS.AM1 and sets.WS.AM1[state.WeaponMode.value] then
+                        built_set = set_combine(built_set, sets.WS.AM1[state.WeaponMode.value])
+                        message = message .. ' and Level 1 Aftermath'
+                    elseif buffactive['Aftermath'] and sets.WS.AM and sets.WS.AM[state.WeaponMode.value] then
+                        built_set = set_combine(built_set, sets.WS.AM[state.WeaponMode.value])
+                        message = message .. ' and Aftermath'
+                    end
+                end
+
+                -- Check if an Obi or Orpheus is to be Equiped
+                if Elemental_WS:contains(spell.name) then built_set = elemental_check(spell, built_set) end
+
+                info(message)
+            else
+                warn('sets.WS not found!')
+            end
+            -- Ranged attack
+        elseif spell.action_type == 'Ranged Attack' then
+            if sets.Precast then
+                built_set = set_combine(built_set, sets.Precast)
+                if sets.Precast.RA then
+                    built_set = set_combine(built_set, sets.Precast.RA)
+                    if buffactive[265] then -- Flurry
+                        if sets.Precast.RA.Flurry then
+                            built_set = set_combine(built_set, sets.Precast.RA.Flurry)
+                        else
+                            warn('sets.Precast.RA.Flurry not found!')
+                        end
+                    elseif buffactive[581] then -- Flurry II
+                        if sets.Precast.RA.Flurry_II then
+                            built_set = set_combine(built_set, sets.Precast.RA.Flurry_II)
+                        else
+                            warn('sets.Precast.RA.Flurry_II not found!')
+                        end
+                    elseif buffactive[228] then -- Embrava
+                        if sets.Precast.RA.Flurry_II then
+                            built_set = set_combine(built_set, sets.Precast.RA.Flurry_II)
+                        else
+                            warn('sets.Precast.RA.Flurry_II not found!')
+                        end
+                    end
+
+                    -- Variable Ammo
+                    if Ammo and Ammo[state.OffenseMode.value] then
+                        built_set = set_combine(built_set,
+                            { ammo = Ammo[state.OffenseMode.value] })
+                    end
+                else
+                    warn('sets.Precast.RA not found!')
+                end
+            else
+                warn('sets.Precast not found!')
+            end
+
+            -- Check for bullets if shooting a round
+            if built_set.ammo ~= "" and built_set.ranged ~= "" then do_bullet_checks(spell, built_set) end
+            -- JobAbility
+        elseif spell.type == 'JobAbility' then
+            if sets.JA then
+                built_set = set_combine(built_set, sets.JA)
+                if spell.name == 'Double-Up' then -- Double Up for distance
+                    if sets.PhantomRoll then
+                        built_set = set_combine(built_set, sets.PhantomRoll)
+                        info('[' .. spell.english .. '] Set')
+                    else
+                        warn('sets.PhantomRoll not found!')
+                    end
+                elseif sets.JA[spell.english] then
+                    built_set = set_combine(built_set, sets.JA[spell.english])
+                    --Summon the correct jug pet
+                    if spell.name == 'Bestial Loyalty' or spell.name == 'Call Beast' then
+                        if sets.Jugs[state.JobMode.value] then
+                            built_set = set_combine(built_set, sets.Jugs[state.JobMode.value])
+                        else
+                            warn('sets.Jugs.' .. state.JobMode.value .. ' not found!')
+                        end
+                    end
+                    info('[' .. spell.english .. '] Set')
+                else
+                    info('JA not set for [' .. spell.english .. ']')
+                end
+                -- Check for bounty shot ammo
+                if spell.name == 'Bounty Shot' then
+                    do_bullet_checks(spell, built_set)
+                end
+            else
+                warn('sets.JA not found!')
+            end
+            if spell.name == "Divine Seal" and not divine_seal_predicted then
+                divine_seal_predicted = true
+                debug("Divine Seal detected while tracking. Divine_Seal_Predicted = True")
+            end
+            -- Items
+        elseif spell.action_type == 'Item' or spell.prefix == '/item' then
+            log('Item Use - Precast')
+            if spell.english == "Holy Water" or spell.english == "Hallowed Water" then
+                info("Holy Water set")
+                if sets.Holy_Water then
+                    if sets.Idle then
+                        built_set = set_combine(sets.Idle, sets.Holy_Water)
+                    else
+                        warn('sets.Idle not found!')
+                    end
+                else
+                    warn('sets.Holy_Water not found!')
+                end
+            else
+                if sets.Idle then
+                    built_set = sets.Idle
+                else
+                    warn('sets.Idle not found!')
+                end
+            end
+            -- Scholar
+        elseif spell.type == 'Scholar' then
+            if spell.name == "Accession" and not accession_predicted then
+                accession_predicted = true
+                debug("Accession detected while tracking. Accession_Predicted = True")
+            end
+            if sets.JA then
+                built_set = set_combine(built_set, sets.JA)
+                if sets.JA[spell.english] then
+                    built_set = set_combine(built_set, sets.JA[spell.english])
+                    info('[' .. spell.english .. '] Set')
+                else
+                    info('Using Default Scholar Set')
+                end
+            else
+                warn('sets.JA not found!')
+            end
+            -- Ward
+        elseif spell.type == 'Ward' then
+            if sets.JA then
+                built_set = set_combine(built_set, sets.JA)
+                if sets.JA[spell.english] then
+                    built_set = set_combine(built_set, sets.JA[spell.english])
+                    info('[' .. spell.english .. '] Set')
+                else
+                    info('Using Default Ward Set')
+                end
+            else
+                warn('sets.JA not found!')
+            end
+            -- Rune
+        elseif spell.type == 'Rune' then
+            if sets.JA then
+                built_set = set_combine(built_set, sets.JA)
+                if sets.JA[spell.english] then
+                    built_set = set_combine(built_set, sets.JA[spell.english])
+                    info('[' .. spell.english .. '] Set')
+                else
+                    info('Using Default Rune Set')
+                end
+            else
+                warn('sets.JA not found!')
+            end
+            -- Effusion
+        elseif spell.type == 'Effusion' then
+            if sets.JA then
+                built_set = set_combine(built_set, sets.JA)
+                if sets.JA[spell.english] then
+                    built_set = set_combine(built_set, sets.JA[spell.english])
+                    info('[' .. spell.english .. '] Set')
+                else
+                    info('Using Default Effusion Set')
+                end
+            else
+                warn('sets.JA not found!')
+            end
+            -- CorsairRoll
+        elseif spell.type == 'CorsairRoll' then
+            log('CorsairRoll')
+            if sets.PhantomRoll then
+                built_set = set_combine(built_set, sets.PhantomRoll)
+                if sets.PhantomRoll[spell.english] then
+                    built_set = set_combine(built_set, sets.PhantomRoll[spell.english])
+                    info('[' .. spell.english .. '] Set ')
+                else
+                    info('Roll not set')
+                end
+            else
+                warn('sets.PhantomRoll not found!')
+            end
+            -- CorsairShot
+        elseif spell.type == 'CorsairShot' then
+            if sets.QuickDraw then
+                built_set = set_combine(built_set, sets.QuickDraw)
+                if sets.QuickDraw[spell.english] then
+                    built_set = set_combine(built_set, sets.QuickDraw[spell.english])
+                    info('[' .. spell.english .. '] Set')
+                else
+                    info('Using Default Quick Draw Set')
+                end
+            else
+                warn('sets.QuickDraw not found!')
+            end
+            -- Waltz
+        elseif spell.type == 'Waltz' then
+            if sets.Waltz then
+                built_set = set_combine(built_set, sets.Waltz)
+                if sets.Waltz[spell.english] then
+                    built_set = set_combine(built_set, sets.Waltz[spell.english])
+                    info('[' .. spell.english .. '] Set')
+                else
+                    info('Using Default Waltz Set')
+                end
+            else
+                warn('sets.Waltz not found!')
+            end
+            --Check for ability casts that are tracked for spell-received gear swapping
+            --Notify eligible targets via IPC that a tracked spell is incoming
+
+            if state.SpellReceived.value ~= "OFF" then
+                local a_info = ability_info[spell.id]
+                if a_info and not outgoing_cast_active then
+                    local target_mob = get_mob_by_id(spell.target.id)
+                    if not player or not target_mob then return end
+
+                    local target_name = spell.target.name
+                    outgoing_cast_active = true
+                    debug(player.name .. ' is using tracked ability measured at precast: ' ..
+                        spell.name .. ' on ' .. target_name .. ' at ' .. get_time())
+
+                    --AoE Checks
+                    if a_info.aoe and is_target_in_party(target_name) then
+                        debug("AoE Ability Cast Detected.  Calculating targets.")
+                        local party = get_party()
+                        if party then
+                            local count = 0
+                            for k, v in pairs(NEARBY_MEMBERS_BUFFER) do NEARBY_MEMBERS_BUFFER[k] = nil end
+
+                            for slot, member in pairs(party) do
+                                if type(member) == 'table' and member.name then
+                                    local m_mob = get_mob_by_name(member.name)
+                                    if m_mob then
+                                        local dx, dy, dz = m_mob.x - target_mob.x, m_mob.y - target_mob.y,
+                                            m_mob.z - target_mob.z
+                                        if ((dx * dx) + (dy * dy) + (dz * dz)) <= 100 then
+                                            debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name)
+                                            count = count + 1
+                                            NEARBY_MEMBERS_BUFFER[count] = member.name
+                                        else
+                                            debug(member.name .. " is OUT of aoe range from " .. target_mob.name)
+                                        end
+                                    else
+                                        debug(member.name .. " data unavailable (Too far away).")
+                                    end
+                                end
+                            end
+                            if count > 0 then target_name = table.concat(NEARBY_MEMBERS_BUFFER, ",") end
+                        end
+                    end
+                    debug(string.format("IPC message sent: MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name,
+                        spell.id, get_time()))
+                    send_ipc(string.format("MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name, spell.id,
+                        get_time()))
+                end
+            end
+            -- Jig
+        elseif spell.type == 'Jig' then
+            if sets.Jig then
+                built_set = set_combine(built_set, sets.Jig)
+                if sets.Jig[spell.english] then
+                    built_set = set_combine(built_set, sets.Jig[spell.english])
+                    info('[' .. spell.english .. '] Set')
+                else
+                    info('Using Default Jig Set')
+                end
+            else
+                warn('sets.Jig not found!')
+            end
+            -- Samba
+        elseif spell.type == 'Samba' then
+            if sets.Samba then
+                built_set = set_combine(built_set, sets.Samba)
+                if sets.Samba[spell.english] then
+                    built_set = set_combine(built_set, sets.Samba[spell.english])
+                    info('[' .. spell.english .. '] Set')
+                else
+                    info('Using Default Samba Set')
+                end
+            else
+                warn('sets.Samba not found!')
+            end
+            -- Step
+        elseif spell.type == 'Step' then
+            if sets.Step then
+                built_set = set_combine(built_set, sets.Step)
+                if sets.Step[spell.english] then
+                    built_set = set_combine(built_set, sets.Step[spell.english])
+                    info('[' .. spell.english .. '] Set')
+                else
+                    info('Using Default Step Set')
+                end
+            else
+                warn('sets.Step not found!')
+            end
+            -- Flourishes
+        elseif spell.type == 'Flourish1' or spell.type == 'Flourish2' or spell.type == 'Flourish3' then
+            if sets.Flourish then
+                built_set = set_combine(built_set, sets.Flourish)
+                if sets.Flourish[spell.english] then
+                    built_set = set_combine(built_set, sets.Flourish[spell.english])
+                    info('[' .. spell.english .. '] Set')
+                else
+                    info('Using Default Flourish Set')
+                end
+            else
+                warn('sets.Flourish not found!')
+            end
+            -- Magic based actions
+        else
+            -- Precast
+            if sets.Precast then
+                built_set = set_combine(built_set, sets.Precast)
+                -- FastCast
+                if sets.Precast.FastCast then
+                    built_set = set_combine(built_set, sets.Precast.FastCast)
+                    -- Augment with Enhancing set
+                    if spell.skill == 'Enhancing Magic' then
+                        if sets.Precast.Enhancing then
+                            built_set = set_combine(built_set, sets.Precast.Enhancing)
+                        else
+                            warn('sets.Precast.Enhancing not found!')
+                        end
+                    end
+                    -- Specified Sets
+                    if sets.Precast[spell.english] then
+                        built_set = set_combine(built_set, sets.Precast[spell.english])
+                        -- Augment with Cure Casting set
+                    elseif spell.name:contains('Cure') or spell.name:contains('Cura') then
+                        if sets.Precast.Cure then
+                            built_set = set_combine(built_set, sets.Precast.Cure)
+                        else
+                            warn('sets.Precast.Cure not found!')
+                        end
+                        -- Augment with Healing Magic set
+                    elseif Healing_Magic:contains(spell.name) then
+                        if sets.Precast.Healing then
+                            built_set = set_combine(built_set, sets.Precast.Healing)
+                        else
+                            warn('sets.Precast.Healing not found!')
+                        end
+                        -- Ninjutsu
+                    elseif spell.type == 'Ninjutsu' and UtsusemiSpell:contains(spell.name) then
+                        do_Utsu_checks(spell)
+                        if sets.Precast.Utsusemi then
+                            built_set = set_combine(built_set, sets.Precast.Utsusemi)
+                        else
+                            warn('sets.Precast.Utsusemi not found!')
+                        end
+                        -- Blue Magic
+                    elseif spell.type == 'BlueMagic' then
+                        if sets.Precast.BlueMagic then
+                            built_set = set_combine(built_set, sets.Precast.BlueMagic)
+                        else
+                            warn('sets.Precast.BlueMagic not found!')
+                        end
+                        -- BardSong
+                    elseif spell.type == 'BardSong' then
+                        if buffactive['Nightingale'] then
+                            -- Default BRD song gear is in Midcast
+                            if sets.Midcast then
+                                built_set = set_combine(built_set, sets.Midcast)
+                            else
+                                warn('sets.Midcast not found!')
+                            end
+                            -- Song Count for Dummy Songs
+                            if SongCount:contains(spell.name) then
+                                if sets.Midcast.DummySongs then
+                                    built_set = set_combine(built_set, sets.Midcast.DummySongs)
+                                else
+                                    warn('sets.Midcast.DummySongs not found!')
+                                end
+                                built_set = set_combine(built_set, { range = Instrument.Count })
+                                -- Potency / Instruments
+                            else
+                                -- Defined Gear Set
+                                if sets.Midcast[spell.english] then
+                                    built_set = set_combine(built_set, sets.Midcast[spell.english])
+                                    -- Equip Harp
+                                elseif spell.name:contains('Horde') then
+                                    if sets.Midcast.Enfeebling then
+                                        built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                                    else
+                                        warn('sets.Midcast.Enfeebling not found!')
+                                    end
+                                    built_set = set_combine(built_set, { range = Instrument.AOE_Sleep })
+                                    -- Normal Enfeebles
+                                elseif Enfeebling_Song:contains(spell.english) then
+                                    if sets.Midcast.Enfeebling then
+                                        built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                                    else
+                                        warn('sets.Midcast.Enfeebling not found!')
+                                    end
+                                    built_set = set_combine(built_set, { range = Instrument.Potency })
+                                    -- Augment the buff songs
+                                else
+                                    built_set = set_combine(built_set, { range = Instrument.Potency })
+                                end
+                                -- Augment the specific Song if set
+                                built_set = set_combine(built_set, equip_song_gear(spell, built_set['range']))
+                            end
+                        else
+                            if sets.Precast.Songs then
+                                built_set = set_combine(built_set, sets.Precast.Songs)
+                            else
+                                warn('sets.Precast.Songs not found!')
+                            end
+                        end
+                    end
+                else
+                    warn('sets.Precast.FastCast not found!')
+                end
+            else
+                warn('sets.Precast not found!')
+            end
+            --Check for spell casts that are tracked for spell-received gear swapping
+            --Notify eligible targets via IPC that a tracked spell is incoming
+            local s_info = spell_info[spell.id]
+            if s_info and state.SpellReceived.value ~= "OFF" and not outgoing_cast_active then
+                local target_mob = get_mob_by_id(spell.target.id)
+                if not target_mob then return end
+
+                local target_name = spell.target.name
+                outgoing_cast_active = true
+
+                debug(player.name ..
+                    ' is using tracked spell measured at precast: ' ..
+                    spell.name .. ' on ' .. target_name .. ' at ' .. get_time())
+                local active_buffs = buffactive
+                local accession_active = active_buffs[366] or active_buffs['Accession']
+                local majesty_active = active_buffs[621] or active_buffs['Majesty']
+                local divine_veil_active = active_buffs[78] or active_buffs['Divine Seal']
+
+                --AoE Checks
+                local has_yagrush = (s_info.divine and get_slot_item_name(sets.Midcast["Cursna"], 'main') == "Yagrush")
+                if is_target_in_party(target_name) and (s_info.aoe or ((accession_predicted or accession_active) and s_info.accession) or (majesty_active and s_info.majesty) or (divine_veil_active and s_info.divine) or has_yagrush) then
+                    debug("AoE Spell Cast Detected. Calculating targets.")
+                    local party = get_party()
+                    if party then
+                        local count = 0
+                        for k in pairs(NEARBY_MEMBERS_BUFFER) do NEARBY_MEMBERS_BUFFER[k] = nil end
+
+                        for slot, member in pairs(party) do
+                            if type(member) == 'table' and member.name then
+                                local m_mob = get_mob_by_name(member.name)
+                                if m_mob then
+                                    local dx = m_mob.x - target_mob.x
+                                    local dy = m_mob.y - target_mob.y
+                                    local dz = m_mob.z - target_mob.z
+                                    if ((dx * dx) + (dy * dy) + (dz * dz)) <= 100 then
+                                        debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name)
+                                        count = count + 1
+                                        NEARBY_MEMBERS_BUFFER[count] = member.name
+                                    else
+                                        debug(member.name .. " is OUT of aoe range from " .. target_mob.name)
+                                    end
+                                else
+                                    debug(member.name .. " data unavailable (Too far away).")
+                                end
+                            end
+                        end
+
+                        if count > 0 then
+                            target_name = table.concat(NEARBY_MEMBERS_BUFFER, ",")
+                        end
+                    end
+                end
+                debug(string.format("IPC message sent: MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, player.name,
+                    target_name, spell.id, get_time()))
+                send_ipc(string.format("MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id, get_time()))
+            end
+        end
+
+        -- Weapon Checks for precast
+        -- If it set to unlocked it will not swap the weapons even if defined in the built_set job lua
+        if state.WeaponMode.value ~= "Unlocked" and spell.type ~= 'CorsairRoll' and spell.name ~= 'Double-Up' then
+            log('Update Weapons - Precast')
+            if state.WeaponMode.value == "Locked" then
+                built_set = set_combine(built_set,
+                    { main = player.equipment.main, sub = player.equipment.sub, range = player.equipment.range })
+            else
+                if sets.Weapons then
+                    if sets.Weapons[state.WeaponMode.value] then
+                        built_set = set_combine(built_set, sets.Weapons[state.WeaponMode.value])
+                        if not TwoHand and not DualWield then
+                            if sets.Weapons.Shield then
+                                built_set = set_combine(built_set, sets.Weapons.Shield)
+                            else
+                                warn('sets.Weapons.Shield not found!')
+                            end
+                        end
+                    else
+                        warn('sets.Weapons.' .. state.WeaponMode.value .. ' not found!')
+                    end
+                else
+                    warn('sets.Weapons not found!')
+                end
+            end
+        end
+
+        --Swap in bard song weapons no matter the mode
+        if spell.type == 'BardSong' then --and spell.target.type ~= 'MONSTER' then
+            if sets.Weapons then
+                if sets.Weapons.Songs then
+                    built_set = set_combine(built_set, sets.Weapons.Songs)
+                    if sets.Weapons.Songs.Midcast then
+                        if not DualWield and not TwoHand then
+                            if sets.Weapons.Shield then
+                                built_set = set_combine(built_set, sets.Weapons.Shield)
+                            else
+                                warn('sets.Weapons.Shield not found!')
+                            end
+                        end
+                        built_set = set_combine(built_set, sets.Weapons.Songs.Midcast)
+                    else
+                        warn('sets.Weapons.Songs.Midcast not found!')
+                    end
+                else
+                    warn('sets.Weapons.Songs not found!')
+                end
+            else
+                warn('sets.Weapons not found!')
+            end
+        end
+
+        --[[ If TH mode is on - check if new mob and then equip TH gear
+        if state.TreasureMode.value ~= 'None' and spell.target.type == 'MONSTER' and not th_info.tagged_mobs[spell.target.id] then
+            if sets.TreasureHunter then
+                built_set = set_combine(built_set, sets.TreasureHunter)
+                info('[' .. spell.english .. '] Set with Treasure Hunter')
+            else
+                warn('sets.TreasureHunter not found!')
+            end
+        end
+        --]]
+        -- Final built_set built to return.  This is not the final set as custom Job can Augment
+        return built_set
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called from the default GearSwap Function "midcast" to build an built_set
+    -------------------------------------------------------------------------------------------------------------------
+
+    function midcastequip(spell)
+        if spell.type == 'WeaponSkill' then
+            log('abort midcast')
+            return
+        end
+        if spell.type == 'JobAbility' then
+            log('abort midcast')
+            return
+        end
+        if spell.type == 'Item' then
+            log('abort midcast')
+            return
+        end
+        if spell.type == 'Scholar' then
+            log('abort midcast')
+            return
+        end
+        if spell.type == 'Ward' then
+            log('abort midcast')
+            return
+        end
+        if spell.type == 'Rune' then
+            log('abort midcast')
+            return
+        end
+        if spell.type == 'Effusion' then
+            log('abort midcast')
+            return
+        end
+        if spell.type == 'CorsairRoll' then
+            log('abort midcast')
+            return
+        end
+        if spell.type == 'CorsairShot' then
+            log('abort midcast')
+            return
+        end
+        if spell.type == 'Waltz' then
+            log('abort midcast')
+            return
+        end
+        if spell.type == 'Jig' then
+            log('abort midcast')
+            return
+        end
+        if spell.type == 'Samba' then
+            log('abort midcast')
+            return
+        end
+        if spell.type == 'Step' then
+            log('abort midcast')
+            return
+        end
+        if spell.type == 'Flourish1' or spell.type == 'Flourish2' or spell.type == 'Flourish3' then
+            log('abort midcast')
+            return
+        end
+        if pet.isvalid and pet_midaction() then return end
+
+        --Default gearset
+        local built_set = {}
+        -- Merge the Idle incase a midcast is not set
+        if sets.Idle then built_set = set_combine(built_set, sets.Idle) end
+        -- Merget the Midcast Set
+        if sets.Midcast then
+            built_set = set_combine(built_set, sets.Midcast)
+            -- Spell interruption Down for the rest of the actions
+            if sets.Midcast.SIRD and spell.action_type ~= 'Ranged Attack' then
+                built_set = set_combine(built_set,
+                    sets.Midcast.SIRD)
+            end
+
+            -- Ranged Attack
+            if spell.action_type == 'Ranged Attack' then
+                if sets.Midcast.RA then
+                    local message = ''
+                    built_set = set_combine(built_set, sets.Midcast.RA)
+
+                    -- Augment based off Mode
+                    if state.OffenseMode.value ~= 'TP' and sets.Midcast.RA[state.OffenseMode.value] then
+                        built_set = set_combine(built_set, sets.Midcast.RA[state.OffenseMode.value])
+                        if state.OffenseMode.value == 'ACC' then
+                            message = 'Ranged Attack with Accuracy'
+                        elseif state.OffenseMode.value == 'PDL' then
+                            message = 'Ranged Attack with Physical Damage Limit'
+                        elseif state.OffenseMode.value == 'SB' then
+                            message = 'Ranged Attack with Subtle Blow'
+                        elseif state.OffenseMode.value == 'MEVA' then
+                            message = 'Ranged Attack with Magic Evasion'
+                        elseif state.OffenseMode.value == 'DT' then
+                            message = 'Ranged Attack with Damage Taken'
+                        elseif state.OffenseMode.value == 'PDT' then
+                            message = 'Ranged Attack with Physical Damage Taken'
+                        elseif state.OffenseMode.value == 'CRIT' then
+                            message = 'Ranged Attack with Critical Hit'
+                        elseif state.OffenseMode.value == 'True Shot' then
+                            message = 'Ranged Attack with True Shot'
+                        end
+                    else
+                        message = 'Ranged Attack Set'
+                    end
+
+                    -- Check if Aftermath is active
+                    if buffactive['Aftermath: Lv.3'] and sets.Midcast.RA.AM3 and sets.Midcast.RA.AM3[state.WeaponMode.value] then
+                        built_set = set_combine(built_set, sets.Midcast.RA.AM3[state.WeaponMode.value])
+                        message = message .. ' and with Aftermath 3 [' .. state.WeaponMode.value .. ']'
+                    elseif buffactive['Aftermath: Lv.2'] and sets.Midcast.RA.AM2 and sets.Midcast.RA.AM2[state.WeaponMode.value] then
+                        built_set = set_combine(built_set, sets.Midcast.RA.AM2[state.WeaponMode.value])
+                        message = message .. ' and with Aftermath 2 [' .. state.WeaponMode.value .. ']'
+                    elseif buffactive['Aftermath: Lv.1'] and sets.Midcast.RA.AM1 and sets.Midcast.RA.AM1[state.WeaponMode.value] then
+                        built_set = set_combine(built_set, sets.Midcast.RA.AM1[state.WeaponMode.value])
+                        message = message .. ' and with Aftermath 1 [' .. state.WeaponMode.value .. ']'
+                    elseif buffactive['Aftermath'] and sets.Midcast.RA.AM and sets.Midcast.RA.AM[state.WeaponMode.value] then
+                        built_set = set_combine(built_set, sets.Midcast.RA.AM[state.WeaponMode.value])
+                        message = message .. ' and with Aftermath [' .. state.WeaponMode.value .. ']'
+                    end
+
+                    -- Buffs
+                    if buffactive['Triple Shot'] and sets.Midcast.RA.TripleShot then
+                        built_set = set_combine(built_set, sets.Midcast.RA.TripleShot)
+                        message = 'Using Triple Shot Set'
+                    elseif buffactive['Double Shot'] and sets.Midcast.RA.DoubleShot then
+                        built_set = set_combine(built_set, sets.Midcast.RA.DoubleShot)
+                        message = 'Using Double Shot Set'
+                    elseif buffactive['Barrage'] and sets.Midcast.RA.Barrage then
+                        built_set = set_combine(built_set, sets.Midcast.RA.Barrage)
+                        message = 'Using Barrage Set'
+                    end
+
+                    -- Variable Ammo
+                    if Ammo[state.OffenseMode.value] then
+                        built_set = set_combine(built_set,
+                            { ammo = Ammo[state.OffenseMode.value] })
+                    end
+
+                    message = message .. ' [' .. available_bullets .. 'x]'
+                    info(message)
+                else
+                    warn('sets.Midcast.RA not found!')
+                end
+                -- Ninjutsu
+            elseif spell.type == 'Ninjutsu' then
+                -- Defined Gear Set
+                if sets.Midcast[spell.english] then
+                    built_set = set_combine(built_set, sets.Midcast[spell.english])
+                    info('[' .. spell.english .. '] Set')
+                    -- Utsusemi Spells
+                elseif UtsusemiSpell:contains(spell.name) then
+                    if sets.Midcast.Utsusemi then
+                        built_set = set_combine(built_set, sets.Midcast.Utsusemi)
+                        info('[' .. spell.english .. '] Utsusemi Set')
+                    else
+                        warn('sets.Midcast.Utsusemi not found!')
+                    end
+                    -- Enhancing Magic
+                elseif spell.target.type == 'SELF' then
+                    if sets.Midcast.Enhancing then
+                        built_set = set_combine(built_set, sets.Midcast.Enhancing)
+                        info('Enhancing set')
+                    else
+                        warn('sets.Midcast.Enhancing not found!')
+                    end
+                    -- Enfeebling
+                elseif Enfeebling_Ninjitsu:contains(spell.english) then
+                    if sets.Midcast.Enfeebling then
+                        built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                        info('Enfeebling set')
+                    else
+                        warn('sets.Midcast.Enfeebling not found!')
+                    end
+                    -- Defaults to Nukes if not the above
+                else
+                    if sets.Midcast.Nuke then
+                        built_set = set_combine(built_set, sets.Midcast.Nuke)
+                        info('Nuke set')
+                    else
+                        warn('sets.Midcast.Nuke not found!')
+                    end
+                    -- Check for an elemental set
+                    built_set = elemental_check(spell, built_set)
+                end
+                -- WhiteMagic
+            elseif spell.type == 'WhiteMagic' then
+                -- Cure
+                if spell.name:contains('Cure') then
+                    if sets.Midcast.Cure then
+                        built_set = set_combine(built_set, sets.Midcast.Cure)
+                        info('Cure Set')
+                    else
+                        warn('sets.Midcast.Cure not found!')
+                    end
+                    -- Check if an Obi or Orpheus is to be Equiped
+                    built_set = elemental_check(spell, built_set)
+                    -- Curaga
+                elseif spell.name:contains('Curaga') then
+                    if sets.Midcast.Curaga then
+                        built_set = set_combine(built_set, sets.Midcast.Curaga)
+                        info('Curaga Set')
+                    else
+                        warn('sets.Midcast.Curaga not found!')
+                    end
+                    -- Check if an Obi or Orpheus is to be Equiped
+                    built_set = elemental_check(spell, built_set)
+                    -- Cura
+                elseif spell.name:contains('Cura') then
+                    if sets.Midcast.Cura then
+                        built_set = set_combine(built_set, sets.Midcast.Cura)
+                        info('Cura Set')
+                    else
+                        warn('sets.Midcast.Cura not found!')
+                    end
+                    -- Check if an Obi or Orpheus is to be Equiped
+                    built_set = elemental_check(spell, built_set)
+                    -- Defined Gear Set
+                elseif sets.Midcast[spell.english] then
+                    built_set = set_combine(built_set, sets.Midcast[spell.english])
+                    info('[' .. spell.english .. '] Set')
+                    -- Healing Magic
+                elseif spell.name:contains('Raise') or spell.name == "Arise" or spell.name:contains('Reraise') then
+                    log('No Swap Defined (Raise)')
+                    -- Enhancing
+                elseif spell.skill == 'Enhancing Magic' then
+                    if sets.Midcast.Enhancing then
+                        built_set = set_combine(built_set, sets.Midcast.Enhancing)
+                        -- Augment the set for Others if defined
+                        if spell.target.type ~= 'SELF' or (spell.target.type == 'SELF' and buffactive['Accession']) then
+                            if sets.Midcast.Enhancing.Others then
+                                built_set = set_combine(built_set, sets.Midcast.Enhancing.Others)
+                            else
+                                warn('sets.Midcast.Enhancing.Others not found!')
+                            end
+                        end
+                        -- Refresh
+                        if spell.name:contains('Refresh') then
+                            if sets.Midcast.Refresh then
+                                built_set = set_combine(built_set, sets.Midcast.Refresh)
+                                info('Refresh Set')
+                            else
+                                warn('sets.Midcast.Refresh not found!')
+                            end
+                            -- Regen
+                        elseif spell.name:contains('Regen') then
+                            if sets.Midcast.Regen then
+                                built_set = set_combine(built_set, sets.Midcast.Regen)
+                                info('Regen Set')
+                            else
+                                warn('sets.Midcast.Regen not found!')
+                            end
+                        elseif Storms:contains(spell.name) then
+                            if sets.Storms then
+                                built_set = set_combine(built_set, sets.Storms)
+                                info('Storms Set')
+                            else
+                                warn('sets.Storms not found!')
+                            end
+                            -- Gain Spells
+                        elseif spell.name:contains('Gain') then
+                            if sets.Midcast.Enhancing.Gain then
+                                built_set = set_combine(built_set, sets.Midcast.Enhancing.Gain)
+                                info('Gain Set')
+                            else
+                                warn('sets.Midcast.Enhancing.Gain not found!')
+                            end
+                            -- Phalanx
+                        elseif spell.name:contains('Phalanx') then
+                            if sets.Midcast.Phalanx then
+                                built_set = set_combine(built_set, sets.Midcast.Phalanx)
+                                info('Phalanx Set')
+                            else
+                                warn('sets.Midcast.Phalanx not found!')
+                            end
+                            -- Bar Spells
+                        elseif Elemental_Bar:contains(spell.name) then
+                            if sets.Midcast.Enhancing.Elemental then
+                                built_set = set_combine(built_set, sets.Midcast.Enhancing.Elemental)
+                                info('Elemental Bar Element Set')
+                            else
+                                warn('sets.Midcast.Enhancing.Elemental not found!')
+                            end
+                            -- Bar Status
+                        elseif Status_Bar:contains(spell.name) then
+                            if sets.Midcast.Enhancing.Status then
+                                built_set = set_combine(built_set, sets.Midcast.Enhancing.Status)
+                                info('Status Bar Status Set')
+                            else
+                                warn('sets.Midcast.Enhancing.Status not found!')
+                            end
+                            -- Enhancing SKill
+                        elseif Enhancing_Skill:contains(spell.name) then
+                            if sets.Midcast.Enhancing.Skill then
+                                built_set = set_combine(built_set, sets.Midcast.Enhancing.Skill)
+                                info('Enhancing Skill Set')
+                            else
+                                warn('sets.Midcast.Enhancing.Skill not found!')
+                            end
+                            -- Enhancing
+                        else
+                            info('Enhancing Magic Set')
+                        end
+                    else
+                        warn('sets.Midcast.Enhancing not found!')
+                    end
+                    -- Divine Spells
+                elseif Divine_Skill:contains(spell.name) then
+                    if sets.Midcast.Divine then
+                        built_set = set_combine(built_set, sets.Midcast.Divine)
+                        info('Divine Skill Set')
+                    else
+                        warn('sets.Midcast.Divine not found!')
+                    end
+                    -- Enfeebling Magic
+                elseif spell.skill == 'Enfeebling Magic' then
+                    if sets.Midcast.Enfeebling then
+                        built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                        -- Accuracy
+                        if Enfeeble_Acc:contains(spell.name) then
+                            if sets.Midcast.Enfeebling.MACC then
+                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.MACC)
+                                info('Enfeebling Magic Set - Magic Accuracy')
+                            else
+                                warn('sets.Midcast.Enfeebling.MACC not found!')
+                            end
+                            -- Potency
+                        elseif Enfeeble_Potency:contains(spell.name) then
+                            if sets.Midcast.Enfeebling.Potency then
+                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.Potency)
+                                info('Enfeebling Magic Set - Potency')
+                            else
+                                warn('sets.Midcast.Enfeebling.Potency not found!')
+                            end
+                            -- Duration
+                        elseif Enfeeble_Duration:contains(spell.name) then
+                            if sets.Midcast.Enfeebling.Duration then
+                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.Duration)
+                                info('Enfeebling Magic Set - Duration')
+                            else
+                                warn('sets.Midcast.Enfeebling.Duration not found!')
+                            end
+                            -- Default
+                        else
+                            info('Enfeebling Magic Set')
+                        end
+                    else
+                        info('No sets.Midcast.Enfeebling defined!')
+                    end
+                end
+                -- Black Magic
+            elseif spell.type == 'BlackMagic' then
+                -- Defined Gear Set
+                if sets.Midcast[spell.english] then
+                    built_set = set_combine(built_set, sets.Midcast[spell.english])
+                    -- Check for an elemental set
+                    if spell.skill == 'Elemental Magic' and not spell.name:contains('helix') then
+                        built_set =
+                            elemental_check(spell, built_set)
+                    end
+                    info('[' .. spell.english .. '] Set')
+                    -- Aspir Gear
+                elseif spell.name:contains('Aspir') then
+                    if sets.Midcast.Aspir then
+                        built_set = set_combine(built_set, sets.Midcast.Aspir)
+                        info('Aspir Set')
+                    else
+                        warn('sets.Midcast.Aspir not found!')
+                    end
+                    -- Drain Gear
+                elseif spell.name:contains('Drain') then
+                    if sets.Midcast.Drain then
+                        built_set = set_combine(built_set, sets.Midcast.Drain)
+                        info('Drain Set')
+                    else
+                        warn('sets.Midcast.Drain not found!')
+                    end
+                    -- Enfeebling Magic
+                elseif spell.skill == 'Enfeebling Magic' then
+                    if sets.Midcast.Enfeebling then
+                        built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                        -- Accuracy
+                        if Enfeeble_Acc:contains(spell.name) then
+                            if sets.Midcast.Enfeebling.MACC then
+                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.MACC)
+                                info('Enfeebling Magic Set - Magic Accuracy')
+                            else
+                                warn('sets.Midcast.Enfeebling.MACC not found!')
+                            end
+                            -- Potency
+                        elseif Enfeeble_Potency:contains(spell.name) then
+                            if sets.Midcast.Enfeebling.Potency then
+                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.Potency)
+                                info('Enfeebling Magic Set - Potency')
+                            else
+                                warn('sets.Midcast.Enfeebling.Potency not found!')
+                            end
+                            -- Duration
+                        elseif Enfeeble_Duration:contains(spell.name) then
+                            if sets.Midcast.Enfeebling.Duration then
+                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.Duration)
+                                info('Enfeebling Magic Set - Duration')
+                            else
+                                warn('sets.Midcast.Enfeebling.Duration not found!')
+                            end
+                            -- Default
+                        else
+                            info('Enfeebling Magic Set')
+                        end
+                    else
+                        info('No sets.Midcast.Enfeebling not found!')
+                    end
+                    -- Dark Magic
+                elseif spell.skill == 'Dark Magic' then
+                    if sets.Midcast.Dark then
+                        built_set = set_combine(built_set, sets.Midcast.Dark)
+                        -- Accuracy
+                        if Dark_Acc:contains(spell.name) then
+                            if sets.Midcast.Dark.MACC then
+                                built_set = set_combine(built_set, sets.Midcast.Dark.MACC)
+                                info('Dark Magic Set - Magic Accuracy')
+                            else
+                                warn('sets.Midcast.Dark.MACC not found!')
+                            end
+                            -- Absorb
+                        elseif Dark_Absorb:contains(spell.name) then
+                            if sets.Midcast.Dark.Absorb then
+                                built_set = set_combine(built_set, sets.Midcast.Dark.Absorb)
+                                info('Absorb Magic Set - Potency')
+                            else
+                                warn('sets.Midcast.Dark.Absorb not found!')
+                            end
+                            -- Enhancing
+                        elseif Dark_Enhancing:contains(spell.name) then
+                            if sets.Midcast.Dark.Enhancing then
+                                built_set = set_combine(built_set, sets.Midcast.Dark.Enhancing)
+                                info('Dark Enhancing Magic Set - Duration')
+                            else
+                                warn('sets.Midcast.Dark.Enhancing not found!')
+                            end
+                            -- Potency
+                        elseif Enfeeble_Potency:contains(spell.name) then
+                            if sets.Midcast.Enfeebling.Potency then
+                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.Potency)
+                                info('Enfeebling Magic Set - Potency')
+                            else
+                                warn('sets.Midcast.Enfeebling.Potency not found!')
+                            end
+                            -- Duration
+                        elseif Enfeeble_Duration:contains(spell.name) then
+                            if sets.Midcast.Enfeebling.Duration then
+                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.Duration)
+                                info('Enfeebling Magic Set - Duration')
+                            else
+                                warn('sets.Midcast.Enfeebling.Duration not found!')
+                            end
+                            -- Default
+                        else
+                            info('Dark Magic Set')
+                        end
+                    else
+                        info('No sets.Midcast.Dark not found!')
+                    end
+                    -- Enhancing Magic
+                elseif spell.skill == 'Enhancing Magic' then
+                    if sets.Midcast.Enhancing then
+                        built_set = set_combine(built_set, sets.Midcast.Enhancing)
+                        info('Enhancing Magic Set')
+                    else
+                        warn('sets.Midcast.Enhancing not found!')
+                    end
+                    -- Enfeebling Elemental Magic
+                elseif Elemental_Enfeeble:contains(spell.name) then
+                    if sets.Midcast.Enfeebling then
+                        built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                        if sets.Midcast.Enfeebling.MACC then
+                            built_set = set_combine(built_set, sets.Midcast.Enfeebling.MACC)
+                            info('Enfeebling Magic Set - Magic Accuracy')
+                        else
+                            warn('sets.Midcast.Enfeebling.MACC not found!')
+                        end
+                    else
+                        warn('sets.Midcast.Enfeebling not found!')
+                    end
+                    -- Standard Offensive Spells
+                elseif spell.skill == 'Elemental Magic' then
+                    local element = res.spells[spell.id].element
+                    local element_name = res.elements[element].en
+                    if spell.target.id == last_skillchain_id and os.clock() - last_skillchain_time < 8 and last_skillchain_elements[element_name] then
+                        info("Burst Detected!")
+                        if sets.Midcast.Burst then
+                            built_set = set_combine(built_set, sets.Midcast.Burst)
+                        else
+                            warn('sets.Midcast.Burst not found!')
+                        end
+                    else
+                        if sets.Midcast.Nuke then
+                            built_set = set_combine(built_set, sets.Midcast.Nuke)
+                            info('Nuke Set')
+                        else
+                            warnd('sets.Midcast.Nuke not found!')
+                        end
+                    end
+                    -- Check for Helix
+                    if spell.name:contains('helix') then
+                        if sets.Helix then
+                            built_set = set_combine(built_set, sets.Helix)
+                            if spell.element == 'Dark' then
+                                if sets.Helix.Dark then
+                                    built_set = set_combine(built_set, sets.Helix.Dark)
+                                else
+                                    warn('sets.Helix.Dark not found!')
+                                end
+                            elseif spell.element == 'Light' then
+                                if sets.Helix.Light then
+                                    built_set = set_combine(built_set, sets.Helix.Light)
+                                else
+                                    warn('sets.Helix.Light not found!')
+                                end
+                            end
+                        else
+                            warn('sets.Helix not found!')
+                        end
+                    else
+                        if spell.element == "Earth" and sets.Midcast.Nuke.Earth then
+                            built_set = set_combine(built_set, sets.Midcast.Nuke.Earth)
+                            windower.add_to_chat(8, 'Earth Element Detected!')
+                        end
+                        -- Check for an elemental set
+                        built_set = elemental_check(spell, built_set)
+                    end
+                end
+                -- Bard Song
+            elseif spell.type == 'BardSong' then
+                -- Song Count for Dummy Songs
+                if SongCount:contains(spell.name) then
+                    if sets.Midcast.DummySongs then
+                        built_set = set_combine(built_set, sets.Midcast.DummySongs)
+                        info('[' .. spell.english .. '] Set (Song Count)')
+                    else
+                        warn('sets.Midcast.DummySongs not found!')
+                    end
+                    built_set = set_combine(built_set, { range = Instrument.Count })
+                    -- Potency / Instruments
+                else
+                    -- Defined Gear Set
+                    if sets.Midcast[spell.english] then
+                        built_set = set_combine(built_set, sets.Midcast[spell.english])
+                        info('[' .. spell.english .. '] Set')
+                        -- Equip Harp
+                    elseif spell.name:contains('Horde') then
+                        if sets.Midcast.Enfeebling then
+                            built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                        else
+                            warn('sets.Midcast.Enfeebling not found!')
+                        end
+                        built_set = set_combine(built_set, { range = Instrument.AOE_Sleep })
+                        info('[' .. spell.english .. '] Set (AOE Sleep)')
+                        -- Normal Enfeebles
+                    elseif Enfeebling_Song:contains(spell.english) then
+                        if sets.Midcast.Enfeebling then
+                            built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                        else
+                            warn('sets.Midcast.Enfeebling not found!')
+                        end
+                        built_set = set_combine(built_set, { range = Instrument.Enfeebling })
+                        info('[' .. spell.english .. '] Set (Enfeebling)')
+                        -- Augment the buff songs
+                    else
+                        info('[' .. spell.english .. '] Set (Potency)')
+                        built_set = set_combine(built_set, { range = Instrument.Potency })
+                    end
+                    -- Augment the specific Song if set
+                    built_set = set_combine(built_set, equip_song_gear(spell, built_set['range']))
+                end
+                -- BlueMagic
+            elseif spell.type == 'BlueMagic' then
+                -- Defined Set
+                if sets.Midcast[spell.english] then
+                    built_set = set_combine(built_set, sets.Midcast[spell.english])
+                    -- Check for an elemental set
+                    if BlueNuke:contains(spell.english) then built_set = elemental_check(spell, built_set) end
+                    info('[' .. spell.english .. '] Set')
+                else
+                    if sets.Midcast.BlueMagic then
+                        -- Defined Blue Nukes
+                        if BlueNuke:contains(spell.english) then
+                            if sets.Midcast.BlueMagic.Nuke then
+                                built_set = set_combine(built_set, sets.Midcast.BlueMagic.Nuke)
+                                info('Blue Nuke set')
+                            else
+                                warn('sets.Midcast.BlueMagic.Nuke not found!')
+                            end
+                            built_set = elemental_check(spell, built_set)
+                            -- Spells that benifit from Blue Magic Skill
+                        elseif BlueSkill:contains(spell.english) then
+                            if sets.Midcast.BlueMagic.Skill then
+                                built_set = set_combine(built_set, sets.Midcast.BlueMagic.Skill)
+                                info('Blue Skill set')
+                            else
+                                warn('sets.Midcast.BlueMagic.Skill not found!')
+                            end
+                        elseif BlueTank:contains(spell.english) then
+                            if sets.Midcast.BlueMagic.Enmity then
+                                built_set = set_combine(built_set, sets.Midcast.BlueMagic.Enmity)
+                                info('Blue Enmity set')
+                            else
+                                warn('sets.Midcast.BlueMagic.Enmity not found!')
+                            end
+                        elseif BlueHealing:contains(spell.english) then
+                            if sets.Midcast.BlueMagic.Healing then
+                                built_set = set_combine(built_set, sets.Midcast.BlueMagic.Healing)
+                                info('Blue Cure set')
+                            else
+                                warn('sets.Midcast.BlueMagic.Healing not found!')
+                            end
+                        elseif BlueACC:contains(spell.english) then
+                            if sets.Midcast.BlueMagic.ACC then
+                                built_set = set_combine(built_set, sets.Midcast.BlueMagic.ACC)
+                                info('Blue Magic Accuracy set')
+                            else
+                                warn('sets.Midcast.BlueMagic.ACC not found!')
+                            end
+                            -- Default Spell set
+                        else
+                            info('Midcast not set')
+                        end
+                        if buffactive["Diffusion"] then
+                            if sets.Diffusion then
+                                built_set = set_combine(built_set, sets.Diffusion)
+                                info('Diffusion Augment')
+                            else
+                                warn('sets.Diffusion not found!')
+                            end
+                        end
+                    else
+                        warn('sets.Midcast.BlueMagic not found!')
+                    end
+                end
+                -- Geomancy
+            elseif spell.type == 'Geomancy' then
+                if sets.Geomancy then
+                    -- Defined Set
+                    if sets.Geomancy[spell.english] then
+                        built_set = set_combine(built_set, sets.Geomancy[spell.english])
+                        info('[' .. spell.english .. '] Set')
+                        -- Indi Equipment
+                    elseif Indicolure_List:contains(spell.english) then
+                        if sets.Geomancy.Indi then
+                            built_set = set_combine(built_set, sets.Geomancy.Indi)
+                            if spell.target.type ~= "SELF" then
+                                if sets.Geomancy.Indi.Entrust then
+                                    built_set = set_combine(built_set, sets.Geomancy.Indi.Entrust)
+                                    info('Indicolure set - Entrust')
+                                else
+                                    warn('sets.Geomancy.Indi.Entrust not found!')
+                                end
+                            else
+                                info('Indicolure set')
+                            end
+                        else
+                            warn('sets.Geomancy.Indi not found!')
+                        end
+                        -- Bubble Equipment
+                    elseif Geomancy_List:contains(spell.english) then
+                        if sets.Geomancy.Geo then
+                            built_set = set_combine(built_set, sets.Geomancy.Geo)
+                            info('Geomancy set')
+                        else
+                            warn('sets.Geomancy.Geo not found!')
+                        end
+                        -- Default set
+                    else
+                        info('Midcast not set')
+                    end
+                else
+                    warn('sets.Geomancy not found!')
+                end
+                -- Trust
+            elseif spell.type == 'Trust' then
+                log('Nothing Defined')
+                -- BloodPactRage and BloodPactWard
+            elseif spell.type == "BloodPactWard" or spell.type == "BloodPactRage" then
+                -- BP Timer gear needs to swap here if not under Astral Conduit
+                if not buffactive["Astral Conduit"] then
+                    if sets.Midcast[spell.english] then
+                        built_set = set_combine(built_set, sets.Midcast[spell.english])
+                        info('[' .. spell.english .. '] Set')
+                    elseif sets.Midcast.BP then
+                        built_set = set_combine(built_set, sets.Midcast.BP)
+                        info('Blood Pact Set')
+                    else
+                        warn('sets.Midcast.BP not found!')
+                    end
+                else
+                    -- Astral Conduit active so don't swap gear
+                    built_set = {}
+                end
+                -- Monster
+            elseif spell.type == 'Monster' then
+                if sets.Ready then
+                    built_set = set_combine(built_set, sets.Ready)
+                    info('[Ready] Set')
+                else
+                    warn('sets.Ready not found!')
+                end
+                -- Elemental Siphon
+            elseif spell.name == "Elemental Siphon" then
+                if sets.Midcast[spell.english] then
+                    built_set = set_combine(built_set, sets.Midcast[spell.english])
+                    info('[' .. spell.english .. '] Set')
+                else
+                    if sets.Midcast.SummoningMagic then
+                        built_set = set_combine(built_set, sets.Midcast.SummoningMagic)
+                        info('Summoning Magic Set')
+                    else
+                        warn('sets.Midcast.SummoningMagic not found!')
+                    end
+                end
+                -- Summon Avatar
+            elseif spell.type == "SummonerPact" then
+                if sets.Midcast[spell.english] then
+                    built_set = set_combine(built_set, sets.Midcast[spell.english])
+                    info('[' .. spell.english .. '] Set')
+                else
+                    if sets.Midcast.Summon then
+                        built_set = set_combine(built_set, sets.Midcast.Summon)
+                        info('Summon Magic Set')
+                    else
+                        warn('sets.Midcast.Summon not found!')
+                    end
+                end
+            end
+        else
+            warn('sets.Midcast not found!')
+        end
+        -- Auto-cancel existing buffs
+        if spell.name == "Stoneskin" and buffactive["Stoneskin"] then
+            send_command('cancel 37;')
+        elseif spell.name == "Sneak" and buffactive["Sneak"] and spell.target.type == "SELF" then
+            send_command('cancel 71;')
+        elseif spell.name == "Spectral Jig" and buffactive["Sneak"] then
+            send_command('cancel 71;')
+        elseif spell.name == "Utsusemi: Ichi" and buffactive["Copy Image"] then
+            send_command('wait .5;cancel 66;')
+        end
+        -- Weapon Checks for midcast
+        -- If it set to unlocked it will not swap the weapons even if defined in the built_set job lua
+        if state.WeaponMode.value ~= "Unlocked" then
+            if spell.type == 'Geomancy' then
+                log('Swap Weapon due to Geomancy')
+            elseif state.WeaponMode.value == "Locked" then
+                built_set = set_combine(built_set,
+                    { main = player.equipment.main, sub = player.equipment.sub, range = player.equipment.range })
+                log(built_set)
+            else
+                if sets.Weapons then
+                    if sets.Weapons[state.WeaponMode.value] then
+                        built_set = set_combine(built_set, sets.Weapons[state.WeaponMode.value])
+                    else
+                        warn('sets.Weapons.' .. state.WeaponMode.value .. ' not found!')
+                    end
+                    if not TwoHand and not DualWield then
+                        if sets.Weapons.Shield then
+                            built_set = set_combine(built_set, sets.Weapons.Shield)
+                        else
+                            warn('sets.Weapons.Shield not found!')
+                        end
+                    end
+                else
+                    warn('sets.Weapons not found!')
+                end
+            end
+        end
+
+        --Swap in bard song weapons no matter the mode
+        if spell.type == 'BardSong' then --and spell.target.type ~= 'MONSTER' then
+            -- Weapons
+            if sets.Weapons.Songs then
+                built_set = set_combine(built_set, sets.Weapons.Songs)
+                if sets.Weapons.Songs.Midcast then
+                    built_set = set_combine(built_set, sets.Weapons.Songs.Midcast)
+                    if not DualWield and not TwoHand then
+                        if sets.Weapons.Shield then
+                            built_set = set_combine(built_set, sets.Weapons.Shield)
+                        else
+                            warn('sets.Weapons.Shield not found!')
+                        end
+                    end
+                else
+                    warn('sets.Weapons.Songs.Midcast not found!')
+                end
+            else
+                warn('sets.Weapons.Songs not found!')
+            end
+
+            -- Instruments for pianissimo buffs
+            if spell.target.id ~= player.id and not SongCount:contains(spell.name) and (spell.target.type == 'PLAYER' or spell.target.type == 'NPC') then
+                log('Pianissimo Check')
+                if Instrument then
+                    --Check for pianissimo Weapons
+                    if Instrument.Pianissimo then
+                        built_set = set_combine(built_set, { range = equip_pianissimo_gear(spell) })
+                    else
+                        warn('Instrument.Pianissimo not found!')
+                    end
+                else
+                    warn('Instrument not found!')
+                end
+            end
+        end
+        -- If TH mode is on - check if new mob and then equip TH gear
+        if state.TreasureMode.value ~= 'None' and spell.target.type == 'MONSTER' and not th_info.tagged_mobs[spell.target.id] and sets.TreasureHunter then
+            built_set = set_combine(built_set, sets.TreasureHunter)
+            info('[' .. spell.english .. '] Set with Treasure Hunter')
+        end
+        -- Built built_set to return
+        return built_set
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called from the default GearSwap Function "aftercast" to build an built_set
+    -------------------------------------------------------------------------------------------------------------------
+
+    function aftercastequip(spell)
+        -- Dont change gear as the pet is still performing an action
+        if pet_midaction() then
+            return
+        else
+            local built_set = choose_set()
+            if choose_set_custom then
+                built_set = set_combine(built_set, choose_set_custom())
+            else
+                info('choose_set_custom() not found!')
+            end
+            return built_set
+        end
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called by gearswap for pretarget checks
+    -------------------------------------------------------------------------------------------------------------------
+
+    function pretarget(spell, action)
+        --Calls the function in the include file for basic checks
+        pretargetcheck(spell, action)
+        --Calls the job specific function
+        if pretarget_custom(spell, action) then
+            pretarget_custom(spell, action)
+        end
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called by gearswap for precast checks
+    -------------------------------------------------------------------------------------------------------------------
+
+    function precast(spell)
+        -- Spell timed out
+        if is_Busy and os.clock() - Spellstart > SpellCastTime then
+            is_Busy = false
+            SpellCastTime = 0
+        end
+        if not is_Busy then
+            if RecastTimers[spell.type] then
+                local cast_spell = res.spells[spell.id]
+                -- assume 80% FC
+                SpellCastTime = cast_spell.cast_time * .2 + 2.5
+                -- Spell not delay set to default 2 sec
+                if buffactive["Chainspell"] or buffactive["Nightingale"] then
+                    SpellCastTime = 1
+                end
+            elseif spell.action_type == 'Ranged Attack' then
+                SpellCastTime = 1.1
+            else
+                -- Set duration of JA/WS
+                SpellCastTime = 1
+            end
+            -- Spell timer counter
+            Spellstart = os.clock()
+            is_Busy = true
+        else
+            log('Player is Busy [' .. spell.english .. ']')
+            cancel_spell()
+            return
+        end
+        --Generate the correct set from the include file and custom function
+        local built_set = precastequip(spell)
+        -- Process a custom set if enabled
+        if precast_custom then
+            built_set = set_combine(built_set, precast_custom(spell))
+        else
+            warn('precast_custom() not found!')
+        end
+        -- Check the gear
+        built_set = set_combine(built_set, check_equipment_spells(spell))
+        -- Here is where gear is actually equipped
+        equip(built_set)
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called by gearswap for midcast checks
+    -------------------------------------------------------------------------------------------------------------------
+
+    function midcast(spell)
+        --Generate the correct set from the include file and custom function
+        local built_set = midcastequip(spell)
+        -- Process a custom set if enabled
+        if midcast_custom then
+            built_set = set_combine(built_set, midcast_custom(spell))
+        else
+            warn('midcast_custom() not found!')
+        end
+        -- Check the gear
+        built_set = set_combine(built_set, check_equipment_spells(spell))
+        -- Here is where gear is actually equipped
+        equip(built_set)
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called by gearswap for aftercast checks
+    -------------------------------------------------------------------------------------------------------------------
+
+    function aftercast(spell)
+        --Reset state for spell-received gear tracking
+        if state.SpellReceived.value ~= 'OFF' and outgoing_cast_active then
+            outgoing_cast_active = false
+            debug(string.format("IPC message sent: MIRDAIN|COMPLETE|%s|%.0f", player.name, get_time()))
+            send_ipc(string.format("MIRDAIN|COMPLETE|%s|%.0f", player.name, get_time()))
+            if accession_predicted and not spell.interrupted and spell.type == "WhiteMagic" then
+                accession_predicted = false
+                debug("Accessioned spell probably used while tracking. Accession_Predicted = False")
+            end
+            if divine_seal_predicted and not spell.interrupted and spell.type == "WhiteMagic" and spell.skill == "Healing Magic" then
+                divine_seal_predicted = false
+                debug("Divine Sealed spell probably used while tracking. Divine_Seal_Predicted = False")
+            end
+        end
+        --Generate the correct set from the include file and custom function
+        local built_set = aftercastequip(spell)
+        if aftercast_custom then
+            built_set = set_combine(built_set, aftercast_custom(spell))
+        else
+            warn('aftercast_custom() not found!')
+        end
+        -- here is where gear is actually equipped
+        equip(built_set)
+        -- Begin Reset Process - Spells have a hard delay where the JA's have a small delay
+        if RecastTimers[spell.type] then
+            SpellCastTime = 2.5
+        elseif spell.action_type == 'Ranged Attack' then
+            SpellCastTime = 1.1
+        else
+            SpellCastTime = 0
+        end
+        Spellstart = os.clock()
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called by gearswap for any buff changes
+    -------------------------------------------------------------------------------------------------------------------
+
+    function buff_change(name, gain)
+        if not is_Busy then
+            --calls the include file and custom on a buff change
+            local built_set = choose_set()
+            if choose_set_custom then
+                built_set = set_combine(built_set, choose_set_custom())
+            else
+                warn('choose_set_custom() not found!')
+            end
+            if buff_change_custom then
+                built_set = set_combine(built_set, buff_change_custom(name, gain))
+            else
+                warn('buff_change_custom(name,gain) not found!')
+            end
+            -- Here is where gear is actually equipped
+            equip(built_set)
+        end
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called by gearswap for any player status changes
+    -------------------------------------------------------------------------------------------------------------------
+
+    function status_change(new, old)
+        --calls the include file and custom on a state change
+        local built_set = choose_set()
+        if choose_set_custom then
+            built_set = set_combine(built_set, choose_set_custom())
+        else
+            warn('choose_set_custom() not found!')
+        end
+        if status_change_custom then
+            built_set = set_combine(built_set, status_change_custom(new, old))
+        else
+            warn('status_change_custom(name,gain) not found!')
+        end
+        -- Here is where gear is actually equipped
+        equip(built_set)
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called by gearswap for any pet changes
+    -------------------------------------------------------------------------------------------------------------------
+
+    function pet_change(pet, gain)
+        -- A new pet is found
+        local built_set = choose_set()
+        if choose_set_custom then
+            built_set = set_combine(built_set, choose_set_custom())
+        else
+            warn('choose_set_custom() not found!')
+        end
+        if pet_change_custom then
+            built_set = set_combine(built_set, pet_change_custom(pet, gain))
+        else
+            warn('pet_change_custom() not found!')
+        end
+        -- Here is where gear is actually equipped
+        equip(built_set)
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called by gearswap for pet mid actions
+    -------------------------------------------------------------------------------------------------------------------
+
+    function pet_midcast(spell)
+        if sets.Pet_Midcast then
+            local built_set = sets.Pet_Midcast
+            -- Specific sets are defined
+            if sets.Pet_Midcast[spell.english] then
+                built_set = set_combine(built_set, sets.Pet_Midcast[spell.english])
+                info('[' .. spell.english .. '] Set')
+            end
+            -- User level commands
+            if pet_midcast_custom then
+                built_set = set_combine(built_set, pet_midcast_custom(spell))
+            end
+            -- Weapon Checks for precast
+            -- If it set to unlocked it will not swap the weapons even if defined in the built_set job lua
+            if state.WeaponMode.value ~= "Unlocked" then
+                if state.WeaponMode.value == "Locked" then
+                    built_set = set_combine(built_set,
+                        { main = player.equipment.main, sub = player.equipment.sub, range = player.equipment.range })
+                else
+                    if sets.Weapons[state.WeaponMode.value] then
+                        built_set = set_combine(built_set, sets.Weapons[state.WeaponMode.value])
+                        if not TwoHand and not DualWield then
+                            if sets.Weapons.Shield then
+                                built_set = set_combine(built_set, sets.Weapons.Shield)
+                            end
+                        end
+                    end
+                end
+                log('Midcast set equiping Offense Mode Gear')
+            end
+            equip(built_set)
+        else
+            warn('sets.Pet_Midcast not found!')
+        end
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called by gearswap for pet after actions
+    -------------------------------------------------------------------------------------------------------------------
+
+    function pet_aftercast(spell)
+        local built_set = choose_set()
+        if pet_aftercast_custom then
+            built_set = set_combine(built_set, pet_aftercast_custom(spell))
+        end
+        equip(built_set)
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called to determine if there are current buffs to be used
+    -------------------------------------------------------------------------------------------------------------------
+
+    function check_buff()
+        -- Auto Buff is on and not in a town
+        if not is_Busy and state.AutoBuff.value ~= 'OFF' and not Cities:contains(world.area) and not buffactive['Stun'] and not buffactive['Terror'] then
+            -- Set defaults
+            local command_JA = 'None'
+            local command_SP = 'None'
+
+            -- Spells
+            if not is_moving and check_buff_SP then command_SP = check_buff_SP() end
+
+            -- Job Abilities
+            if check_buff_JA then command_JA = check_buff_JA() end
+
+            if command_JA ~= 'None' and not buffactive['Amnesia'] then
+                command_JA_execute(command_JA)
+            elseif command_SP ~= 'None' then
+                command_SP_execute(command_SP)
+            end
+        end
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- Determine whether we have sufficient ammo for the action being attempted.
+    -------------------------------------------------------------------------------------------------------------------
+
+    function do_bullet_checks(spell, built_set)
+        if spell and built_set then
+            local bullet_name = built_set.ammo
+            if bullet_name == 'empty' or not bullet_name then return end
+            log('Ammo name is: ' .. bullet_name)
+
+            local bullet_min_count = 1
+            if spell.action_type == 'Ranged Attack' then
+                if buffactive['Triple Shot'] then
+                    bullet_min_count = 3
+                elseif buffactive['Double Shot'] then
+                    bullet_min_count = 2
+                elseif buffactive['Barrage'] then
+                    bullet_min_count = 8
+                end
+            end
+
+            available_bullets = 0
+
+            if player.inventory[bullet_name] then
+                available_bullets = available_bullets +
+                    player.inventory[bullet_name].count
+            end
+            if player.wardrobe[bullet_name] then
+                available_bullets = available_bullets +
+                    player.wardrobe[bullet_name].count
+            end
+            if player.wardrobe2[bullet_name] then
+                available_bullets = available_bullets +
+                    player.wardrobe2[bullet_name].count
+            end
+            if player.wardrobe3[bullet_name] then
+                available_bullets = available_bullets +
+                    player.wardrobe3[bullet_name].count
+            end
+            if player.wardrobe4[bullet_name] then
+                available_bullets = available_bullets +
+                    player.wardrobe4[bullet_name].count
+            end
+            if player.wardrobe5[bullet_name] then
+                available_bullets = available_bullets +
+                    player.wardrobe5[bullet_name].count
+            end
+            if player.wardrobe6[bullet_name] then
+                available_bullets = available_bullets +
+                    player.wardrobe6[bullet_name].count
+            end
+            if player.wardrobe7[bullet_name] then
+                available_bullets = available_bullets +
+                    player.wardrobe7[bullet_name].count
+            end
+            if player.wardrobe8[bullet_name] then
+                available_bullets = available_bullets +
+                    player.wardrobe8[bullet_name].count
+            end
+
+            log('Bullet Count [' .. available_bullets .. ']')
+
+            if available_bullets == 0 then
+                -- If no ammo is available, give appropriate warning and end.
+                if spell.type == 'CorsairShot' and player.equipment.ammo ~= 'empty' then
+                    add_to_chat(104,
+                        'No Quick Draw ammo left.  Using what\'s currently equipped (' .. player.equipment.ammo .. ').')
+                    return
+                elseif spell.type == 'WeaponSkill' and player.equipment.ammo == Ammo.Bullet.RA then
+                    add_to_chat(104,
+                        'No weaponskill ammo left.  Using what\'s currently equipped (standard ranged bullets: ' ..
+                        player.equipment.ammo .. ').')
+                    return
+                else
+                    add_to_chat(104, 'No ammo (' .. tostring(bullet_name) .. ') available for that action.')
+                    cancel_spell()
+                    return
+                end
+            end
+
+            -- Don't allow shooting or weaponskilling with ammo reserved for quick draw.
+            if spell.type ~= 'CorsairShot' and available_bullets <= bullet_min_count then
+                add_to_chat(104, 'Not enough ammo.  Cancelling.')
+                cancel_spell()
+                return
+            end
+
+            -- Low ammo warning.
+            if spell.type ~= 'CorsairShot' and state.warned.value == false and available_bullets > 1 and available_bullets <= Ammo_Warning_Limit then
+                local msg = '*****  LOW AMMO WARNING: ' .. tostring(available_bullets) .. 'x ' .. bullet_name .. ' *****'
+                local border = ""
+                for i = 2, #msg do border = border .. "*" end
+                windower.send_command('send @others input /echo ' .. msg .. '')
+                add_to_chat(167, border)
+                add_to_chat(167, msg)
+                add_to_chat(167, border)
+                state.warned:set()
+            elseif available_bullets > Ammo_Warning_Limit and state.warned then
+                state.warned:reset()
+            end
+        end
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- Determine whether we have sufficient Shihei for the action being attempted.
+    -------------------------------------------------------------------------------------------------------------------
+
+    function do_Utsu_checks(spell)
+        if spell.name == 'Utsusemi: Ichi' or spell.name == 'Utsusemi: Ni' or spell.name == 'Utsusemi: San' then
+            local display_message = false
+            local warning_level = 10
+            local count = 0
+            local available_shihei = player.inventory['Shihei']
+            local available_shiki = player.inventory['Shikanofuda']
+            -- Check for levels
+            if available_shihei then
+                if available_shihei.count < warning_level then
+                    display_message = true
+                    count = available_shihei.count
+                end
+            elseif available_shiki then
+                if available_shiki.count < warning_level then
+                    display_message = true
+                    count = available_shiki.count
+                end
+            else
+                display_message = true
+            end
+            -- Notify player is low
+            if display_message then
+                local msg = '*****  LOW TOOL WARNING: ' .. tostring(count) .. 'x *****'
+                local border = ""
+                for i = 1, #msg do border = border .. "*" end
+                windower.send_command('send @others input /echo ' .. msg .. '')
+                add_to_chat(167, border)
+                add_to_chat(167, msg)
+                add_to_chat(167, border)
+            end
+        end
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function returns the correct equipement to perform an action
+    -------------------------------------------------------------------------------------------------------------------
+
+    function check_equipment_spells(spell)
+        local built_set = {}
+        --Equip weapon for Dispelga
+        if spell.name == "Dispelga" then
+            built_set = { main = "Daybreak" }
+            -- Equip Marsyas
+        elseif spell.name == "Honor March" then
+            built_set = { range = "Marsyas" }
+            -- Equip Loughnashade
+        elseif spell.name == "Aria of Passion" then
+            built_set = { range = "Loughnashade" }
+            --Equip body for Impact
+        elseif spell.name == "Impact" then
+            local Crepuscular = player.inventory["Crepuscular Cloak"] or player.wardrobe["Crepuscular Cloak"] or
+                player.wardrobe2["Crepuscular Cloak"]
+                or player.wardrobe3["Crepuscular Cloak"] or player.wardrobe4["Crepuscular Cloak"] or
+                player.wardrobe5["Crepuscular Cloak"]
+                or player.wardrobe6["Crepuscular Cloak"] or player.wardrobe7["Crepuscular Cloak"] or
+                player.wardrobe8["Crepuscular Cloak"]
+            local Twilight = player.inventory["Twilight Cloak"] or player.wardrobe["Twilight Cloak"] or
+                player.wardrobe2["Twilight Cloak"]
+                or player.wardrobe3["Twilight Cloak"] or player.wardrobe4["Twilight Cloak"] or
+                player.wardrobe5["Twilight Cloak"]
+                or player.wardrobe6["Twilight Cloak"] or player.wardrobe7["Twilight Cloak"] or
+                player.wardrobe8["Twilight Cloak"]
+            -- Crepuscular Cloak Found
+            if Crepuscular then
+                log("Crepuscular Found")
+                built_set = { head = empty, body = "Crepuscular Cloak", }
+                -- Twilight Cloak Found
+            elseif Twilight then
+                log("Twilight Found")
+                built_set = { head = empty, body = "Twilight Cloak", }
+            end
+        end
+        return built_set
+    end
+
+    --Helper function for checking if player has an item available to equip.
+    local function has_item(item_id)
+        -- 0 = Main Inventory
+        -- 8, 9, 10, 11 = Wardrobes 1-4
+        -- 12, 13, 14, 15 = Wardrobes 5-8
+        local target_bags = { 0, 8, 9, 10, 11, 12, 13, 14, 15 }
+
+        for _, bag_id in ipairs(target_bags) do
+            local bag = windower.ffxi.get_items(bag_id)
+            if bag then
+                for _, item in ipairs(bag) do
+                    if type(item) == 'table' and item.id == item_id then
+                        return true
+                    end
+                end
+            end
+        end
+        return false
+    end
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called by the user via the self command - "gs c XXXX"
+    -------------------------------------------------------------------------------------------------------------------
+
+    function self_command(cmd)
+        local command = cmd:lower()
+        if command == 'update auto' then
+            local built_set = choose_set()
+            if choose_set_custom then
+                built_set = set_combine(built_set, choose_set_custom())
+            else
+                warn('choose_set_custom() not found!')
+            end
+            -- Order the gear and then equip
+            equip(built_set)
+            return
+        elseif command == 'zero' then
+            display_zero_command()
+        elseif command == 'displaymode' then
+            settings.oneline = not settings.oneline
+            info('One line display is: [' .. (settings.oneline and "ON" or "OFF") .. ']')
+            display_box_update()
+            config.save(settings)
+            add_to_chat(80, "Settings saved")
+            -- Toggles the TH state
+        elseif command:contains('treasurehunter') then
+            if command == "treasurehunter" then
+                state.TreasureMode:cycle()
+                info('Treasure Hunter Mode: [' .. state.TreasureMode.value .. ']')
+                display_box_update()
+            else
+                local mode = {}
+                mode = string.split(cmd, " ", 2)
+                state.TreasureMode:set(mode[2])
+                info('Treasure Hunter Mode: [' .. state.TreasureMode.value .. ']')
+                display_box_update()
+            end
+            equip_set_command()
+            return
+        elseif command:contains('spellreceived') then
+            if command == "spellreceived" then
+                state.SpellReceived:cycle()
+                info('Spell Received Mode: [' .. state.SpellReceived.value .. ']')
+                display_box_update()
+            else
+                local mode = {}
+                mode = string.split(cmd, " ", 2)
+                if mode[2]:contains("on-locked") then
+                    state.SpellReceived:set("ON-Locked")
+                elseif mode[2]:contains("on-unlocked") then
+                    state.SpellReceived:set('ON-Unlocked')
+                elseif mode[2]:contains("off") then
+                    state.SpellReceived:set('OFF')
+                else
+                    warn('Spell Received state not recognized')
+                end
+                info('Spell Received Mode: [' .. state.SpellReceived.value .. ']')
+                display_box_update()
+            end
+            equip_set_command()
+            return
+        elseif command:contains('hoxne') then
+            if command == "hoxne" then
+                state.Hoxne:cycle()
+                info('Hoxne Ampulla Mode: [' .. state.Hoxne.value .. ']')
+                display_box_update()
+            else
+                local mode = {}
+                mode = string.split(cmd, " ", 2)
+                if mode[2]:contains("on") then
+                    state.Hoxne:set("ON")
+                elseif mode[2]:contains("off") then
+                    state.Hoxne:set('OFF')
+                else
+                    warn('Hoxne Ampulla locking state not recognized')
+                end
+                info('Spell Received Mode: [' .. state.Hoxne.value .. ']')
+                display_box_update()
+            end
+            if state.Hoxne.value == "ON" then
+                local hoxne_id = res.items:with('en', "Hoxne Ampulla").id
+                if has_item(hoxne_id) then
+                    equip({ ranged = "", ammo = "Hoxne Ampulla" })
+                    disable('ranged', 'ammo')
+                    info('Hoxne Ampulla equipped. Ranged and ammo locked. Use hoxne manually.')
+                else
+                    warn("Hoxne Ampulla not found.  Not locking ranged/ammo")
+                    state.Hoxne:set('OFF')
+                    info('Hoxne Ampulla Mode: [' .. state.Hoxne.value .. ']')
+                    display_box_update()
+                end
+            else
+                enable('ranged', 'ammo')
+                info('Hoxne mode disabled.  Ranged and ammo unlocked.')
+            end
+            equip_set_command()
+            return
+            -- Toggles the Auto Buff function off/on
+        elseif command:contains('autobuff') then
+            if command == 'autobuff' then
+                state.AutoBuff:cycle()
+                info('Auto Buff is [' .. state.AutoBuff.value .. ']')
+            else
+                local mode = {}
+                mode = string.split(cmd, " ", 2)
+                state.AutoBuff:set(mode[2])
+                info('Auto Buff is [' .. state.AutoBuff.value .. ']')
+            end
+            display_box_update()
+            equip_set_command()
+            return
+            -- Shuts down instnace
+        elseif command == 'shutdown' then
+            send_command('terminate')
+            -- Saves the location of HUD
+        elseif command == 'save' then
+            config.save(settings)
+            add_to_chat(80, 'Settings saved')
+            -- Toggles dispay of the HUD
+        elseif command == 'display' then
+            if settings.visible == true then
+                settings.visible = false
+                gs_status:hide()
+                add_to_chat(80, 'The UI is now hidden')
+            else
+                gs_status:show()
+                settings.visible = true
+                display_box_update()
+                add_to_chat(80, 'The UI is now shown')
+            end
+        elseif command == 'debug' then
+            if settings.debug == true then
+                settings.debug = false
+                gs_debug:hide()
+                windower.add_to_chat(80, 'The debugging is now [OFF]')
+            else
+                settings.debug = true
+                gs_debug:show()
+                log('The debugging is now [ON]')
+            end
+        elseif command == 'warn' then
+            if settings.warn == true then
+                settings.warn = false
+                windower.add_to_chat(8, 'The set warning is now [OFF]')
+            else
+                settings.warn = true
+                warn('The set warning is now [ON]')
+            end
+        elseif command == 'info' then
+            if settings.info == true then
+                settings.info = false
+                windower.add_to_chat(8, 'Information is now [OFF]')
+            else
+                settings.info = true
+                info('Information is now [ON]')
+            end
+        elseif command == 'two_hand_check' then
+            two_hand_check()
+            -- Esha Temps
+        elseif command == 'temps' then
+            escha_temps()
+            -- Warp Ring
+        elseif command == 'warp' then
+            use_enchantment("Warp Ring")
+            -- Warp Club
+        elseif command == 'warp club' then
+            use_enchantment("Warp Cudgel")
+            -- Holla Teleport
+        elseif command == 'holla' then
+            use_enchantment("Dim. Ring (Holla)")
+            -- Dem Teleport
+        elseif command == 'dem' then
+            use_enchantment("Dim. Ring (Dem)")
+            -- Mea Teleport
+        elseif command == 'mea' then
+            use_enchantment("Dim. Ring (Mea)")
+            -- CP Ring
+        elseif command == 'cp' then
+            use_enchantment("Trizek Ring")
+            -- Toggles the current player stances
+        elseif command:contains('offensemode') then
+            if command == 'offensemode' then
+                for i, v in ipairs(state.OffenseMode) do
+                    if state.OffenseMode.value == v then
+                        if state.OffenseMode.value ~= state.OffenseMode[#state.OffenseMode] then
+                            state.OffenseMode:set(state.OffenseMode[i + 1])
+                        else
+                            state.OffenseMode:set(state.OffenseMode[1])
+                        end
+                        info('Offense Mode: [' .. state.OffenseMode.value .. ']')
+                        display_box_update()
+                        equip_set_command()
+                        return
+                    end
+                end
+            else
+                local mode = {}
+                mode = string.split(cmd, " ", 2)
+                state.OffenseMode:set(mode[2])
+                info('Offense Mode: [' .. state.OffenseMode.value .. ']')
+                display_box_update()
+                equip_set_command()
+                return
+            end
+        elseif command:contains('weaponmode') then
+            if command == 'weaponmode' then
+                for i, v in ipairs(state.WeaponMode) do
+                    if state.WeaponMode.value == v then
+                        if state.WeaponMode.value ~= state.WeaponMode[#state.WeaponMode] then
+                            state.WeaponMode:set(state.WeaponMode[i + 1])
+                        else
+                            state.WeaponMode:set(state.WeaponMode[1])
+                        end
+                        info('Weapon Mode: [' .. state.WeaponMode.value .. ']')
+                        display_box_update()
+                        if self_command_custom then self_command_custom(command) end
+                        two_hand_check()
+                        equip_set_command()
+                        return
+                    end
+                end
+            else
+                local mode = {}
+                mode = string.split(cmd, " ", 2)
+                state.WeaponMode:set(mode[2])
+                info('Weapon Mode: [' .. state.WeaponMode.value .. ']')
+                display_box_update()
+                if self_command_custom then self_command_custom(command) end
+                two_hand_check()
+                equip_set_command()
+                return
+            end
+        elseif command:contains('jobmode2') then
+            if command == 'jobmode2' then
+                for i, v in ipairs(state.JobMode2) do
+                    if state.JobMode2.value == v then
+                        if state.JobMode2.value ~= state.JobMode2[#state.JobMode2] then
+                            state.JobMode2:set(state.JobMode2[i + 1])
+                        else
+                            state.JobMode2:set(state.JobMode2[1])
+                        end
+                        info(UI_Name2 .. ': [' .. state.JobMode2.value .. ']')
+                        display_box_update()
+                        if self_command_custom then self_command_custom(command) end
+                        equip_set_command()
+                        return
+                    end
+                end
+            else
+                local mode = {}
+                mode = string.split(cmd, " ", 2)
+                state.JobMode2:set(mode[2])
+                info(UI_Name2 .. ': [' .. state.JobMode2.value .. ']')
+                display_box_update()
+                if self_command_custom then self_command_custom(command) end
+                equip_set_command()
+                return
+            end
+        elseif command:contains('jobmode') then
+            if command == 'jobmode' then
+                for i, v in ipairs(state.JobMode) do
+                    if state.JobMode.value == v then
+                        if state.JobMode.value ~= state.JobMode[#state.JobMode] then
+                            state.JobMode:set(state.JobMode[i + 1])
+                        else
+                            state.JobMode:set(state.JobMode[1])
+                        end
+                        info(UI_Name .. ': [' .. state.JobMode.value .. ']')
+                        display_box_update()
+                        -- Issue a command to the lua for the job specific command
+                        if self_command_custom then self_command_custom(command) end
+                        equip_set_command()
+                        return
+                    end
+                end
+            else
+                local mode = {}
+                mode = string.split(cmd, " ", 2)
+                state.JobMode:set(mode[2])
+                info(UI_Name .. ': [' .. state.JobMode.value .. ']')
+                display_box_update()
+                -- Issue a command to the lua for the job specific command
+                if self_command_custom then self_command_custom(command) end
+                equip_set_command()
+                return
+            end
+            -- This profile mode is used to load a Silmaril profile and execute a script
+        elseif command:contains('profile') then
+            local modes = {}
+            for mode in string.gmatch(cmd, "(%w+)") do
+                table.insert(modes, mode)
+            end
+            local smModePath = table.concat(modes, '_', 2, #modes)
+            info('Profile: [' .. modes[#modes] .. ']')
+            windower.send_command('exec ' .. smModePath .. '/' .. player.main_job ..
+                '_' .. player.sub_job .. '_' .. player.name)
+        elseif command == 'food' then
+            windower.chat.input('/item "' .. Food .. '" <me>')
+            -- Command to use any enchanted item, can use either en or enl names from resources, autodetects slot, equip timeout and cast time
+        elseif command:startswith('use') then
+            use_enchantment(command:slice(5))
+        elseif command == 'version' then
+            info('Include Version is [' .. Mirdain_GS .. ']')
+
+            -------Custom Commands for Proccing and 1Dmg Weapons-------
+        elseif command == 'naked' then
+            equip({
+                main = empty,
+                sub = empty,
+                range = empty,
+                ammo = empty,
+                head = empty,
+                neck = empty,
+                ear1 = empty,
+                ear2 = empty,
+                body = empty,
+                hands = empty,
+                ring1 = empty,
+                ring2 = empty,
+                back = empty,
+                waist = empty,
+                legs = empty,
+                feet = empty
+            })
+            Lock()
+
+            --Disable all slots but weapons, range and ammo
+        elseif command == 'weaponsonly' then
+            equip({
+                head = empty,
+                neck = empty,
+                ear1 = empty,
+                ear2 = empty,
+                body = empty,
+                hands = empty,
+                ring1 = empty,
+                ring2 = empty,
+                back = empty,
+                waist = empty,
+                legs = empty,
+                feet = empty
+            })
+            disable('head', 'neck', 'ear1', 'ear2', 'body', 'hands', 'ring1', 'ring2', 'back', 'waist', 'legs', 'feet')
+            --Mode to disable main equipment slots for abyssea red proccing
+        elseif command == 'abysseaproc' then
+            equip({
+                head = empty,
+                --body = empty,
+                hands = empty,
+                legs = empty,
+                feet = empty,
+            })
+            --disable('head', 'neck', 'ear1', 'ear2', 'body', 'hands', 'ring1', 'ring2', 'back', 'waist', 'legs', 'feet')
+            disable('head', 'hands', 'legs', 'feet')
+
+            --Enable All Slots
+        elseif command == 'enableall' then
+            Unlock()
+        end
+
+        --use below for custom Job commands
+        if self_command_custom then self_command_custom(command) end
+    end
+
+    -- Functin used to exectue Job Abilities
+    function command_JA_execute(command_JA)
+        local cast_ability = res.job_abilities:with('en', command_JA)
+        local target = ''
+        if tostring(cast_ability.targets) == "{Self}" then
+            target = '<me>'
+        elseif tostring(cast_ability.targets) == "{Enemy}" then
+            target = '<bt>'
+        else
+            target = '<me>'
+        end
+        --log('input /ja "'..command_JA..'" '..target..'')
+        windower.chat.input('/ja "' .. command_JA .. '" ' .. target .. '')
+    end
+
+    -- Functin used to exectue Spells
+    function command_SP_execute(command_SP)
+        local cast_spell = res.spells:with('en', command_SP)
+        local spell_cast_time = cast_spell.cast_time
+        local target = ''
+        if tostring(cast_spell.targets) == '{Self}' then
+            target = '<me>'
+        elseif tostring(cast_spell.targets) == '{Enemy}' then
+            target = '<bt>'
+        else
+            target = '<me>'
+        end
+        --log('input /ma "'..command_SP..'" '..target..'')
+        windower.chat.input('/ma "' .. command_SP .. '" ' .. target .. '')
+    end
+
+    -- Used for Escha Temp and Zerg
+    function escha_temps()
+        info('Escha Temps')
+        windower.send_command(
+            "input /item \"Monarch's Drink\" <me>;wait 2.5;input /item \"Braver's Drink\" <me>;wait 2.5;input /item \"Fighter's Drink\" <me>;wait 2.5;input /item \"Champion's Drink\" <me>;wait 2.5;input /item \"Soldier's Drink\" <me>;wait 2.5;input /item \"Barbarian's Drink\" <me>")
+    end
+
+    -- Determines correct gear for the songs
+    function equip_song_gear(spell, instrument)
+        local song_set = {}
+        if string.find(spell.english, 'Finale') and sets.Midcast.Finale then
+            song_set = sets.Midcast.Finale
+        elseif string.find(spell.english, 'Lullaby') and sets.Midcast.Lullaby then
+            song_set = sets.Midcast.Lullaby
+        elseif string.find(spell.english, 'Threnody') and sets.Midcast.Threnody then
+            song_set = sets.Midcast.Threnody
+        elseif string.find(spell.english, 'Elegy') and sets.Midcast.Elegy then
+            song_set = sets.Midcast.Elegy
+        elseif string.find(spell.english, 'Requiem') and sets.Midcast.Requiem then
+            song_set = sets.Midcast.Requiem
+        elseif string.find(spell.english, 'March') and sets.Midcast.March then
+            song_set = sets.Midcast.March
+        elseif string.find(spell.english, 'Minuet') and sets.Midcast.Minuet then
+            song_set = sets.Midcast.Minuet
+        elseif string.find(spell.english, 'Madrigal') and sets.Midcast.Madrigal then
+            song_set = sets.Midcast.Madrigal
+        elseif string.find(spell.english, 'Ballad') and sets.Midcast.Ballad then
+            song_set = sets.Midcast.Ballad
+        elseif string.find(spell.english, 'Scherzo') and sets.Midcast.Scherzo then
+            song_set = sets.Midcast.Scherzo
+        elseif string.find(spell.english, 'Mazurka') and sets.Midcast.Mazurka then
+            song_set = sets.Midcast.Mazurka
+        elseif string.find(spell.english, 'Paeon') and sets.Midcast.Paeon then
+            song_set = sets.Midcast.Paeon
+        elseif string.find(spell.english, 'Carol') and sets.Midcast.Carol then
+            song_set = sets.Midcast.Carol
+        elseif string.find(spell.english, 'Minne') and sets.Midcast.Minne then
+            song_set = sets.Midcast.Minne
+        elseif string.find(spell.english, 'Mambo') and sets.Midcast.Mambo then
+            song_set = sets.Midcast.Mambo
+        elseif string.find(spell.english, 'Etude') and sets.Midcast.Etude then
+            song_set = sets.Midcast.Etude
+        elseif string.find(spell.english, 'Prelude') and sets.Midcast.Prelude then
+            song_set = sets.Midcast.Prelude
+        elseif string.find(spell.english, 'Dirge') and sets.Midcast.Dirge then
+            song_set = sets.Midcast.Dirge
+        elseif string.find(spell.english, 'Sirvente') and sets.Midcast.Sirvente then
+            song_set = sets.Midcast.Sirvente
+        elseif string.find(spell.english, 'Aria') and sets.Midcast.Aria then
+            song_set = sets.Midcast.Aria
+        else
+            warn('[' .. spell.english .. '] set not found!')
+        end
+        song_set['range'] = instrument
+        return song_set
+    end
+
+    -- Determines correct instrument for Pianissimo
+    function equip_pianissimo_gear(spell)
+        if spell.english == "Honor March" or spell.english == "Aria of Passion" then return end
+        if Instrument then
+            if Instrument.Pianissimo then
+                log('Check Pianissimo Instrument')
+                if string.find(spell.english, 'March') and Instrument.Pianissimo.March then
+                    return Instrument.Pianissimo.March
+                elseif string.find(spell.english, 'Minuet') and Instrument.Pianissimo.Minuet then
+                    return Instrument.Pianissimo.Minuet
+                elseif string.find(spell.english, 'Madrigal') and Instrument.Pianissimo.Madrigal then
+                    return Instrument.Pianissimo.Madrigal
+                elseif string.find(spell.english, 'Ballad') and Instrument.Pianissimo.Ballad then
+                    return Instrument.Pianissimo.Ballad
+                elseif string.find(spell.english, 'Scherzo') and Instrument.Pianissimo.Scherzo then
+                    return Instrument.Pianissimo.Scherzo
+                elseif string.find(spell.english, 'Mazurka') and Instrument.Pianissimo.Mazurka then
+                    return Instrument.Pianissimo.Mazurka
+                elseif string.find(spell.english, 'Paeon') and Instrument.Pianissimo.Paeon then
+                    return Instrument.Pianissimo.Paeon
+                elseif string.find(spell.english, 'Carol') and Instrument.Pianissimo.Carol then
+                    return Instrument.Pianissimo.Carol
+                elseif string.find(spell.english, 'Minne') and Instrument.Pianissimo.Minne then
+                    return Instrument.Pianissimo.Minne
+                elseif string.find(spell.english, 'Mambo') and Instrument.Pianissimo.Mambo then
+                    return Instrument.Pianissimo.Mambo
+                elseif string.find(spell.english, 'Etude') and Instrument.Pianissimo.Etude then
+                    return Instrument.Pianissimo.Etude
+                elseif string.find(spell.english, 'Prelude') and Instrument.Pianissimo.Prelude then
+                    return Instrument.Pianissimo.Prelude
+                elseif string.find(spell.english, 'Dirge') and Instrument.Pianissimo.Dirge then
+                    return Instrument.Pianissimo.Dirge
+                elseif string.find(spell.english, 'Sirvente') and Instrument.Pianissimo.Sirvente then
+                    return Instrument.Pianissimo.Sirvente
+                else
+                    return Instrument.Pianissimo
+                end
+            else
+                warn('sets.Instrument.Pianissimo not found!')
+            end
+        else
+            warn('sets.Instrument not found!')
+        end
+    end
+
+    function use_enchantment(item)
+        local SlotList = { "main", "sub", "range", "ammo", "head", "body", "hands", "legs", "feet", "neck", "waist",
+            "lear", "rear", "left_ring", "right_ring", "back" }
+        local item_table = res.items:with('enl', item) or res.items:with('en', item)
+        local slot = ''
+
+        if item_table == nil or not item_table.targets:contains('Self') then
+            info("Invalid item.")
+            return
+        end
+        if item_table.slots:contains(0) then
+            slot = 'main'
+        else
+            for k, v in pairs(item_table.slots) do
+                if v == true then
+                    slot = SlotList[k + 1]
+                    break
+                end
+            end
+        end
+        enable(slot)
+        equip({ [slot] = item_table.en })
+        disable(slot)
+        local delay_use = item_table.cast_delay + 3
+        local delay_unlock = delay_use + item_table.cast_time + 3
+        Use_Item_Command = item_table.en
+        coroutine.schedule(Use_Item, delay_use)
+        coroutine.schedule(Unlock, delay_unlock)
+        coroutine.schedule(equip_set_command, delay_unlock)
+    end
+
+    function Use_Item()
+        log('/item "' .. Use_Item_Command .. '" ' .. player.id)
+        windower.chat.input('/item "' .. Use_Item_Command .. '" <me>')
+    end
+
+    -- Unbind Keys when the file is unloaded
+    function file_unload(file_name)
+        send_command('unbind ^f9')
+        send_command('unbind ^f10')
+        send_command('unbind ^f11')
+        send_command('unbind ^f12')
+        send_command('unbind f9')
+        send_command('unbind f10')
+        send_command('unbind f11')
+        send_command('unbind f12')
+
+        if gs_status then
+            gs_status:destroy()
+        end
+        if gs_debug then
+            gs_debug:destroy()
+        end
+
+        if active_external_locks and next(active_external_locks) ~= nil then
+            for slot, _ in pairs(active_external_locks) do
+                enable(slot)
+            end
+            active_external_locks = {}
+        end
+
+        if user_file_unload then
+            user_file_unload()
+        else
+            info('user_file_unload() not found!')
+        end
+    end
+
+    -- Command to Lock Style and Set the correct macros
+    function jobsetup(LockStylePallet, MacroBook, MacroSet)
+        if Random_Lockstyle then
+            LockStylePallet = Lockstyle_List[math.random(#Lockstyle_List)]
+        end
+
+        windower.send_command('wait 1;input /macro book ' ..
+            MacroBook ..
+            ';wait 1;input /macro set ' ..
+            MacroSet ..
+            ';gs validate;wait 3;input /lockstyleset ' ..
+            LockStylePallet .. ';input /echo Change Complete;gs c update auto;')
+
+        send_command('bind f12 gs c OffenseMode')
+        send_command('bind f11 gs c TreasureHunter')
+        send_command('bind f10 gs c AutoBuff')
+        send_command('bind f9 gs c WeaponMode')
+        send_command('bind ^f12 gs c JobMode')
+        send_command('bind ^f11 gs c JobMode2')
+        send_command('bind ^f10 gs c Hoxne')
+        send_command('bind ^f9 gs c SpellReceived')
+
+        local maxWidth = 40
+        windower.add_to_chat(8, 'Stance - ' .. string.format('[%s]', 'F12'))
+        windower.add_to_chat(8, 'TH Mode - ' .. string.format('[%s]', 'F11'))
+        windower.add_to_chat(8, 'Auto Buff - ' .. string.format('[%s]', 'F10'))
+        windower.add_to_chat(8, 'Weapon Mode - ' .. string.format('[%s]', 'F9'))
+        if UI_Name ~= '' then
+            windower.add_to_chat(8, UI_Name .. ' - ' .. string.format('[%s]', 'Ctrl + F12'))
+        end
+        if UI_Name2 ~= '' then
+            windower.add_to_chat(8, UI_Name2 .. ' - ' .. string.format('[%s]', 'Ctrl + F11'))
+        end
+        windower.add_to_chat(8, 'Hoxne Ampulla Mode - ' .. string.format('[%s]', 'Ctrl + F10'))
+        windower.add_to_chat(8,
+            'Spell Received Gear Mode (Multibox Only) - ' .. string.format('[%s]', 'Ctrl + F9'))
+    end
+
+    -- Called when the player's subjob changes.
+    function sub_job_change(new, old)
+        coroutine.schedule(dual_wield_check, 2)
+        coroutine.schedule(two_hand_check, 2.1)
+        coroutine.schedule(equip_set_command, 2.2)
+        if sub_job_change_custom then
+            sub_job_change_custom()
+        end
+    end
+
+    -- Check if you have the dual wield trait
+    function dual_wield_check()
+        local current_abilities = windower.ffxi.get_abilities()
+        if table.contains(current_abilities.job_traits, 18) then -- Dual Wield trait
+            DualWield = true
+        else
+            DualWield = false
+        end
+    end
+
+    function two_hand_check()
+        if sets.Weapons[state.WeaponMode.value] and sets.Weapons[state.WeaponMode.value]['main'] then
+            local weapon_name = sets.Weapons[state.WeaponMode.value]['main']
+            if type(weapon_name) == "table" then weapon_name = sets.Weapons[state.WeaponMode.value]['main'].name end
+            local Main_Weapon = res.items:with('en', weapon_name)
+            if Main_Weapon then
+                --log('Weapon:['..Main_Weapon.en..']')
+                local Skill_type = Main_Weapon.skill
+                if Skill_type == 4 or Skill_type == 6 or Skill_type == 7 or Skill_type == 8 or Skill_type == 10 or Skill_type == 12 then
+                    TwoHand = true
+                else
+                    TwoHand = false
+                end
+            else
+                TwoHand = false
+            end
+        end
+    end
+
+    -- On changing targets, attempt to add TH gear.
+    function on_target_change_for_th(new_index, old_index)
+        -- Only care about changing targets while we're engaged, either manually or via current target death.
+        if player.status == 'Engaged' and state.TreasureMode.value ~= 'None' then
+            -- If  the current player.target is the same as the new mob then we're actually engaged with it.
+            -- If it's different than the last known mob, then we've actually changed targets.
+            if player.target.index == new_index and new_index ~= th_info.last_player_target_index then
+                th_info.last_player_target_index = player.target.index
+                local built_set = choose_set()
+                if choose_set_custom then
+                    built_set = set_combine(built_set, choose_set_custom())
+                else
+                    warn('choose_set_custom() not found!')
+                end
+                equip(built_set)
+            end
+        end
+    end
+
+    -- This function removes mobs from our tracking table when they die.
+    function on_incoming_chunk_for_th(id, data, modified, injected, blocked)
+        -- Action Packet
+        if id == 0x29 and state.TreasureMode.value ~= 'None' then
+            local target_id = data:unpack('I', 0x09)
+            local message_id = data:unpack('H', 0x19) % 32768
+            -- Remove mobs that die from our tagged mobs list.
+            if th_info.tagged_mobs[target_id] then
+                -- 6 == actor defeats target
+                -- 20 == target falls to the ground
+                if message_id == 6 or message_id == 20 then
+                    if settings.debug then
+                        add_to_chat(123, 'Mob ' ..
+                            target_id .. ' died. Removing from tagged mobs table.')
+                    end
+                    th_info.tagged_mobs[target_id] = nil
+                end
+            end
+        end
+    end
+
+    -- Clear out the entire tagged mobs table when zoning.
+    function on_zone_change_for_th(new_zone, old_zone)
+        UnlockByMode()
+        if settings.debug then windower.add_to_chat(123, 'Zoning. Clearing tagged mobs table.') end
+        th_info.tagged_mobs:clear()
+        -- Turn off for zones
+        state.AutoBuff:set('OFF')
+    end
+
+    -- Remove mobs that we've marked as tagged with TH if we haven't seen any activity from or on them
+    -- for over 3 minutes.  This is to handle deagros, player deaths, or other random stuff where the
+    -- mob is lost, but doesn't die.
+    function cleanup_tagged_mobs()
+        -- If it's been more than 3 minutes since an action on or by a tagged mob,
+        -- remove them from the tagged mobs list.
+        local current_time = os.clock()
+        local remove_mobs = S {}
+
+        --log('The TH table contains ['..tostring(#th_info.tagged_mobs)..'] entries.')
+
+        -- Search list and flag old entries.
+        for target_id, action_time in pairs(th_info.tagged_mobs) do
+            local time_since_last_action = current_time - action_time
+            if time_since_last_action > 180 then
+                remove_mobs:add(target_id)
+                if settings.debug then
+                    windower.add_to_chat(123,
+                        'Over 3 minutes since last action on mob ' .. target_id .. '. Removing from tagged mobs list.')
+                end
+            end
+        end
+
+        -- Clean out mobs flagged for removal.
+        for mob_id, _ in pairs(remove_mobs) do
+            th_info.tagged_mobs[mob_id] = nil
+        end
+    end
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- BELOW IS FROM THE CANCEL ADDON
+    -- ADDING DUE TO FACT SOME PEOPLE MAY NOT HAVE IT INSTALLED
+    -- ALLOWS CANCELING OF BUFFS EASIER
+    -------------------------------------------------------------------------------------------------------------------
+
+    function cancel(...)
+        local command = table.concat({ ... }, ' ')
+        if not command then return end
+        local status_id_tab = command:split(',')
+        status_id_tab.n = nil
+        local ids = {}
+        local buffs = {}
+        for _, v in pairs(player.buffs) do
+            for _, r in pairs(status_id_tab) do
+                if windower.wc_match(res.buffs[v][Language], r) or windower.wc_match(tostring(v), r) then
+                    cancel_buff(v)
+                    break
+                end
+            end
+        end
+    end
+
+    function cancel_buff(id)
+        windower.packets.inject_outgoing(0xF1, string.char(0xF1, 0x04, 0, 0, id % 256, math.floor(id / 256), 0, 0)) -- Inject the cancel packet
+    end
+
+    function Unlock()
+        log('Unlock Called')
+        enable('main', 'sub', 'range', 'ammo', 'head', 'neck', 'ear1', 'ear2', 'body', 'hands', 'ring1', 'ring2', 'waist',
+            'legs', 'feet', 'back')
+    end
+
+    function UnlockByMode()
+        log('Unlock By Mode Called')
+        if state.Hoxne.value == "ON" then
+            enable('main', 'sub', 'head', 'ear1', 'ear2', 'body', 'hands', 'ring1', 'ring2', 'waist',
+                'legs', 'feet', 'back')
+        else
+            enable('main', 'sub', 'range', 'ammo', 'head', 'ear1', 'ear2', 'body', 'hands', 'ring1', 'ring2',
+                'waist',
+                'legs', 'feet', 'back')
+        end
+        if not Divergence_Zones:contains(world.area) then
+            -- Only unlock neck if not in divergence zone.
+            enable('neck')
+        end
+    end
+
+    function Lock()
+        log('Lock Called')
+        disable('main', 'sub', 'range', 'ammo', 'head', 'neck', 'ear1', 'ear2', 'body', 'hands', 'ring1', 'ring2',
+            'waist',
+            'legs', 'feet', 'back')
+    end
+
+    -- UI for displaying the current states
+    function display_box_update()
+        local dialog = {}
+
+        dialog[1] = { description = 'TH', value = state.TreasureMode.value, color = '255,215,0' } -- Gold
+
+        dialog[2] = {
+            description = 'Spell-Rec',
+            value = state.SpellReceived.value,
+            color = (state.SpellReceived.value:contains('ON') and '0,255,0' or state.SpellReceived.value == 'OFF' and '255,0,0' or '255,255,255')
+        }
+
+        dialog[3] = {
+            description = 'Hoxne',
+            value = state.Hoxne.value,
+            color = (state.Hoxne.value == 'ON' and '0,255,0' or state.Hoxne.value == 'OFF' and '255,0,0' or '255,255,255')
+        }
+
+        dialog[4] = { description = 'Stance', value = state.OffenseMode.value, color = '255,255,255' }
+        dialog[5] = { description = 'DPS', value = state.WeaponMode.value, color = '255,255,255' }
+
+        if UI_Name ~= "" then
+            dialog[6] = { description = UI_Name, value = state.JobMode.value, color = '255,255,255' }
+        end
+        if UI_Name2 ~= "" then
+            dialog[7] = { description = UI_Name2, value = state.JobMode2.value, color = '255,255,255' }
+        end
+
+        local lines = T {}
+
+        if settings.oneline then
+            for k, v in ipairs(dialog) do
+                local colored_val = string.format('\\cs(%s)[%s]\\cr', v.color, tostring(v.value))
+                lines:insert(string.format('%s:%s', v.description, colored_val))
+            end
+            gs_status:text(lines:concat(' '))
+        else
+            local max_desc_len = 0
+            local max_val_len = 0
+
+            for _, v in ipairs(dialog) do
+                local raw_val_str = '[' .. tostring(v.value) .. ']'
+                if string.len(v.description) > max_desc_len then
+                    max_desc_len = string.len(v.description)
+                end
+                if string.len(raw_val_str) > max_val_len then
+                    max_val_len = string.len(raw_val_str)
+                end
+            end
+
+            local target_desc_width = max_desc_len + 1
+
+            for k, v in ipairs(dialog) do
+                local raw_val_str = '[' .. tostring(v.value) .. ']'
+                local padded_desc = v.description:rpad(' ', target_desc_width)
+                local value_padding_needed = max_val_len - string.len(raw_val_str)
+                local value_spaces = string.rep(' ', value_padding_needed)
+                local colored_val = string.format('\\cs(%s)%s\\cr', v.color, raw_val_str)
+                lines:insert(padded_desc .. value_spaces .. colored_val)
+            end
+
+            gs_status:text(lines:concat('\n'))
+        end
+    end
+
+    -- Zero the display window
+    function display_zero_command()
+        gs_status:pos_x(0)
+        gs_status:pos_y(0)
+        config.save(settings)
+        add_to_chat("Settings Saved")
+    end
+
+    -- Used to help debug issues
+    function debug_box_update()
+        local lines = T {}
+        lines:insert('is_Busy' .. string.format('[%s]', tostring(is_Busy)):lpad(' ', 12))
+        lines:insert('is_Moving' .. string.format('[%s]', tostring(is_moving)):lpad(' ', 10))
+        lines:insert('DualWield' .. string.format('[%s]', tostring(DualWield)):lpad(' ', 10))
+        lines:insert('TwoHand' .. string.format('[%s]', tostring(TwoHand)):lpad(' ', 12))
+        lines:insert('Casting' .. string.format('[%s]', tostring(outgoing_cast_active)):lpad(' ', 12))
+        lines:insert('Failsafe' .. string.format('[%s]', tostring(failsafe_active)):lpad(' ', 11))
+        local maxWidth = math.max(1, table.reduce(lines, function(a, b) return math.max(a, #b) end, '1'))
+        for i, line in ipairs(lines) do lines[i] = lines[i]:rpad(' ', maxWidth) end
+        gs_debug:text(lines:concat('\n'))
+    end
+
+    function log(msg)
+        if settings.debug then print(80, msg) end
+    end
+
+    function info(msg)
+        if settings.info then print(8, msg) end
+    end
+
+    function warn(msg)
+        if settings.warn then print(12, msg) end
+    end
+
+    function print(mode, msg)
+        if msg == nil then
+            windower.add_to_chat(mode, 'Value is Nil')
+        elseif type(msg) == "table" then
+            for index, value in pairs(msg) do
+                if type(value) == "table" then
+                    for index2, value2 in pairs(value) do
+                        if type(value2) == "table" then
+                            for index3, value3 in pairs(value2) do
+                                if type(value3) == "table" then
+                                    for index4, value4 in pairs(value3) do
+                                        windower.add_to_chat(mode,
+                                            '---- [' ..
+                                            tostring(index) ..
+                                            '] [' ..
+                                            tostring(index2) ..
+                                            '] [' ..
+                                            tostring(index3) .. '] [' ..
+                                            tostring(index4) .. '] ' .. tostring(value4) .. ' ----')
+                                    end
+                                else
+                                    windower.add_to_chat(mode,
+                                        '---- [' ..
+                                        tostring(index) ..
+                                        '] [' ..
+                                        tostring(index2) .. '] [' .. tostring(index3) .. '] ' ..
+                                        tostring(value3) .. ' ----')
+                                end
+                            end
+                        else
+                            windower.add_to_chat(mode,
+                                '---- [' .. tostring(index) .. '] [' .. tostring(index2) ..
+                                '] ' .. tostring(value2) .. ' ----')
+                        end
+                    end
+                else
+                    windower.add_to_chat(mode, '---- [' .. tostring(index) .. '] ' .. tostring(value) .. ' ----')
+                end
+            end
+        elseif type(msg) == "number" then
+            windower.add_to_chat(mode, tostring(msg))
+        elseif type(msg) == "string" then
+            windower.add_to_chat(mode, msg)
+        elseif type(msg) == "boolean" then
+            windower.add_to_chat(mode, tostring(msg))
+        else
+            windower.add_to_chat(mode, 'Unknown Message')
+        end
+    end
+
+    function elemental_check(spell, built_set)
+        -- Rule for Cures
+        if spell.name:contains('Cure') or spell.name:contains('Cura') then
+            if world.weather_element == spell.element or spell.element == world.day_element then
+                -- Verify player has the gear
+                local Obi = player.inventory["Hachirin-no-Obi"] or player.wardrobe["Hachirin-no-Obi"] or
+                    player.wardrobe2["Hachirin-no-Obi"]
+                    or player.wardrobe3["Hachirin-no-Obi"] or player.wardrobe4["Hachirin-no-Obi"] or
+                    player.wardrobe5["Hachirin-no-Obi"]
+                    or player.wardrobe6["Hachirin-no-Obi"] or player.wardrobe7["Hachirin-no-Obi"] or
+                    player.wardrobe8["Hachirin-no-Obi"]
+
+                local Staff = player.inventory["Chatoyant Staff"] or player.wardrobe["Chatoyant Staff"] or
+                    player.wardrobe2["Chatoyant Staff"]
+                    or player.wardrobe3["Chatoyant Staff"] or player.wardrobe4["Chatoyant Staff"] or
+                    player.wardrobe5["Chatoyant Staff"]
+                    or player.wardrobe6["Chatoyant Staff"] or player.wardrobe7["Chatoyant Staff"] or
+                    player.wardrobe8["Chatoyant Staff"]
+
+                local Cape = player.inventory["Twilight Cape"] or player.wardrobe["Twilight Cape"] or
+                    player.wardrobe2["Twilight Cape"]
+                    or player.wardrobe3["Twilight Cape"] or player.wardrobe4["Twilight Cape"] or
+                    player.wardrobe5["Twilight Cape"]
+                    or player.wardrobe6["Twilight Cape"] or player.wardrobe7["Twilight Cape"] or
+                    player.wardrobe8["Twilight Cape"]
+
+                -- Check for bonus
+                if spell.element == world.day_element then
+                    if Obi then built_set = set_combine(built_set, { waist = "Hachirin-no-Obi" }) end
+                    if Staff then
+                        built_set = set_combine(built_set, sets.Weapons['Light Bonus'],
+                            { main = "Chatoyant Staff" })
+                    end
+                    if Cape then built_set = set_combine(built_set, { back = "Twilight Cape" }) end
+                    windower.add_to_chat(8, '[' .. world.day_element .. '] day - using Bonus Gear')
+                elseif world.weather_element == spell.element then
+                    if Obi then built_set = set_combine(built_set, { waist = "Hachirin-no-Obi" }) end
+                    if Staff then
+                        built_set = set_combine(built_set, sets.Weapons['Light Bonus'],
+                            { main = "Chatoyant Staff" })
+                    end
+                    if Cape then built_set = set_combine(built_set, { back = "Twilight Cape" }) end
+                    windower.add_to_chat(8, 'Weather is [' .. world.weather_element .. '] - using Bonus Gear')
+                end
+            end
+            -- This function swaps in the Orpheus or Hachirin as needed
+        else
+            -- Check for player gear
+            local Osash = player.inventory["Orpheus's Sash"] or player.wardrobe["Orpheus's Sash"] or
+                player.wardrobe2["Orpheus's Sash"]
+                or player.wardrobe3["Orpheus's Sash"] or player.wardrobe4["Orpheus's Sash"] or
+                player.wardrobe5["Orpheus's Sash"]
+                or player.wardrobe6["Orpheus's Sash"] or player.wardrobe7["Orpheus's Sash"] or
+                player.wardrobe8["Orpheus's Sash"]
+            local Obi = player.inventory["Hachirin-no-Obi"] or player.wardrobe["Hachirin-no-Obi"] or
+                player.wardrobe2["Hachirin-no-Obi"]
+                or player.wardrobe3["Hachirin-no-Obi"] or player.wardrobe4["Hachirin-no-Obi"] or
+                player.wardrobe5["Hachirin-no-Obi"]
+                or player.wardrobe6["Hachirin-no-Obi"] or player.wardrobe7["Hachirin-no-Obi"] or
+                player.wardrobe8["Hachirin-no-Obi"]
+
+            -- Matching double weather (w/o day conflict).
+            if spell.element == world.weather_element and world.weather_intensity == 2 and Obi then
+                built_set = set_combine(built_set, { waist = "Hachirin-no-Obi" })
+                info('Weather is Double [' .. world.weather_element .. '] - using Hachirin-no-Obi')
+                -- Matching day and weather.
+            elseif spell.element == world.day_element and spell.element == world.weather_element and Obi then
+                built_set = set_combine(built_set, { waist = "Hachirin-no-Obi" })
+                info('[' ..
+                    world.day_element .. '] day and weather is [' .. world.weather_element .. '] - using Hachirin-no-Obi')
+                -- Target distance less than 6 yalms
+            elseif spell.target.distance < (6 + spell.target.model_size) and Osash then
+                built_set = set_combine(built_set, { waist = "Orpheus's Sash" })
+                info('Distance is [' .. round(spell.target.distance, 2) .. '] using Orpheus Sash')
+                -- Match day or weather.
+            elseif spell.element == world.day_element or spell.element == world.weather_element and Obi then
+                built_set = set_combine(built_set, { waist = "Hachirin-no-Obi" })
+                info('[' ..
+                    world.day_element .. '] day and weather is [' .. world.weather_element .. '] - using Hachirin-no-Obi')
+            end
+        end
+        return built_set
+    end
+
+    function round(num, numDecimalPlaces)
+        if num ~= nil then
+            local mult = 10 ^ (numDecimalPlaces or 0)
+            return math.floor(num * mult + 0.5) / mult
+        end
+    end
+
+    function run_burst(data)
+        local action = data.targets[1].actions[1]
+        if (action.add_effect_message > 287 and action.add_effect_message < 302)     -- Normal SC DMG
+            or (action.add_effect_message > 384 and action.add_effect_message < 399) -- SC Heals
+            or (action.add_effect_message > 766 and action.add_effect_message < 771) -- Umbra/Radiance
+        then
+            log('There was a skillchain')
+            local t = windower.ffxi.get_mob_by_id(data.targets[1].id)
+            -- valid party target and within range
+            if t and t.spawn_type == 16 and t.distance:sqrt() < 21 then
+                -- Update the enemy to track
+                last_skillchain_id = t.id
+                last_skillchain_time = os.clock()
+                last_skillchain_elements = {}
+                log('Skillchain detected')
+                -- get the type of skillchain
+                local skillchain = skillchains[action.add_effect_message]
+                -- Find the elements
+                for index, element in pairs(skillchain.elements) do
+                    last_skillchain_elements[element] = element
+                end
+                log(last_skillchain_elements)
+            end
+            -- This is used to stop bursting if a ws happened to close the window
+        elseif data.category == 3 and data.param ~= 0 then
+            local t = windower.ffxi.get_mob_by_id(data.targets[1].id)
+            if t and t.id == last_skillchain_id then
+                log('Skillchain is closed for [' .. last_skillchain_id .. ']')
+                last_skillchain_elements = {}
+                last_skillchain_id = 0
+                last_skillchain_time = 0
+            end
+        end
+    end
+
+    function main_engine()
+        local now = os.clock()
+        -- Spell timed out
+        if is_Busy and now - Spellstart > SpellCastTime then
+            is_Busy = false
+            SpellCastTime = 0
+        end
+        -- Make sure not update faster than .1 seconds
+        if now - main_engine_time < .1 then return end
+        -- Update the debug UI if visible
+        if settings.debug then debug_box_update() end
+        -- Go no farther as you are dead
+        if not player or player.status == "Dead" or player.status == "Engaged dead" or buffactive['Charm'] or buffactive['Sleep'] then return end
+        -- Status Ailment Check
+        if not buffactive['Paralysis'] and not buffactive['Silence'] and not buffactive['Muddle'] then
+            check_buff()
+        end
+        local position = windower.ffxi.get_mob_by_id(player.id)
+        if position and not buffactive['Mounted'] and not is_Busy then
+            local movement = math.sqrt((position.x - Location.x) ^ 2 + (position.y - Location.y) ^ 2 +
+                (position.z - Location.z) ^ 2) > 0.5
+            if movement and not is_moving then
+                if player.status ~= "Engaged" then
+                    is_moving = true
+                    Require_Update = true
+                    --windower.chat.input('/echo Moving! Status: '..player.status..'')
+                end
+            elseif not movement and is_moving then
+                is_moving = false
+                Require_Update = true
+                --windower.chat.input('/echo Stopped Moving! Status: '..player.status..'')
+            end
+            Location.x = position.x
+            Location.y = position.y
+            Location.z = position.z
+        end
+
+        if Require_Update and not is_busy then
+            equip_set_command()
+            Require_Update = false
+        end
+
+        -- 30 second cycle timer
+        if now - UpdateTime1 > 30 then
+            dual_wield_check()
+            cleanup_tagged_mobs()
+            UpdateTime1 = now
+        end
+
+        -- function used for periodic updates - feature
+        if Cycle_Timer and now - UpdateTime2 > 2 and not is_busy then
+            Cycle_Timer()
+            UpdateTime2 = now
+        end
+
+        main_engine_time = os.clock()
+    end
+
+    -- Register event section
+    windower.register_event('target change', on_target_change_for_th)
+    windower.raw_register_event('incoming chunk', on_incoming_chunk_for_th)
+    windower.raw_register_event('outgoing chunk', main_engine)
+    windower.raw_register_event('zone change', on_zone_change_for_th)
+
+    -- Auto save function for dragging and dropping status and debug boxes
+    local is_dragging = false
+    windower.register_event('mouse', function(type, x, y, delta, blocked)
+        -- Windower Type 1 = Left Click Down - sets dragging state
+        if type == 1 and (gs_status:hover(x, y) or gs_debug:hover(x, y)) then
+            is_dragging = true
+            -- Windower Type 2 = Left Click Up / Drag Release triggers saving and resets state
+        elseif type == 2 and is_dragging then
+            is_dragging = false
+            settings.Display_Box.pos.x = gs_status:settings().pos.x
+            settings.Display_Box.pos.y = gs_status:settings().pos.y
+            settings.Debug_Box.pos.x = gs_debug:settings().pos.x
+            settings.Debug_Box.pos.y = gs_debug:settings().pos.y
+
+            config.save(settings)
+            windower.add_to_chat(80, "Settings saved")
+        end
+    end)
+
+    windower.register_event('ipc message', function(msg)
+        if state.SpellReceived.value == 'OFF' then return end
+
+        if msg:startswith('MIRDAIN|SPELL|') then
+            local split_msg = msg:split("|")
+            local target_name = split_msg[4] or "Missing Target Name"
+            if string.find(target_name, player.name, 1, true) then
+                local caster_name = split_msg[3] or "Missing Caster Name"
+                local spell_id = split_msg[5] or "Missing Spell ID"
+                local time_sent = tonumber(split_msg[6]) or 9999999999999
+                local time_received = get_time()
+                debug("Targeted IPC Message Received: " ..
+                    msg .. " after " .. (time_received - time_sent) .. " ms")
+
+                if next(active_incoming_casters) == nil then
+                    cast_start_time = time_sent
+                    equip_spell_received_gear(tonumber(spell_id), "spell")
+                end
+
+                -- Add caster to active pool and refresh failsafe timer
+                active_incoming_casters[caster_name] = true
+                debug(caster_name .. " added to Active Incoming Casters (" .. count_keys(active_incoming_casters) .. ")")
+                failsafe_active = true
+                failsafe_trigger_time = os.clock() + settings.delay
+                debug(player.name .. " is targeted by " .. caster_name .. ". Gear equipped and timer refreshed.")
+            end
+        elseif msg:startswith('MIRDAIN|ABILITY|') then
+            local split_msg = msg:split("|")
+            local target_name = split_msg[4] or "Missing Target Name"
+            if string.find(target_name, player.name, 1, true) then
+                local caster_name = split_msg[3] or "Missing Caster Name"
+                local spell_id = split_msg[5] or "Missing Spell ID"
+                local time_sent = tonumber(split_msg[6]) or 9999999999999
+                local time_received = get_time()
+                debug("Targeted IPC Message Received: " ..
+                    msg .. " after " .. (time_received - time_sent) .. " ms")
+
+                if next(active_incoming_casters) == nil then
+                    cast_start_time = time_sent
+                    equip_spell_received_gear(tonumber(spell_id), "ability")
+                end
+
+                -- Add caster to active pool and refresh failsafe timer
+                active_incoming_casters[caster_name] = true
+                debug(caster_name .. " added to Active Incoming Casters (" .. count_keys(active_incoming_casters) .. ")")
+                failsafe_active = true
+                failsafe_trigger_time = os.clock() + settings.delay
+                debug(player.name .. " is targeted by " .. caster_name .. ". Gear equipped and timer refreshed.")
+            end
+        elseif msg:startswith('MIRDAIN|COMPLETE|') then
+            if next(active_incoming_casters) ~= nil then
+                debug("Targeted IPC Message Received: " .. msg)
+                local split_msg = msg:split("|")
+                local caster_name = split_msg[3]
+                local time_sent = tonumber(split_msg[4])
+                if active_incoming_casters[caster_name] then
+                    active_incoming_casters[caster_name] = nil
+                    debug(caster_name ..
+                        " finished casting after " ..
+                        (time_sent - cast_start_time) ..
+                        " ms and is removed from Active Incoming Casters (" .. count_keys(active_incoming_casters) .. ")")
+                    if next(active_incoming_casters) == nil then
+                        debug("No active incoming casts remain. Resetting gear.")
+                        if state.SpellReceived.value == 'ON-Locked' then
+                            for slot, _ in pairs(active_external_locks) do
+                                enable(slot)
+                                debug("Unlocking " .. tostring(slot))
+                            end
+                            active_external_locks = {}
+                        end
+                        equip_set_command()
+                        failsafe_active = false
+                    end
+                end
+            end
+        end
+    end)
+
+    windower.register_event('prerender', function()
+        if state.SpellReceived.value == "OFF" or not failsafe_active then return end
+
+        if os.clock() >= failsafe_trigger_time then
+            failsafe_active = false
+            failsafe_trigger_time = 0
+            active_incoming_casters = {}
+            debug("Failsafe triggered! Sending equipment reset command.")
+            for slot, _ in pairs(active_external_locks) do
+                enable(slot)
+            end
+            active_external_locks = {}
+
+            local built_set = choose_set()
+            if type(choose_set_custom) == 'function' then
+                built_set = set_combine(built_set, choose_set_custom())
+            else
+                warn('[Mirdain Spell-Rec]: choose_set_custom() not found!')
+            end
+        end
+    end)
+
+    windower.register_event('gain buff', function(id)
+        local name = res.buffs[id].en
+        if id == 6 and (Mage_Job:contains(player.main_job) or Mage_Job:contains(player.sub_job)) then
+            if player.inventory['Remedy'] ~= nil then
+                if AutoItem == true then
+                    windower.chat.input('/item "Remedy" <me>')
+                end
+            else
+                info('No Remedies in inventory.')
+            end
+        elseif id == 4 then
+            if player.inventory['Remedy'] ~= nil then
+                if AutoItem == true then
+                    windower.chat.input('/item "Remedy" <me>')
+                end
+            else
+                info('No Remedies in inventory.')
+            end
+        elseif id == 2 then
+            local built_set = {}
+            if sets.Idle then
+                built_set = sets.Idle
+            else
+                warn('sets.Idle not found!')
+            end
+            if sets.Weapons then
+                if sets.Weapons.Sleep then
+                    info('Locking Sleep Gear')
+                    built_set = set_combine(built_set, sets.Weapons.Sleep)
+                else
+                    warn('sets.Weapons.Sleep not found!')
+                end
+            else
+                warn('sets.Weapons not found!')
+            end
+            equip(built_set)
+            disable('main', 'range')
+            -- Used to wake up during sleep
+            -- Cancel stoneskin
+            if buffactive['Stoneskin'] then
+                info('Cancel Stoneskin')
+                cancel('Stoneskin')
+            end
+        elseif id == 7 then
+            log("Petrification - Checking Gear")
+            if choose_set_custom then
+                equip(set_combine(choose_set(), choose_set_custom()))
+            else
+                equip(set_combine(choose_set()))
+            end
+        elseif id == 10 then
+            log("Stunned - Checking Gear")
+            if choose_set_custom then
+                equip(set_combine(choose_set(), choose_set_custom()))
+            else
+                equip(set_combine(choose_set()))
+            end
+        elseif id == 15 then
+            info('DOOOOOOM!!!')
+            --Lock eligible slots for cursna received gear if not tracking party spellcasting through IPC
+            if state.SpellReceived.value == "OFF" then
+                if sets.Cursna_Received then
+                    equip(sets.Cursna_Received)
+                    for slot, item in pairs(sets.Cursna_Received) do
+                        disable(slot)
+                    end
+                    info('Locking Cursna Received Gear')
+                else
+                    warn('sets.Cursna_Received not found!')
+                end
+            end
+            if AutoItem then
+                if player.inventory['Holy Water'] ~= nil then -- Only here to notify player about Doom status and potential lack of Holy Waters
+                    windower.chat.input('/item "Holy Water" <me>')
+                else
+                    info('No Holy Waters in inventory. Unable to cure DOOM status!')
+                end
+            end
+        end
+    end)
+
+    windower.register_event('lose buff', function(id)
+        local name = res.buffs[id].en
+        local gain = false
+        --Unlock cursna received gear if not tracking party spellcasting through IPC
+        if id == 15 and state.SpellReceived.value == "OFF" then -- Doom
+            UnlockByMode()
+            if choose_set_custom then
+                if buff_change_custom then
+                    equip(set_combine(choose_set(), choose_set_custom(), buff_change_custom(name, gain)))
+                else
+                    equip(set_combine(choose_set(), choose_set_custom()))
+                end
+            else
+                equip(set_combine(choose_set()))
+            end
+            info('Unlocking Cursna Received Gear')
+        elseif id == 2 then -- sleep
+            UnlockByMode()
+            if choose_set_custom then
+                if buff_change_custom then
+                    equip(set_combine(choose_set(), choose_set_custom(), buff_change_custom(name, gain)))
+                else
+                    equip(set_combine(choose_set(), choose_set_custom()))
+                end
+            else
+                equip(set_combine(choose_set()))
+            end
+            info('Unlocking Sleep Gear')
+        end
+    end)
+
+    windower.register_event('chat message', function(message, sender, mode, gm)
+        --Future Hooks for PT chat or tells
+        -- Mode 3 is tell
+        -- Mode 4 is party
+        --Ignore it if it's not party chat or a tell
+        if mode ~= 3 or mode ~= 4 then
+            return
+        end
+        message = message:lower()
+        -- Example Use
+        if message:contains('hqzerg') then
+            windower.send_command('sm on')
+        end
+    end)
+
+    -- Section used to determine if player is performing an action
+    windower.register_event('action', function(data)
+        if data ~= nil then
+            --log('cat='..data.category..',param='..data.param)
+            if data.actor_id == player.id then
+                -- Ranged attack finish
+                if data.category == 2 then
+                    if data.param == 26739 then
+                        log('Player finished Shooting')
+                    end
+                    --Casting finish
+                elseif data.category == 4 then
+                    log('Casting Finished')
+                    -- Item Use
+                elseif data.category == 9 then
+                    if data.param == 24931 then
+                        log('Item use')
+                    elseif data.param == 28787 then
+                        log('Item Use Interupted')
+                        UnlockByMode()
+                        if choose_set_custom then
+                            equip(set_combine(choose_set(), choose_set_custom()))
+                        else
+                            equip(set_combine(choose_set()))
+                        end
+                    end
+                    -- Item use Finished
+                elseif data.category == 5 then
+                    if data.param == 4154 then
+                        log('Item Use Finished')
+                        UnlockByMode()
+                        if choose_set_custom then
+                            equip(set_combine(choose_set(), choose_set_custom()))
+                        else
+                            equip(set_combine(choose_set()))
+                        end
+                    end
+                    -- Casting Start
+                elseif data.category == 8 then
+                    if data.param == 28787 then
+                        log('Spell Interupt')
+                        if choose_set_custom then
+                            equip(set_combine(choose_set(), choose_set_custom()))
+                        else
+                            equip(set_combine(choose_set()))
+                        end
+                    elseif data.param == 24931 then
+                        log('Casting Spell')
+                    end
+                    -- Ranged attack start
+                elseif data.category == 12 then
+                    if data.param == 24931 then
+                        log('' .. player.name .. ' is Shooting')
+                    elseif data.param == 28787 then
+                        log('Shooting is interrupted')
+                    end
+                end
+                -- If player takes action, adjust TH tagging information
+                if state.TreasureMode.value ~= 'None' and TaggingCategories:contains(data.category) then
+                    if windower.ffxi.get_mob_by_id(data.targets[1].id).is_npc then
+                        th_info.tagged_mobs[data.targets[1].id] = os.clock()
+                        if state.TreasureMode.value ~= 'Full Time' then
+                            if choose_set_custom then
+                                equip(set_combine(choose_set(), choose_set_custom()))
+                            else
+                                equip(set_combine(choose_set()))
+                            end
+                        end
+                    elseif th_info.tagged_mobs[data.actor_id] then
+                        th_info.tagged_mobs[data.actor_id] = os.clock()
+                    else
+                        if th_info.tagged_mobs[data.targets[1].id] then
+                            th_info.tagged_mobs[data.targets[1].id] = os.clock()
+                        end
+                    end
+                end
+            end
+            -- Casting Spell
+            if data.category == 8 then
+                if data.param == 24931 then
+                    if data.targets[1].actions[1].param ~= 0 then
+                        -- Get the ability
+                        -- local ability = res.spells[targets[1].actions[1].param]
+                    end
+                    -- Spell inturpted
+                elseif data.param == 28787 then
+                end
+                -- Weaponskill Finished
+            elseif data.category == 3 and data.param ~= 0 then
+                run_burst(data)
+                -- Casting finish
+            elseif data.category == 4 then
+                run_burst(data)
+            end
+        end
+    end)
+
+    -------------------------------------------------------------------------------------------------------------------
+    -- This function is called to determine correct sets and not a built in gearswap call
+    -------------------------------------------------------------------------------------------------------------------
+
+    function choose_set()
+        if buffactive['Sleep'] then return end
+        local built_set = {}
+        -- Combat Checks
+        if player.status == "Engaged" then
+            if sets.OffenseMode then
+                built_set = sets.OffenseMode
+                if sets.OffenseMode[state.OffenseMode.value] then
+                    built_set = set_combine(built_set, sets.OffenseMode[state.OffenseMode.value])
+                    -- Check the weapons
+                    if state.WeaponMode.value ~= "Locked" then
+                        if sets.Weapons then
+                            if sets.Weapons[state.WeaponMode.value] then
+                                built_set = set_combine(built_set, sets.Weapons[state.WeaponMode.value])
+                            else
+                                warn('sets.Weapons.' .. state.WeaponMode.value .. ' not found!')
+                            end
+                        else
+                            warn('sets.Weapons not found!')
+                        end
+                        -- Equip sub weapon based off mode
+                        if not DualWield and not TwoHand then
+                            if sets.Weapons.Shield then
+                                built_set = set_combine(built_set, sets.Weapons.Shield)
+                            else
+                                warn('sets.Weapons.Shield not found!')
+                            end
+                        elseif DualWield then
+                            if sets.DualWield then
+                                built_set = set_combine(built_set, sets.DualWield)
+                            else
+                                warn('sets.DualWield not found!')
+                            end
+                        end
+                    end
+                    -- Ranged Mode
+                    if state.JobMode.value == "Ranged" then
+                        log('Ranged Mode')
+                        if sets.Idle and sets.Idle[state.OffenseMode.value] then
+                            built_set = set_combine(built_set, sets.Idle[state.OffenseMode.value])
+                        else
+                            warn('sets.Idle.' .. state.OffenseMode.value .. ' not found!')
+                        end
+                    end
+                    -- Check if AM3 is active
+                    if buffactive['Aftermath: Lv.3'] and sets.OffenseMode.AM3 and sets.OffenseMode.AM3[state.WeaponMode.value] then
+                        built_set = set_combine(built_set, sets.OffenseMode.AM3[state.WeaponMode.value])
+                    elseif buffactive['Aftermath: Lv.2'] and sets.OffenseMode.AM2 and sets.OffenseMode.AM2[state.WeaponMode.value] then
+                        built_set = set_combine(built_set, sets.OffenseMode.AM2[state.WeaponMode.value])
+                    elseif buffactive['Aftermath: Lv.1'] and sets.OffenseMode.AM1 and sets.OffenseMode.AM1[state.WeaponMode.value] then
+                        built_set = set_combine(built_set, sets.OffenseMode.AM1[state.WeaponMode.value])
+                    elseif buffactive['Aftermath'] and sets.OffenseMode.AM and sets.OffenseMode.AM[state.WeaponMode.value] then
+                        built_set = set_combine(built_set, sets.OffenseMode.AM[state.WeaponMode.value])
+                    end
+                    -- Check if TreasureMode is activew
+                    if state.TreasureMode.value ~= 'None' then
+                        if sets.TreasureHunter then
+                            -- Equip TH gear if mob is not marked as tagged
+                            if not th_info.tagged_mobs[player.target.id] then
+                                built_set = set_combine(built_set, sets.TreasureHunter)
+
+                                -- Equip TH gear if TreasureMode is Full Time
+                            elseif state.TreasureMode.value == 'Full Time' then
+                                built_set = set_combine(built_set, sets.TreasureHunter)
+
+                                -- Equip TH gear if TreasureMode is SATA and either SA, TA or Feint is active
+                            elseif state.TreasureMode.value == 'SATA' and (buffactive['Sneak Attack'] or buffactive['Trick Attack'] or buffactive['Feint']) then
+                                built_set = set_combine(built_set, sets.TreasureHunter)
+                            end
+                        else
+                            warn('sets.TreasureHunter not found!')
+                        end
+                    end
+                else
+                    warn('sets.OffenseMode.' .. state.OffenseMode.value .. ' not found!')
+                end
+            else
+                warn('sets.OffenseMode not found!')
+            end
+            -- Idle sets
+        else
+            if sets.Idle then
+                built_set = sets.Idle
+
+                -- Idle state
+                if sets.Idle[state.OffenseMode.value] then
+                    built_set = set_combine(built_set, sets.Idle[state.OffenseMode.value])
+                else
+                    warn('sets.Idle.' .. state.OffenseMode.value .. ' not found!')
+                end
+
+                -- Resting condition
+                if player.status == "Resting" then
+                    if sets.Idle.Resting then
+                        built_set = set_combine(built_set, sets.Idle.Resting)
+                    else
+                        warn('sets.Idle.Resting not found!')
+                    end
+                end
+
+                -- Check the weapons
+                if state.WeaponMode.value == "Locked" then
+                    built_set = set_combine(built_set,
+                        { main = player.equipment.main, sub = player.equipment.sub, range = player.equipment.range })
+                    log(built_set)
+                else
+                    if sets.Weapons then
+                        if sets.Weapons[state.WeaponMode.value] then
+                            built_set = set_combine(built_set, sets.Weapons[state.WeaponMode.value])
+                        else
+                            warn('sets.Weapons.' .. state.WeaponMode.value .. ' not found!')
+                        end
+                    else
+                        warn('sets.Weapons not found!')
+                    end
+
+                    -- Check for sub weapon
+                    if not TwoHand and not DualWield then
+                        if sets.Weapons.Shield then
+                            built_set = set_combine(built_set, sets.Weapons.Shield)
+                        else
+                            warn('sets.Weapons.Shield not found!')
+                        end
+                    end
+                end
+
+                --Pet specific checks
+                if pet.isvalid then
+                    if sets.Idle.Pet then
+                        built_set = set_combine(built_set, sets.Idle.Pet)
+                    else
+                        warn('sets.Idle.Pet not found!')
+                    end
+                end
+                -- Equip Sublimation gear
+                if buffactive[187] then
+                    if sets.Idle.Sublimation then
+                        built_set = set_combine(built_set, sets.Idle.Sublimation)
+                    else
+                        warn('sets.Idle.Sublimation not found!')
+                    end
+                end
+                -- Equip movement gear
+                if is_moving then
+                    if sets.Movement then
+                        built_set = set_combine(built_set, sets.Movement)
+                    else
+                        warn('sets.Movement not found!')
+                    end
+                end
+            else
+                warn('sets.Idle not found!')
+            end
+        end
+
+        -- Variable Ammo
+        if Ammo and Ammo[state.OffenseMode.value] then
+            built_set = set_combine(built_set,
+                { ammo = Ammo[state.OffenseMode.value] })
+        end
+
+        return built_set
+    end
+
+    function equip_set_command()
+        windower.send_command("gs c update auto")
+    end
+
+    -- Start the engine with a 5 sec delay
+    coroutine.schedule(display_box_update, 2)
+    coroutine.schedule(dual_wield_check, 2.1)
+    coroutine.schedule(two_hand_check, 2.2)
+    coroutine.schedule(equip_set_command, 2.3)
+    coroutine.schedule(main_engine, 2.4)
 end

--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -13,7 +13,7 @@ Original credit to Mirdain.  Pull request to be submitted after beta testing.
 ]]
 
 -- Global Variables
-Mirdain_GS = '1.6.3'
+Mirdain_GS = '1.6.4'
 
 -- Modes is the include file for a mode-tracking variable class.  Used for state vars, below.
 include('Modes')
@@ -282,7 +282,6 @@ is_Busy = false
 is_Dragging = false
 AutoItem = false
 Random_Lockstyle = false
-Target_Assist = true
 Lockstyle_List = {}
 
 Elemental_WS = S {
@@ -331,11 +330,62 @@ Dark_Enhancing = S { 'Dread Spikes', 'Endark', 'Endark II', 'Klimaform', 'Tracto
 Enhancing_Skill = S { 'Temper', 'Temper II', 'Enaero', 'Enstone', 'Enthunder', 'Enwater', 'Enfire', 'Enblizzard', 'Boost-STR', 'Boost-DEX', 'Boost-VIT', 'Boost-AGI', 'Boost-INT', 'Boost-MND', 'Boost-CHR' }
 Divine_Skill = S { 'Enlight', 'Enlight II', 'Flash', 'Repose', 'Holy', 'Holy II', 'Banish', 'Banish II', 'Banish III', 'Banishga', 'Banishga II', }
 
-BlueNuke = S { 'Spectral Floe', 'Entomb', 'Magic Hammer', 'Tenebral Crush' }
-BlueACC = S { 'Cruel Joke', 'Dream Flower', 'Reaving Wind' }
-BlueHealing = S { 'Magic Fruit', 'Healing Breeze', 'Wild Carrot', 'Plenilune Embrace', 'Restoral' }
-BlueSkill = S { 'Occultation', 'Erratic Flutter', 'Nature\'s Meditation', 'Cocoon', 'Barrier Tusk', 'Metallic Body', 'Mighty Guard' }
-BlueTank = S { 'Jettatura', 'Geist Wall', 'Blank Gaze', 'Sheep Song', 'Sandspin', 'Healing Breeze' }
+-- BluePhysical - weapon accuracy + stat mod + physical Attack.  MAB does nothing.
+-- White Wind is deliberately absent: floor(MaxHP/7)*2 scaled by Cure Potency and
+-- unaffected by Blue Magic Skill or MND, so it uses sets.Midcast['White Wind'].
+BluePhysical = S { 'Amorphic Spikes', 'Asuran Claws', 'Barbed Crescent', 'Battle Dance',
+    'Benthic Typhoon', 'Bilgestorm', 'Bloodrake', 'Bludgeon', 'Body Slam', 'Cannonball',
+    'Claw Cyclone', 'Death Scissors', 'Delta Thrust', 'Dimensional Death', 'Disseverment',
+    'Empty Thrash', 'Feather Storm', 'Final Sting', 'Foot Kick', 'Frenetic Rip', 'Frypan',
+    'Glutinous Dart', 'Goblin Rush', 'Grand Slam', 'Head Butt', 'Heavy Strike', 'Helldive',
+    'Hydro Shot', 'Hysteric Barrage', 'Jet Stream', 'Mandibular Bite', 'Paralyzing Triad',
+    'Pinecone Bomb', 'Power Attack', 'Quad. Continuum', 'Quadrastrike', 'Queasyshroom',
+    'Ram Charge', 'Saurian Slide', 'Screwdriver', 'Seedspray', 'Sickle Slash', 'Sinker Drill',
+    'Smite of Rage', 'Spinal Cleave', 'Spiral Spin', 'Sprout Smack', 'Sub-zero Smash',
+    'Sudden Lunge', 'Sweeping Gouge', 'Tail Slap', 'Terror Touch', 'Thrashing Assault',
+    'Tourbillion', 'Uppercut', 'Vanity Dive', 'Vertical Cleave', 'Whirl of Rage', 'Wild Oats' }
+-- BlueBreath   - HP and level only (Hecatomb Wave = CurrentHP/4 + Level/1.5).
+-- INT, MAB and Blue Magic Skill do nothing.
+BlueBreath = S { 'Bad Breath', 'Flying Hip Press', 'Frost Breath', 'Heat Breath',
+    'Hecatomb Wave', 'Magnetite Cloud', 'Poison Breath', 'Radiant Breath', 'Self-Destruct',
+    'Thunder Breath', 'Vapor Spray', 'Wind Breath' }
+-- BlueNuke     - magical damage (MAB, INT/MND/CHR/VIT/DEX/AGI per spell).
+BlueNuke = S { 'Acrid Stream', 'Anvil Lightning', 'Blastbomb', 'Blazing Bound',
+    'Blinding Fulgor', 'Blitzstrahl', 'Bomb Toss', 'Cesspool', 'Charged Whisker',
+    'Crashing Thunder', 'Cursed Sphere', 'Dark Orb', 'Death Ray', 'Diffusion Ray',
+    'Droning Whirlwind', 'Embalming Earth', 'Entomb', 'Evryone. Grudge', 'Eyes On Me',
+    'Firespit', 'Foul Waters', 'Gates of Hades', 'Ice Break', 'Leafstorm', 'Maelstrom',
+    'Magic Hammer', 'Mind Blast', 'Molting Plumage', 'Mysterious Light', 'Nectarous Deluge',
+    'Palling Salvo', 'Polar Roar', 'Rail Cannon', 'Regurgitation', 'Rending Deluge',
+    'Retinal Glare', 'Scouring Spate', 'Searing Tempest', 'Silent Storm', 'Spectral Floe',
+    'Subduction', 'Tearing Gust', 'Tem. Upheaval', 'Temporal Shift', 'Tenebral Crush',
+    'Thermal Pulse', 'Thunderbolt', 'Uproot', 'Water Bomb' }
+-- BlueSkill - potency scales with Blue Magic Skill (Occultation shadows =
+-- floor(skill/50); Atra. Libations drain = skill*.11*9).
+BlueSkill = S { 'Atra. Libations', 'Barrier Tusk', 'Diamondhide', 'Magic Barrier',
+    'Metallic Body', 'Occultation', 'Plasma Charge', 'Pyric Bulwark', 'Reactor Cool' }
+--   BlueBuff - fixed potency; only duration responds to gear.
+BlueBuff = S { 'Amplification', 'Animating Wail', 'Battery Charge', 'Carcharian Verve',
+    'Cocoon', 'Erratic Flutter', 'Exuviation', 'Fantod', 'Feather Barrier', 'Harden Shell',
+    'Memento Mori', 'Mighty Guard', 'Nat. Meditation', 'O. Counterstance', 'Refueling',
+    'Regeneration', 'Saline Coat', 'Triumphant Roar', 'Warm-Up', 'Winds of Promy.',
+    'Zephyr Mantle' }
+-- BlueHealing - Cure Potency, MND, Blue Magic Skill
+-- White Wind is deliberately absent: it heals floor(MaxHP/7)*2 scaled by Cure
+-- Potency and is unaffected by Blue Magic Skill or MND, so it uses its own named
+-- set (sets.Midcast["White Wind"]) rather than the healing bucket.
+BlueHealing = S { 'Healing Breeze', 'Magic Fruit', 'Plenilune Embrace', 'Pollen', 'Restoral',
+    'Wild Carrot' }
+-- BlueTank - enmity-generating enfeebles.
+BlueTank = S { 'Actinic Burst', 'Blank Gaze', 'Demoralizing Roar', 'Frightful Roar',
+    'Geist Wall', 'Jettatura', 'Sheep Song', 'Soporific', 'Stinking Gas' }
+-- BlueACC - enfeebles/debuffs wanting magic accuracy.
+BlueACC = S { '1000 Needles', 'Absolute Terror', 'Auroral Drape', 'Awful Eye',
+    'Blistering Roar', 'Blood Drain', 'Blood Saber', 'Chaotic Eye', 'Cimicine Discharge',
+    'Cold Wave', 'Corrosive Ooze', 'Cruel Joke', 'Digest', 'Dream Flower', 'Enervation',
+    'Feather Tickle', 'Filamented Hold', 'Infrasonics', 'Light of Penance', 'Lowing',
+    'MP Drainkiss', 'Mortal Ray', 'Osmosis', 'Reaving Wind', 'Sandspin', 'Sandspray',
+    'Sound Blast', 'Venom Shell', 'Voracious Trunk', 'Yawn' }
 
 Elemental_Enfeeble = S { 'Burn', 'Frost', 'Choke', 'Rasp', 'Shock', 'Drown' }
 
@@ -439,12 +489,26 @@ do
         "Aurorastorm II", "Voidstorm II", "Firestorm II", "Sandstorm II", "Rainstorm II", "Windstorm II", "Hailstorm II", "Thunderstorm II" }
 
     local UtsusemiSpell = S { 'Utsusemi: Ichi', 'Utsusemi: Ni', 'Utsusemi: San' }
+
+    -- Used only for the get_spell_recasts() pre-check in pretargetcheck().
+    local HasRecastTimer = {
+        ['WhiteMagic']   = true,
+        ['BlackMagic']   = true,
+        ['BlueMagic']    = true,
+        ['Ninjutsu']     = true,
+        ['BardSong']     = true,
+        ['Geomancy']     = true,
+        ['SummonerPact'] = true,
+        ['Trust']        = true,
+    }
+
+    -- Types that additionally arm the post-cast busy window in precast()/aftercast().
     local RecastTimers = {
         ['WhiteMagic'] = true,
         ['BlackMagic'] = true,
-        ['Ninjutsu'] = true,
-        ['BardSong'] = true,
-        ['Geomancy'] = true
+        ['Ninjutsu']   = true,
+        ['BardSong']   = true,
+        ['Geomancy']   = true,
     }
     local SleepSongs = S { 'Foe Lullaby', 'Foe Lullaby II', 'Horde Lullaby', 'Horde Lullaby II', }
 
@@ -501,9 +565,6 @@ do
     local BUFF_SLEEP, BUFF_STUN, BUFF_KO = 'Sleep', 'Stun', 'KO'
     local BUFF_PETRI, BUFF_CHARM, BUFF_TERROR = 'Petrification', 'Charm', 'Terror'
     local TYPE_JA, TYPE_WS, TYPE_MS, TYPE_SCH = 'JobAbility', 'WeaponSkill', 'Magic', 'Scholar'
-    local TARGET_SELF, TARGET_ENEMY = '{Self}', '{Enemy}'
-    local TARGET_PARTY1 = '{Self, Party}'
-    local TARGET_PARTY2 = '{Self, Party, Ally, NPC}'
 
     -- Tracking vars for TH
     local th_info = {}
@@ -676,6 +737,48 @@ do
         return false
     end
 
+    -- Canonical slot names, mirroring GearSwap's default_slot_map (statics.lua:148).
+    local CANON_SLOT = {
+        main = 'main',
+        sub = 'sub',
+        range = 'range',
+        ranged = 'range',
+        ammo = 'ammo',
+        head = 'head',
+        body = 'body',
+        hands = 'hands',
+        legs = 'legs',
+        feet = 'feet',
+        neck = 'neck',
+        waist = 'waist',
+        back = 'back',
+        ear1 = 'left_ear',
+        ear2 = 'right_ear',
+        lear = 'left_ear',
+        rear = 'right_ear',
+        learring = 'left_ear',
+        rearring = 'right_ear',
+        left_ear = 'left_ear',
+        right_ear = 'right_ear',
+        ring1 = 'left_ring',
+        ring2 = 'right_ring',
+        lring = 'left_ring',
+        rring = 'right_ring',
+        left_ring = 'left_ring',
+        right_ring = 'right_ring',
+    }
+
+    -- In-place equivalent of: built_set = set_combine(built_set, layer)
+    -- Reduces table creation and GC from set_combine
+    local function merge_into(base, layer)
+        if type(layer) ~= 'table' then return base end
+        for slot, item in pairs(layer) do
+            local canon = CANON_SLOT[slot] or (type(slot) == 'string' and CANON_SLOT[slot:lower()])
+            if canon then base[canon] = item end
+        end
+        return base
+    end
+
     --Given the mob being targeted and the name currently addressed on the outgoing IPC message,
     --expand target_name to a comma-separated list of party members within AoE range (10 yalms),
     --or return it unchanged if the target isn't a valid AoE candidate.
@@ -684,10 +787,10 @@ do
         if not (party and is_target_in_party(target_name, party)) then
             return target_name
         end
-    
+
         local count = 0
         for k in pairs(NEARBY_MEMBERS_BUFFER) do NEARBY_MEMBERS_BUFFER[k] = nil end
-    
+
         for slot, member in pairs(party) do
             if type(member) == 'table' and member.name then
                 local m_mob = get_mob_by_name(member.name)
@@ -707,13 +810,13 @@ do
                 end
             end
         end
-    
+
         if count > 0 then
             return table.concat(NEARBY_MEMBERS_BUFFER, ",")
         end
         return target_name
     end
-    
+
     --Calculate and return how many strategems are off cooldown.
     local function get_current_stratagem_count()
         local charge_cooldown = windower.ffxi.get_ability_recasts()[231] or 0
@@ -934,21 +1037,25 @@ do
 
                     local target_name = spell.target.name
                     outgoing_cast_active = true
-                    if settings.debug then debug(player.name .. ' is using tracked ability measured at pretarget: ' ..
-                        spell.name .. ' on ' .. target_name .. ' at ' .. get_time()) end
+                    if settings.debug then
+                        debug(player.name .. ' is using tracked ability measured at pretarget: ' ..
+                            spell.name .. ' on ' .. target_name .. ' at ' .. get_time())
+                    end
 
                     --AoE Checks
                     if a_info.aoe then
                         if settings.debug then debug("AoE Ability Cast Detected.  Calculating targets.") end
                         target_name = resolve_aoe_target_name(target_mob, target_name)
                     end
-                    if settings.debug then debug(string.format("IPC message sent: MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name,
-                        spell.id, get_time())) end
+                    if settings.debug then
+                        debug(string.format("IPC message sent: MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name,
+                            spell.id, get_time()))
+                    end
                     send_ipc(string.format("MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name, spell.id,
                         get_time()))
                 end
             end
-        elseif RecastTimers[s_type] then
+        elseif HasRecastTimer[s_type] then
             local recast_time = get_spell_recasts()[spell.recast_id]
             if recast_time and recast_time > 0 then
                 local total_sec = recast_time / 60
@@ -956,55 +1063,6 @@ do
                     ' [' .. math.floor(total_sec / 60) .. ':' .. string.format("%02d", total_sec % 60) .. ']')
                 cancel_spell()
                 return
-            end
-            if target_assist then
-                local t_type = spell.target.type
-
-                if not t_type and s_type == 'BardSong' then
-                    if active_buffs['Pianissimo'] then
-                        cancel_spell()
-                        windower.chat.input('/ma "' .. spell.name .. '" ' .. (not is_Pianissimo and '<stpc>' or '<me>'))
-                        is_Pianissimo = not is_Pianissimo
-                    else
-                        change_target('<me>')
-                    end
-                elseif t_type then
-                    local cast_spell = res.spells[spell.id]
-                    if not cast_spell or not cast_spell.targets then
-                        info('Unable to find spell [' .. spell.name .. ']')
-                    else
-                        local s_targets = cast_spell.targets
-
-                        if s_targets[TARGET_SELF] and t_type ~= 'SELF' then
-                            change_target('<me>')
-                        elseif s_targets[TARGET_ENEMY] then
-                            if t_type ~= 'MONSTER' and not spell.name:contains('Lullaby') and not spell.name:contains('Sleep') then
-                                cancel_spell()
-                                return
-                            end
-                        elseif s_targets[TARGET_PARTY1] or s_targets[TARGET_PARTY2] then
-                            if t_type == 'MONSTER' then
-                                if s_type == 'BardSong' then
-                                    if active_buffs['Pianissimo'] then
-                                        cancel_spell()
-                                        windower.chat.input('/ma "' ..
-                                            spell.name .. '" ' .. (not is_Pianissimo and '<stpc>' or '<me>'))
-                                        is_Pianissimo = not is_Pianissimo
-                                    else
-                                        change_target('<me>')
-                                    end
-                                else
-                                    cancel_spell()
-                                    return
-                                end
-                            elseif s_type == 'BardSong' and t_type == 'SELF' and active_buffs['Pianissimo'] then
-                                cancel_spell()
-                                windower.chat.input('/ma "' .. spell.name .. '" <stpc>')
-                                return
-                            end
-                        end
-                    end
-                end
             end
 
             --Check for spell casts that are tracked for spell-received gear swapping
@@ -1017,9 +1075,11 @@ do
                 local target_name = spell.target.name
                 outgoing_cast_active = true
 
-                if settings.debug then debug(player.name ..
-                    ' is using tracked spell measured at pretarget: ' ..
-                    spell.name .. ' on ' .. target_name .. ' at ' .. get_time()) end
+                if settings.debug then
+                    debug(player.name ..
+                        ' is using tracked spell measured at pretarget: ' ..
+                        spell.name .. ' on ' .. target_name .. ' at ' .. get_time())
+                end
 
                 local accession_active = active_buffs[366] or active_buffs['Accession']
                 local majesty_active = active_buffs[621] or active_buffs['Majesty']
@@ -1031,8 +1091,11 @@ do
                     if settings.debug then debug("AoE Spell Cast Detected. Calculating targets.") end
                     target_name = resolve_aoe_target_name(target_mob, target_name)
                 end
-                if settings.debug then debug(string.format("IPC message sent: MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id,
-                    get_time())) end
+                if settings.debug then
+                    debug(string.format("IPC message sent: MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name,
+                        spell.id,
+                        get_time()))
+                end
                 send_ipc(string.format("MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id, get_time()))
             end
         elseif s_type == TYPE_SCH then
@@ -1053,39 +1116,41 @@ do
 
     function precastequip(spell)
         log('precastequip Called')
-        if settings.debug then debug("spell.type = " ..
-            spell.type ..
-            " , spell.action_type = " ..
-            spell.action_type .. " , spell.english = " .. spell.english .. " , spell.name = " .. spell.name) end
+        if settings.debug then
+            debug("spell.type = " ..
+                spell.type ..
+                " , spell.action_type = " ..
+                spell.action_type .. " , spell.english = " .. spell.english .. " , spell.name = " .. spell.name)
+        end
         --Cancel for SMN if Avatar is mid action
         if pet.isvalid and pet_midaction() then return end
         --Default gearset
         local built_set = {}
         -- Merge the Idle incase a midcast is not set
-        if sets.Idle then built_set = set_combine(built_set, sets.Idle) end
+        if sets.Idle then merge_into(built_set, sets.Idle) end
         -- WeaponSkill
         if spell.type == 'WeaponSkill' then
             if sets.WS then
-                built_set = set_combine(built_set, sets.WS)
+                merge_into(built_set, sets.WS)
                 local message = ''
                 if spell.skill == "Marksmanship" or spell.skill == "Archery" then
                     -- Try to equip a generic ranged WS set
                     if sets.WS.RA then
-                        built_set = set_combine(built_set, sets.WS.RA)
+                        merge_into(built_set, sets.WS.RA)
                     else
                         warn('sets.WS.RA not found!')
                     end
 
                     -- Set is defined
                     if sets.WS[spell.english] then
-                        built_set = set_combine(built_set, sets.WS[spell.english])
+                        merge_into(built_set, sets.WS[spell.english])
                         -- Example would be WS[Savage Blade]['PDL']
                         if sets.WS[spell.english][state.OffenseMode.value] then
-                            built_set = set_combine(built_set, sets.WS[spell.english][state.OffenseMode.value])
+                            merge_into(built_set, sets.WS[spell.english][state.OffenseMode.value])
                             message = '[' .. spell.english .. '] Set (Augmented)'
                             -- Example would be WS.RA.ACC
                         elseif state.OffenseMode.value ~= 'TP' and sets.WS.RA and sets.WS.RA[state.OffenseMode.value] then
-                            built_set = set_combine(built_set, sets.WS.RA[state.OffenseMode.value])
+                            merge_into(built_set, sets.WS.RA[state.OffenseMode.value])
                             -- Augment the specified WS
                             if state.OffenseMode.value == 'ACC' then
                                 message = '[' .. spell.english .. '] Set with Accuracy'
@@ -1105,7 +1170,7 @@ do
                         -- Generic
                     else
                         if state.OffenseMode.value ~= 'TP' and sets.WS.RA and sets.WS.RA[state.OffenseMode.value] then
-                            built_set = set_combine(built_set, sets.WS.RA[state.OffenseMode.value])
+                            merge_into(built_set, sets.WS.RA[state.OffenseMode.value])
                             if state.OffenseMode.value == 'ACC' then
                                 message = 'Using Default WS Set with Accuracy'
                             elseif state.OffenseMode.value == 'PDL' then
@@ -1125,16 +1190,16 @@ do
                     -- Check if Aftermath is active
                     if sets.WS.RA then
                         if buffactive['Aftermath: Lv.3'] and sets.WS.RA.AM3 and sets.WS.RA.AM3[state.WeaponMode.value] then
-                            built_set = set_combine(built_set, sets.WS.RA.AM3[state.WeaponMode.value])
+                            merge_into(built_set, sets.WS.RA.AM3[state.WeaponMode.value])
                             message = message .. ' and Level 3 Aftermath [' .. state.WeaponMode.value .. ']'
                         elseif buffactive['Aftermath: Lv.2'] and sets.WS.RA.AM2 and sets.WS.RA.AM2[state.WeaponMode.value] then
-                            built_set = set_combine(built_set, sets.WS.RA.AM2[state.WeaponMode.value])
+                            merge_into(built_set, sets.WS.RA.AM2[state.WeaponMode.value])
                             message = message .. ' and Level 2 Aftermath [' .. state.WeaponMode.value .. ']'
                         elseif buffactive['Aftermath: Lv.1'] and sets.WS.RA.AM1 and sets.WS.RA.AM1[state.WeaponMode.value] then
-                            built_set = set_combine(built_set, sets.WS.RA.AM1[state.WeaponMode.value])
+                            merge_into(built_set, sets.WS.RA.AM1[state.WeaponMode.value])
                             message = message .. ' and Level 1 Aftermath [' .. state.WeaponMode.value .. ']'
                         elseif buffactive['Aftermath'] and sets.WS.RA.AM and sets.WS.RA.AM[state.WeaponMode.value] then
-                            built_set = set_combine(built_set, sets.WS.RA.AM[state.WeaponMode.value])
+                            merge_into(built_set, sets.WS.RA.AM[state.WeaponMode.value])
                             message = message .. ' and Aftermath [' .. state.WeaponMode.value .. ']'
                         end
                     end
@@ -1144,7 +1209,7 @@ do
 
                     -- Variable Ammo
                     if Ammo and Ammo[state.OffenseMode.value] then
-                        built_set = set_combine(built_set,
+                        merge_into(built_set,
                             { ammo = Ammo[state.OffenseMode.value] })
                     end
 
@@ -1152,14 +1217,14 @@ do
                 else
                     -- Set is defined
                     if sets.WS[spell.english] then
-                        built_set = set_combine(built_set, sets.WS[spell.english])
+                        merge_into(built_set, sets.WS[spell.english])
                         -- Example would be WS[Savage Blade]['PDL']
                         if sets.WS[spell.english][state.OffenseMode.value] then
-                            built_set = set_combine(built_set, sets.WS[spell.english][state.OffenseMode.value])
+                            merge_into(built_set, sets.WS[spell.english][state.OffenseMode.value])
                             message = '[' .. spell.english .. '] Set (Augmented)'
                             -- Example would be WS.ACC
                         elseif state.OffenseMode.value ~= 'TP' and sets.WS[state.OffenseMode.value] then
-                            built_set = set_combine(built_set, sets.WS[state.OffenseMode.value])
+                            merge_into(built_set, sets.WS[state.OffenseMode.value])
                             -- Augment the specified WS
                             if state.OffenseMode.value == 'ACC' then
                                 message = '[' .. spell.english .. '] Set with Accuracy'
@@ -1179,7 +1244,7 @@ do
                         -- Generic
                     else
                         if state.OffenseMode.value ~= 'TP' and sets.WS[state.OffenseMode.value] then
-                            built_set = set_combine(built_set, sets.WS[state.OffenseMode.value])
+                            merge_into(built_set, sets.WS[state.OffenseMode.value])
                             -- Augment the specified WS
                             if state.OffenseMode.value == 'ACC' then
                                 message = 'Using Default WS Set with Accuracy'
@@ -1199,16 +1264,16 @@ do
 
                     -- Check if Aftermath is active
                     if buffactive['Aftermath: Lv.3'] and sets.WS.AM3 and sets.WS.AM3[state.WeaponMode.value] then
-                        built_set = set_combine(built_set, sets.WS.AM3[state.WeaponMode.value])
+                        merge_into(built_set, sets.WS.AM3[state.WeaponMode.value])
                         message = message .. ' and Level 3 Aftermath'
                     elseif buffactive['Aftermath: Lv.2'] and sets.WS.AM2 and sets.WS.AM2[state.WeaponMode.value] then
-                        built_set = set_combine(built_set, sets.WS.AM2[state.WeaponMode.value])
+                        merge_into(built_set, sets.WS.AM2[state.WeaponMode.value])
                         message = message .. ' and Level 2 Aftermath'
                     elseif buffactive['Aftermath: Lv.1'] and sets.WS.AM1 and sets.WS.AM1[state.WeaponMode.value] then
-                        built_set = set_combine(built_set, sets.WS.AM1[state.WeaponMode.value])
+                        merge_into(built_set, sets.WS.AM1[state.WeaponMode.value])
                         message = message .. ' and Level 1 Aftermath'
                     elseif buffactive['Aftermath'] and sets.WS.AM and sets.WS.AM[state.WeaponMode.value] then
-                        built_set = set_combine(built_set, sets.WS.AM[state.WeaponMode.value])
+                        merge_into(built_set, sets.WS.AM[state.WeaponMode.value])
                         message = message .. ' and Aftermath'
                     end
                 end
@@ -1223,24 +1288,24 @@ do
             -- Ranged attack
         elseif spell.action_type == 'Ranged Attack' then
             if sets.Precast then
-                built_set = set_combine(built_set, sets.Precast)
+                merge_into(built_set, sets.Precast)
                 if sets.Precast.RA then
-                    built_set = set_combine(built_set, sets.Precast.RA)
+                    merge_into(built_set, sets.Precast.RA)
                     if buffactive[265] then -- Flurry
                         if sets.Precast.RA.Flurry then
-                            built_set = set_combine(built_set, sets.Precast.RA.Flurry)
+                            merge_into(built_set, sets.Precast.RA.Flurry)
                         else
                             warn('sets.Precast.RA.Flurry not found!')
                         end
                     elseif buffactive[581] then -- Flurry II
                         if sets.Precast.RA.Flurry_II then
-                            built_set = set_combine(built_set, sets.Precast.RA.Flurry_II)
+                            merge_into(built_set, sets.Precast.RA.Flurry_II)
                         else
                             warn('sets.Precast.RA.Flurry_II not found!')
                         end
                     elseif buffactive[228] then -- Embrava
                         if sets.Precast.RA.Flurry_II then
-                            built_set = set_combine(built_set, sets.Precast.RA.Flurry_II)
+                            merge_into(built_set, sets.Precast.RA.Flurry_II)
                         else
                             warn('sets.Precast.RA.Flurry_II not found!')
                         end
@@ -1248,7 +1313,7 @@ do
 
                     -- Variable Ammo
                     if Ammo and Ammo[state.OffenseMode.value] then
-                        built_set = set_combine(built_set,
+                        merge_into(built_set,
                             { ammo = Ammo[state.OffenseMode.value] })
                     end
                 else
@@ -1263,20 +1328,20 @@ do
             -- JobAbility
         elseif spell.type == 'JobAbility' then
             if sets.JA then
-                built_set = set_combine(built_set, sets.JA)
+                merge_into(built_set, sets.JA)
                 if spell.name == 'Double-Up' then -- Double Up for distance
                     if sets.PhantomRoll then
-                        built_set = set_combine(built_set, sets.PhantomRoll)
+                        merge_into(built_set, sets.PhantomRoll)
                         info('[' .. spell.english .. '] Set')
                     else
                         warn('sets.PhantomRoll not found!')
                     end
                 elseif sets.JA[spell.english] then
-                    built_set = set_combine(built_set, sets.JA[spell.english])
+                    merge_into(built_set, sets.JA[spell.english])
                     --Summon the correct jug pet
                     if spell.name == 'Bestial Loyalty' or spell.name == 'Call Beast' then
                         if sets.Jugs[state.JobMode.value] then
-                            built_set = set_combine(built_set, sets.Jugs[state.JobMode.value])
+                            merge_into(built_set, sets.Jugs[state.JobMode.value])
                         else
                             warn('sets.Jugs.' .. state.JobMode.value .. ' not found!')
                         end
@@ -1303,7 +1368,7 @@ do
                 info("Holy Water set")
                 if sets.Holy_Water then
                     if sets.Idle then
-                        built_set = set_combine(sets.Idle, sets.Holy_Water)
+                        merge_into(built_set, sets.Holy_Water)
                     else
                         warn('sets.Idle not found!')
                     end
@@ -1312,7 +1377,7 @@ do
                 end
             else
                 if sets.Idle then
-                    built_set = sets.Idle
+                    merge_into(built_set, sets.Idle)
                 else
                     warn('sets.Idle not found!')
                 end
@@ -1324,9 +1389,9 @@ do
                 if settings.debug then debug("Accession detected while tracking. Accession_Predicted = True") end
             end
             if sets.JA then
-                built_set = set_combine(built_set, sets.JA)
+                merge_into(built_set, sets.JA)
                 if sets.JA[spell.english] then
-                    built_set = set_combine(built_set, sets.JA[spell.english])
+                    merge_into(built_set, sets.JA[spell.english])
                     info('[' .. spell.english .. '] Set')
                 else
                     info('Using Default Scholar Set')
@@ -1337,9 +1402,9 @@ do
             -- Ward
         elseif spell.type == 'Ward' then
             if sets.JA then
-                built_set = set_combine(built_set, sets.JA)
+                merge_into(built_set, sets.JA)
                 if sets.JA[spell.english] then
-                    built_set = set_combine(built_set, sets.JA[spell.english])
+                    merge_into(built_set, sets.JA[spell.english])
                     info('[' .. spell.english .. '] Set')
                 else
                     info('Using Default Ward Set')
@@ -1350,9 +1415,9 @@ do
             -- Rune
         elseif spell.type == 'Rune' then
             if sets.JA then
-                built_set = set_combine(built_set, sets.JA)
+                merge_into(built_set, sets.JA)
                 if sets.JA[spell.english] then
-                    built_set = set_combine(built_set, sets.JA[spell.english])
+                    merge_into(built_set, sets.JA[spell.english])
                     info('[' .. spell.english .. '] Set')
                 else
                     info('Using Default Rune Set')
@@ -1363,9 +1428,9 @@ do
             -- Effusion
         elseif spell.type == 'Effusion' then
             if sets.JA then
-                built_set = set_combine(built_set, sets.JA)
+                merge_into(built_set, sets.JA)
                 if sets.JA[spell.english] then
-                    built_set = set_combine(built_set, sets.JA[spell.english])
+                    merge_into(built_set, sets.JA[spell.english])
                     info('[' .. spell.english .. '] Set')
                 else
                     info('Using Default Effusion Set')
@@ -1377,9 +1442,9 @@ do
         elseif spell.type == 'CorsairRoll' then
             log('CorsairRoll')
             if sets.PhantomRoll then
-                built_set = set_combine(built_set, sets.PhantomRoll)
+                merge_into(built_set, sets.PhantomRoll)
                 if sets.PhantomRoll[spell.english] then
-                    built_set = set_combine(built_set, sets.PhantomRoll[spell.english])
+                    merge_into(built_set, sets.PhantomRoll[spell.english])
                     info('[' .. spell.english .. '] Set ')
                 else
                     info('Roll not set')
@@ -1390,9 +1455,9 @@ do
             -- CorsairShot
         elseif spell.type == 'CorsairShot' then
             if sets.QuickDraw then
-                built_set = set_combine(built_set, sets.QuickDraw)
+                merge_into(built_set, sets.QuickDraw)
                 if sets.QuickDraw[spell.english] then
-                    built_set = set_combine(built_set, sets.QuickDraw[spell.english])
+                    merge_into(built_set, sets.QuickDraw[spell.english])
                     info('[' .. spell.english .. '] Set')
                 else
                     info('Using Default Quick Draw Set')
@@ -1403,9 +1468,9 @@ do
             -- Waltz
         elseif spell.type == 'Waltz' then
             if sets.Waltz then
-                built_set = set_combine(built_set, sets.Waltz)
+                merge_into(built_set, sets.Waltz)
                 if sets.Waltz[spell.english] then
-                    built_set = set_combine(built_set, sets.Waltz[spell.english])
+                    merge_into(built_set, sets.Waltz[spell.english])
                     info('[' .. spell.english .. '] Set')
                 else
                     info('Using Default Waltz Set')
@@ -1413,9 +1478,9 @@ do
             else
                 warn('sets.Waltz not found!')
             end
+
             --Check for ability casts that are tracked for spell-received gear swapping
             --Notify eligible targets via IPC that a tracked spell is incoming
-
             if state.SpellReceived.value ~= "OFF" then
                 local a_info = ability_info[spell.id]
                 if a_info and not outgoing_cast_active then
@@ -1424,16 +1489,20 @@ do
 
                     local target_name = spell.target.name
                     outgoing_cast_active = true
-                    if settings.debug then debug(player.name .. ' is using tracked ability measured at precast: ' ..
-                        spell.name .. ' on ' .. target_name .. ' at ' .. get_time()) end
+                    if settings.debug then
+                        debug(player.name .. ' is using tracked ability measured at precast: ' ..
+                            spell.name .. ' on ' .. target_name .. ' at ' .. get_time())
+                    end
 
                     --AoE Checks
                     if a_info.aoe then
                         if settings.debug then debug("AoE Ability Cast Detected.  Calculating targets.") end
                         target_name = resolve_aoe_target_name(target_mob, target_name)
                     end
-                    if settings.debug then debug(string.format("IPC message sent: MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name,
-                        spell.id, get_time())) end
+                    if settings.debug then
+                        debug(string.format("IPC message sent: MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name,
+                            spell.id, get_time()))
+                    end
                     send_ipc(string.format("MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name, spell.id,
                         get_time()))
                 end
@@ -1441,9 +1510,9 @@ do
             -- Jig
         elseif spell.type == 'Jig' then
             if sets.Jig then
-                built_set = set_combine(built_set, sets.Jig)
+                merge_into(built_set, sets.Jig)
                 if sets.Jig[spell.english] then
-                    built_set = set_combine(built_set, sets.Jig[spell.english])
+                    merge_into(built_set, sets.Jig[spell.english])
                     info('[' .. spell.english .. '] Set')
                 else
                     info('Using Default Jig Set')
@@ -1454,9 +1523,9 @@ do
             -- Samba
         elseif spell.type == 'Samba' then
             if sets.Samba then
-                built_set = set_combine(built_set, sets.Samba)
+                merge_into(built_set, sets.Samba)
                 if sets.Samba[spell.english] then
-                    built_set = set_combine(built_set, sets.Samba[spell.english])
+                    merge_into(built_set, sets.Samba[spell.english])
                     info('[' .. spell.english .. '] Set')
                 else
                     info('Using Default Samba Set')
@@ -1467,9 +1536,9 @@ do
             -- Step
         elseif spell.type == 'Step' then
             if sets.Step then
-                built_set = set_combine(built_set, sets.Step)
+                merge_into(built_set, sets.Step)
                 if sets.Step[spell.english] then
-                    built_set = set_combine(built_set, sets.Step[spell.english])
+                    merge_into(built_set, sets.Step[spell.english])
                     info('[' .. spell.english .. '] Set')
                 else
                     info('Using Default Step Set')
@@ -1480,9 +1549,9 @@ do
             -- Flourishes
         elseif spell.type == 'Flourish1' or spell.type == 'Flourish2' or spell.type == 'Flourish3' then
             if sets.Flourish then
-                built_set = set_combine(built_set, sets.Flourish)
+                merge_into(built_set, sets.Flourish)
                 if sets.Flourish[spell.english] then
-                    built_set = set_combine(built_set, sets.Flourish[spell.english])
+                    merge_into(built_set, sets.Flourish[spell.english])
                     info('[' .. spell.english .. '] Set')
                 else
                     info('Using Default Flourish Set')
@@ -1494,32 +1563,32 @@ do
         else
             -- Precast
             if sets.Precast then
-                built_set = set_combine(built_set, sets.Precast)
+                merge_into(built_set, sets.Precast)
                 -- FastCast
                 if sets.Precast.FastCast then
-                    built_set = set_combine(built_set, sets.Precast.FastCast)
+                    merge_into(built_set, sets.Precast.FastCast)
                     -- Augment with Enhancing set
                     if spell.skill == 'Enhancing Magic' then
                         if sets.Precast.Enhancing then
-                            built_set = set_combine(built_set, sets.Precast.Enhancing)
+                            merge_into(built_set, sets.Precast.Enhancing)
                         else
                             warn('sets.Precast.Enhancing not found!')
                         end
                     end
                     -- Specified Sets
                     if sets.Precast[spell.english] then
-                        built_set = set_combine(built_set, sets.Precast[spell.english])
+                        merge_into(built_set, sets.Precast[spell.english])
                         -- Augment with Cure Casting set
                     elseif spell.name:contains('Cure') or spell.name:contains('Cura') then
                         if sets.Precast.Cure then
-                            built_set = set_combine(built_set, sets.Precast.Cure)
+                            merge_into(built_set, sets.Precast.Cure)
                         else
                             warn('sets.Precast.Cure not found!')
                         end
                         -- Augment with Healing Magic set
                     elseif Healing_Magic:contains(spell.name) then
                         if sets.Precast.Healing then
-                            built_set = set_combine(built_set, sets.Precast.Healing)
+                            merge_into(built_set, sets.Precast.Healing)
                         else
                             warn('sets.Precast.Healing not found!')
                         end
@@ -1527,14 +1596,14 @@ do
                     elseif spell.type == 'Ninjutsu' and UtsusemiSpell:contains(spell.name) then
                         do_Utsu_checks(spell)
                         if sets.Precast.Utsusemi then
-                            built_set = set_combine(built_set, sets.Precast.Utsusemi)
+                            merge_into(built_set, sets.Precast.Utsusemi)
                         else
                             warn('sets.Precast.Utsusemi not found!')
                         end
                         -- Blue Magic
                     elseif spell.type == 'BlueMagic' then
                         if sets.Precast.BlueMagic then
-                            built_set = set_combine(built_set, sets.Precast.BlueMagic)
+                            merge_into(built_set, sets.Precast.BlueMagic)
                         else
                             warn('sets.Precast.BlueMagic not found!')
                         end
@@ -1543,49 +1612,49 @@ do
                         if buffactive['Nightingale'] then
                             -- Default BRD song gear is in Midcast
                             if sets.Midcast then
-                                built_set = set_combine(built_set, sets.Midcast)
+                                merge_into(built_set, sets.Midcast)
                             else
                                 warn('sets.Midcast not found!')
                             end
                             -- Song Count for Dummy Songs
                             if SongCount:contains(spell.name) then
                                 if sets.Midcast.DummySongs then
-                                    built_set = set_combine(built_set, sets.Midcast.DummySongs)
+                                    merge_into(built_set, sets.Midcast.DummySongs)
                                 else
                                     warn('sets.Midcast.DummySongs not found!')
                                 end
-                                built_set = set_combine(built_set, { range = Instrument.Count })
+                                merge_into(built_set, { range = Instrument.Count })
                                 -- Potency / Instruments
                             else
                                 -- Defined Gear Set
                                 if sets.Midcast[spell.english] then
-                                    built_set = set_combine(built_set, sets.Midcast[spell.english])
+                                    merge_into(built_set, sets.Midcast[spell.english])
                                     -- Equip Harp
                                 elseif spell.name:contains('Horde') then
                                     if sets.Midcast.Enfeebling then
-                                        built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                                        merge_into(built_set, sets.Midcast.Enfeebling)
                                     else
                                         warn('sets.Midcast.Enfeebling not found!')
                                     end
-                                    built_set = set_combine(built_set, { range = Instrument.AOE_Sleep })
+                                    merge_into(built_set, { range = Instrument.AOE_Sleep })
                                     -- Normal Enfeebles
                                 elseif Enfeebling_Song:contains(spell.english) then
                                     if sets.Midcast.Enfeebling then
-                                        built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                                        merge_into(built_set, sets.Midcast.Enfeebling)
                                     else
                                         warn('sets.Midcast.Enfeebling not found!')
                                     end
-                                    built_set = set_combine(built_set, { range = Instrument.Potency })
+                                    merge_into(built_set, { range = Instrument.Potency })
                                     -- Augment the buff songs
                                 else
-                                    built_set = set_combine(built_set, { range = Instrument.Potency })
+                                    merge_into(built_set, { range = Instrument.Potency })
                                 end
                                 -- Augment the specific Song if set
-                                built_set = set_combine(built_set, equip_song_gear(spell, built_set['range']))
+                                merge_into(built_set, equip_song_gear(spell, built_set['range']))
                             end
                         else
                             if sets.Precast.Songs then
-                                built_set = set_combine(built_set, sets.Precast.Songs)
+                                merge_into(built_set, sets.Precast.Songs)
                             else
                                 warn('sets.Precast.Songs not found!')
                             end
@@ -1607,9 +1676,11 @@ do
                 local target_name = spell.target.name
                 outgoing_cast_active = true
 
-                if settings.debug then debug(player.name ..
-                    ' is using tracked spell measured at precast: ' ..
-                    spell.name .. ' on ' .. target_name .. ' at ' .. get_time()) end
+                if settings.debug then
+                    debug(player.name ..
+                        ' is using tracked spell measured at precast: ' ..
+                        spell.name .. ' on ' .. target_name .. ' at ' .. get_time())
+                end
                 local active_buffs = buffactive
                 local accession_active = active_buffs[366] or active_buffs['Accession']
                 local majesty_active = active_buffs[621] or active_buffs['Majesty']
@@ -1621,7 +1692,10 @@ do
                     if settings.debug then debug("AoE Spell Cast Detected. Calculating targets.") end
                     target_name = resolve_aoe_target_name(target_mob, target_name)
                 end
-                if settings.debug then debug(string.format("IPC message sent: MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id, get_time())) end
+                if settings.debug then
+                    debug(string.format("IPC message sent: MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name,
+                        target_name, spell.id, get_time()))
+                end
                 send_ipc(string.format("MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id, get_time()))
             end
         end
@@ -1631,15 +1705,15 @@ do
         if state.WeaponMode.value ~= "Unlocked" and spell.type ~= 'CorsairRoll' and spell.name ~= 'Double-Up' then
             log('Update Weapons - Precast')
             if state.WeaponMode.value == "Locked" then
-                built_set = set_combine(built_set,
+                merge_into(built_set,
                     { main = player.equipment.main, sub = player.equipment.sub, range = player.equipment.range })
             else
                 if sets.Weapons then
                     if sets.Weapons[state.WeaponMode.value] then
-                        built_set = set_combine(built_set, sets.Weapons[state.WeaponMode.value])
+                        merge_into(built_set, sets.Weapons[state.WeaponMode.value])
                         if not TwoHand and not DualWield then
                             if sets.Weapons.Shield then
-                                built_set = set_combine(built_set, sets.Weapons.Shield)
+                                merge_into(built_set, sets.Weapons.Shield)
                             else
                                 warn('sets.Weapons.Shield not found!')
                             end
@@ -1657,16 +1731,16 @@ do
         if spell.type == 'BardSong' then --and spell.target.type ~= 'MONSTER' then
             if sets.Weapons then
                 if sets.Weapons.Songs then
-                    built_set = set_combine(built_set, sets.Weapons.Songs)
+                    merge_into(built_set, sets.Weapons.Songs)
                     if sets.Weapons.Songs.Midcast then
                         if not DualWield and not TwoHand then
                             if sets.Weapons.Shield then
-                                built_set = set_combine(built_set, sets.Weapons.Shield)
+                                merge_into(built_set, sets.Weapons.Shield)
                             else
                                 warn('sets.Weapons.Shield not found!')
                             end
                         end
-                        built_set = set_combine(built_set, sets.Weapons.Songs.Midcast)
+                        merge_into(built_set, sets.Weapons.Songs.Midcast)
                     else
                         warn('sets.Weapons.Songs.Midcast not found!')
                     end
@@ -1681,7 +1755,7 @@ do
         --[[ If TH mode is on - check if new mob and then equip TH gear
         if state.TreasureMode.value ~= 'None' and spell.target.type == 'MONSTER' and not th_info.tagged_mobs[spell.target.id] then
             if sets.TreasureHunter then
-                built_set = set_combine(built_set, sets.TreasureHunter)
+                merge_into(built_set, sets.TreasureHunter)
                 info('[' .. spell.english .. '] Set with Treasure Hunter')
             else
                 warn('sets.TreasureHunter not found!')
@@ -1758,13 +1832,13 @@ do
         --Default gearset
         local built_set = {}
         -- Merge the Idle incase a midcast is not set
-        if sets.Idle then built_set = set_combine(built_set, sets.Idle) end
+        if sets.Idle then merge_into(built_set, sets.Idle) end
         -- Merget the Midcast Set
         if sets.Midcast then
-            built_set = set_combine(built_set, sets.Midcast)
+            merge_into(built_set, sets.Midcast)
             -- Spell interruption Down for the rest of the actions
             if sets.Midcast.SIRD and spell.action_type ~= 'Ranged Attack' then
-                built_set = set_combine(built_set,
+                merge_into(built_set,
                     sets.Midcast.SIRD)
             end
 
@@ -1772,11 +1846,11 @@ do
             if spell.action_type == 'Ranged Attack' then
                 if sets.Midcast.RA then
                     local message = ''
-                    built_set = set_combine(built_set, sets.Midcast.RA)
+                    merge_into(built_set, sets.Midcast.RA)
 
                     -- Augment based off Mode
                     if state.OffenseMode.value ~= 'TP' and sets.Midcast.RA[state.OffenseMode.value] then
-                        built_set = set_combine(built_set, sets.Midcast.RA[state.OffenseMode.value])
+                        merge_into(built_set, sets.Midcast.RA[state.OffenseMode.value])
                         if state.OffenseMode.value == 'ACC' then
                             message = 'Ranged Attack with Accuracy'
                         elseif state.OffenseMode.value == 'PDL' then
@@ -1800,34 +1874,34 @@ do
 
                     -- Check if Aftermath is active
                     if buffactive['Aftermath: Lv.3'] and sets.Midcast.RA.AM3 and sets.Midcast.RA.AM3[state.WeaponMode.value] then
-                        built_set = set_combine(built_set, sets.Midcast.RA.AM3[state.WeaponMode.value])
+                        merge_into(built_set, sets.Midcast.RA.AM3[state.WeaponMode.value])
                         message = message .. ' and with Aftermath 3 [' .. state.WeaponMode.value .. ']'
                     elseif buffactive['Aftermath: Lv.2'] and sets.Midcast.RA.AM2 and sets.Midcast.RA.AM2[state.WeaponMode.value] then
-                        built_set = set_combine(built_set, sets.Midcast.RA.AM2[state.WeaponMode.value])
+                        merge_into(built_set, sets.Midcast.RA.AM2[state.WeaponMode.value])
                         message = message .. ' and with Aftermath 2 [' .. state.WeaponMode.value .. ']'
                     elseif buffactive['Aftermath: Lv.1'] and sets.Midcast.RA.AM1 and sets.Midcast.RA.AM1[state.WeaponMode.value] then
-                        built_set = set_combine(built_set, sets.Midcast.RA.AM1[state.WeaponMode.value])
+                        merge_into(built_set, sets.Midcast.RA.AM1[state.WeaponMode.value])
                         message = message .. ' and with Aftermath 1 [' .. state.WeaponMode.value .. ']'
                     elseif buffactive['Aftermath'] and sets.Midcast.RA.AM and sets.Midcast.RA.AM[state.WeaponMode.value] then
-                        built_set = set_combine(built_set, sets.Midcast.RA.AM[state.WeaponMode.value])
+                        merge_into(built_set, sets.Midcast.RA.AM[state.WeaponMode.value])
                         message = message .. ' and with Aftermath [' .. state.WeaponMode.value .. ']'
                     end
 
                     -- Buffs
                     if buffactive['Triple Shot'] and sets.Midcast.RA.TripleShot then
-                        built_set = set_combine(built_set, sets.Midcast.RA.TripleShot)
+                        merge_into(built_set, sets.Midcast.RA.TripleShot)
                         message = 'Using Triple Shot Set'
                     elseif buffactive['Double Shot'] and sets.Midcast.RA.DoubleShot then
-                        built_set = set_combine(built_set, sets.Midcast.RA.DoubleShot)
+                        merge_into(built_set, sets.Midcast.RA.DoubleShot)
                         message = 'Using Double Shot Set'
                     elseif buffactive['Barrage'] and sets.Midcast.RA.Barrage then
-                        built_set = set_combine(built_set, sets.Midcast.RA.Barrage)
+                        merge_into(built_set, sets.Midcast.RA.Barrage)
                         message = 'Using Barrage Set'
                     end
 
                     -- Variable Ammo
                     if Ammo[state.OffenseMode.value] then
-                        built_set = set_combine(built_set,
+                        merge_into(built_set,
                             { ammo = Ammo[state.OffenseMode.value] })
                     end
 
@@ -1840,12 +1914,12 @@ do
             elseif spell.type == 'Ninjutsu' then
                 -- Defined Gear Set
                 if sets.Midcast[spell.english] then
-                    built_set = set_combine(built_set, sets.Midcast[spell.english])
+                    merge_into(built_set, sets.Midcast[spell.english])
                     info('[' .. spell.english .. '] Set')
                     -- Utsusemi Spells
                 elseif UtsusemiSpell:contains(spell.name) then
                     if sets.Midcast.Utsusemi then
-                        built_set = set_combine(built_set, sets.Midcast.Utsusemi)
+                        merge_into(built_set, sets.Midcast.Utsusemi)
                         info('[' .. spell.english .. '] Utsusemi Set')
                     else
                         warn('sets.Midcast.Utsusemi not found!')
@@ -1853,7 +1927,7 @@ do
                     -- Enhancing Magic
                 elseif spell.target.type == 'SELF' then
                     if sets.Midcast.Enhancing then
-                        built_set = set_combine(built_set, sets.Midcast.Enhancing)
+                        merge_into(built_set, sets.Midcast.Enhancing)
                         info('Enhancing set')
                     else
                         warn('sets.Midcast.Enhancing not found!')
@@ -1861,7 +1935,7 @@ do
                     -- Enfeebling
                 elseif Enfeebling_Ninjitsu:contains(spell.english) then
                     if sets.Midcast.Enfeebling then
-                        built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                        merge_into(built_set, sets.Midcast.Enfeebling)
                         info('Enfeebling set')
                     else
                         warn('sets.Midcast.Enfeebling not found!')
@@ -1869,7 +1943,7 @@ do
                     -- Defaults to Nukes if not the above
                 else
                     if sets.Midcast.Nuke then
-                        built_set = set_combine(built_set, sets.Midcast.Nuke)
+                        merge_into(built_set, sets.Midcast.Nuke)
                         info('Nuke set')
                     else
                         warn('sets.Midcast.Nuke not found!')
@@ -1882,7 +1956,7 @@ do
                 -- Cure
                 if spell.name:contains('Cure') then
                     if sets.Midcast.Cure then
-                        built_set = set_combine(built_set, sets.Midcast.Cure)
+                        merge_into(built_set, sets.Midcast.Cure)
                         info('Cure Set')
                     else
                         warn('sets.Midcast.Cure not found!')
@@ -1892,7 +1966,7 @@ do
                     -- Curaga
                 elseif spell.name:contains('Curaga') then
                     if sets.Midcast.Curaga then
-                        built_set = set_combine(built_set, sets.Midcast.Curaga)
+                        merge_into(built_set, sets.Midcast.Curaga)
                         info('Curaga Set')
                     else
                         warn('sets.Midcast.Curaga not found!')
@@ -1902,7 +1976,7 @@ do
                     -- Cura
                 elseif spell.name:contains('Cura') then
                     if sets.Midcast.Cura then
-                        built_set = set_combine(built_set, sets.Midcast.Cura)
+                        merge_into(built_set, sets.Midcast.Cura)
                         info('Cura Set')
                     else
                         warn('sets.Midcast.Cura not found!')
@@ -1911,7 +1985,7 @@ do
                     built_set = elemental_check(spell, built_set)
                     -- Defined Gear Set
                 elseif sets.Midcast[spell.english] then
-                    built_set = set_combine(built_set, sets.Midcast[spell.english])
+                    merge_into(built_set, sets.Midcast[spell.english])
                     info('[' .. spell.english .. '] Set')
                     -- Healing Magic
                 elseif spell.name:contains('Raise') or spell.name == "Arise" or spell.name:contains('Reraise') then
@@ -1919,11 +1993,11 @@ do
                     -- Enhancing
                 elseif spell.skill == 'Enhancing Magic' then
                     if sets.Midcast.Enhancing then
-                        built_set = set_combine(built_set, sets.Midcast.Enhancing)
+                        merge_into(built_set, sets.Midcast.Enhancing)
                         -- Augment the set for Others if defined
                         if spell.target.type ~= 'SELF' or (spell.target.type == 'SELF' and buffactive['Accession']) then
                             if sets.Midcast.Enhancing.Others then
-                                built_set = set_combine(built_set, sets.Midcast.Enhancing.Others)
+                                merge_into(built_set, sets.Midcast.Enhancing.Others)
                             else
                                 warn('sets.Midcast.Enhancing.Others not found!')
                             end
@@ -1931,7 +2005,7 @@ do
                         -- Refresh
                         if spell.name:contains('Refresh') then
                             if sets.Midcast.Refresh then
-                                built_set = set_combine(built_set, sets.Midcast.Refresh)
+                                merge_into(built_set, sets.Midcast.Refresh)
                                 info('Refresh Set')
                             else
                                 warn('sets.Midcast.Refresh not found!')
@@ -1939,14 +2013,14 @@ do
                             -- Regen
                         elseif spell.name:contains('Regen') then
                             if sets.Midcast.Regen then
-                                built_set = set_combine(built_set, sets.Midcast.Regen)
+                                merge_into(built_set, sets.Midcast.Regen)
                                 info('Regen Set')
                             else
                                 warn('sets.Midcast.Regen not found!')
                             end
                         elseif Storms:contains(spell.name) then
                             if sets.Storms then
-                                built_set = set_combine(built_set, sets.Storms)
+                                merge_into(built_set, sets.Storms)
                                 info('Storms Set')
                             else
                                 warn('sets.Storms not found!')
@@ -1954,7 +2028,7 @@ do
                             -- Gain Spells
                         elseif spell.name:contains('Gain') then
                             if sets.Midcast.Enhancing.Gain then
-                                built_set = set_combine(built_set, sets.Midcast.Enhancing.Gain)
+                                merge_into(built_set, sets.Midcast.Enhancing.Gain)
                                 info('Gain Set')
                             else
                                 warn('sets.Midcast.Enhancing.Gain not found!')
@@ -1962,7 +2036,7 @@ do
                             -- Phalanx
                         elseif spell.name:contains('Phalanx') then
                             if sets.Midcast.Phalanx then
-                                built_set = set_combine(built_set, sets.Midcast.Phalanx)
+                                merge_into(built_set, sets.Midcast.Phalanx)
                                 info('Phalanx Set')
                             else
                                 warn('sets.Midcast.Phalanx not found!')
@@ -1970,7 +2044,7 @@ do
                             -- Bar Spells
                         elseif Elemental_Bar:contains(spell.name) then
                             if sets.Midcast.Enhancing.Elemental then
-                                built_set = set_combine(built_set, sets.Midcast.Enhancing.Elemental)
+                                merge_into(built_set, sets.Midcast.Enhancing.Elemental)
                                 info('Elemental Bar Element Set')
                             else
                                 warn('sets.Midcast.Enhancing.Elemental not found!')
@@ -1978,7 +2052,7 @@ do
                             -- Bar Status
                         elseif Status_Bar:contains(spell.name) then
                             if sets.Midcast.Enhancing.Status then
-                                built_set = set_combine(built_set, sets.Midcast.Enhancing.Status)
+                                merge_into(built_set, sets.Midcast.Enhancing.Status)
                                 info('Status Bar Status Set')
                             else
                                 warn('sets.Midcast.Enhancing.Status not found!')
@@ -1986,7 +2060,7 @@ do
                             -- Enhancing SKill
                         elseif Enhancing_Skill:contains(spell.name) then
                             if sets.Midcast.Enhancing.Skill then
-                                built_set = set_combine(built_set, sets.Midcast.Enhancing.Skill)
+                                merge_into(built_set, sets.Midcast.Enhancing.Skill)
                                 info('Enhancing Skill Set')
                             else
                                 warn('sets.Midcast.Enhancing.Skill not found!')
@@ -2001,7 +2075,7 @@ do
                     -- Divine Spells
                 elseif Divine_Skill:contains(spell.name) then
                     if sets.Midcast.Divine then
-                        built_set = set_combine(built_set, sets.Midcast.Divine)
+                        merge_into(built_set, sets.Midcast.Divine)
                         info('Divine Skill Set')
                     else
                         warn('sets.Midcast.Divine not found!')
@@ -2009,11 +2083,11 @@ do
                     -- Enfeebling Magic
                 elseif spell.skill == 'Enfeebling Magic' then
                     if sets.Midcast.Enfeebling then
-                        built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                        merge_into(built_set, sets.Midcast.Enfeebling)
                         -- Accuracy
                         if Enfeeble_Acc:contains(spell.name) then
                             if sets.Midcast.Enfeebling.MACC then
-                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.MACC)
+                                merge_into(built_set, sets.Midcast.Enfeebling.MACC)
                                 info('Enfeebling Magic Set - Magic Accuracy')
                             else
                                 warn('sets.Midcast.Enfeebling.MACC not found!')
@@ -2021,7 +2095,7 @@ do
                             -- Potency
                         elseif Enfeeble_Potency:contains(spell.name) then
                             if sets.Midcast.Enfeebling.Potency then
-                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.Potency)
+                                merge_into(built_set, sets.Midcast.Enfeebling.Potency)
                                 info('Enfeebling Magic Set - Potency')
                             else
                                 warn('sets.Midcast.Enfeebling.Potency not found!')
@@ -2029,7 +2103,7 @@ do
                             -- Duration
                         elseif Enfeeble_Duration:contains(spell.name) then
                             if sets.Midcast.Enfeebling.Duration then
-                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.Duration)
+                                merge_into(built_set, sets.Midcast.Enfeebling.Duration)
                                 info('Enfeebling Magic Set - Duration')
                             else
                                 warn('sets.Midcast.Enfeebling.Duration not found!')
@@ -2046,7 +2120,7 @@ do
             elseif spell.type == 'BlackMagic' then
                 -- Defined Gear Set
                 if sets.Midcast[spell.english] then
-                    built_set = set_combine(built_set, sets.Midcast[spell.english])
+                    merge_into(built_set, sets.Midcast[spell.english])
                     -- Check for an elemental set
                     if spell.skill == 'Elemental Magic' and not spell.name:contains('helix') then
                         built_set =
@@ -2056,7 +2130,7 @@ do
                     -- Aspir Gear
                 elseif spell.name:contains('Aspir') then
                     if sets.Midcast.Aspir then
-                        built_set = set_combine(built_set, sets.Midcast.Aspir)
+                        merge_into(built_set, sets.Midcast.Aspir)
                         info('Aspir Set')
                     else
                         warn('sets.Midcast.Aspir not found!')
@@ -2064,7 +2138,7 @@ do
                     -- Drain Gear
                 elseif spell.name:contains('Drain') then
                     if sets.Midcast.Drain then
-                        built_set = set_combine(built_set, sets.Midcast.Drain)
+                        merge_into(built_set, sets.Midcast.Drain)
                         info('Drain Set')
                     else
                         warn('sets.Midcast.Drain not found!')
@@ -2072,11 +2146,11 @@ do
                     -- Enfeebling Magic
                 elseif spell.skill == 'Enfeebling Magic' then
                     if sets.Midcast.Enfeebling then
-                        built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                        merge_into(built_set, sets.Midcast.Enfeebling)
                         -- Accuracy
                         if Enfeeble_Acc:contains(spell.name) then
                             if sets.Midcast.Enfeebling.MACC then
-                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.MACC)
+                                merge_into(built_set, sets.Midcast.Enfeebling.MACC)
                                 info('Enfeebling Magic Set - Magic Accuracy')
                             else
                                 warn('sets.Midcast.Enfeebling.MACC not found!')
@@ -2084,7 +2158,7 @@ do
                             -- Potency
                         elseif Enfeeble_Potency:contains(spell.name) then
                             if sets.Midcast.Enfeebling.Potency then
-                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.Potency)
+                                merge_into(built_set, sets.Midcast.Enfeebling.Potency)
                                 info('Enfeebling Magic Set - Potency')
                             else
                                 warn('sets.Midcast.Enfeebling.Potency not found!')
@@ -2092,7 +2166,7 @@ do
                             -- Duration
                         elseif Enfeeble_Duration:contains(spell.name) then
                             if sets.Midcast.Enfeebling.Duration then
-                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.Duration)
+                                merge_into(built_set, sets.Midcast.Enfeebling.Duration)
                                 info('Enfeebling Magic Set - Duration')
                             else
                                 warn('sets.Midcast.Enfeebling.Duration not found!')
@@ -2107,11 +2181,11 @@ do
                     -- Dark Magic
                 elseif spell.skill == 'Dark Magic' then
                     if sets.Midcast.Dark then
-                        built_set = set_combine(built_set, sets.Midcast.Dark)
+                        merge_into(built_set, sets.Midcast.Dark)
                         -- Accuracy
                         if Dark_Acc:contains(spell.name) then
                             if sets.Midcast.Dark.MACC then
-                                built_set = set_combine(built_set, sets.Midcast.Dark.MACC)
+                                merge_into(built_set, sets.Midcast.Dark.MACC)
                                 info('Dark Magic Set - Magic Accuracy')
                             else
                                 warn('sets.Midcast.Dark.MACC not found!')
@@ -2119,7 +2193,7 @@ do
                             -- Absorb
                         elseif Dark_Absorb:contains(spell.name) then
                             if sets.Midcast.Dark.Absorb then
-                                built_set = set_combine(built_set, sets.Midcast.Dark.Absorb)
+                                merge_into(built_set, sets.Midcast.Dark.Absorb)
                                 info('Absorb Magic Set - Potency')
                             else
                                 warn('sets.Midcast.Dark.Absorb not found!')
@@ -2127,7 +2201,7 @@ do
                             -- Enhancing
                         elseif Dark_Enhancing:contains(spell.name) then
                             if sets.Midcast.Dark.Enhancing then
-                                built_set = set_combine(built_set, sets.Midcast.Dark.Enhancing)
+                                merge_into(built_set, sets.Midcast.Dark.Enhancing)
                                 info('Dark Enhancing Magic Set - Duration')
                             else
                                 warn('sets.Midcast.Dark.Enhancing not found!')
@@ -2135,7 +2209,7 @@ do
                             -- Potency
                         elseif Enfeeble_Potency:contains(spell.name) then
                             if sets.Midcast.Enfeebling.Potency then
-                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.Potency)
+                                merge_into(built_set, sets.Midcast.Enfeebling.Potency)
                                 info('Enfeebling Magic Set - Potency')
                             else
                                 warn('sets.Midcast.Enfeebling.Potency not found!')
@@ -2143,7 +2217,7 @@ do
                             -- Duration
                         elseif Enfeeble_Duration:contains(spell.name) then
                             if sets.Midcast.Enfeebling.Duration then
-                                built_set = set_combine(built_set, sets.Midcast.Enfeebling.Duration)
+                                merge_into(built_set, sets.Midcast.Enfeebling.Duration)
                                 info('Enfeebling Magic Set - Duration')
                             else
                                 warn('sets.Midcast.Enfeebling.Duration not found!')
@@ -2158,7 +2232,7 @@ do
                     -- Enhancing Magic
                 elseif spell.skill == 'Enhancing Magic' then
                     if sets.Midcast.Enhancing then
-                        built_set = set_combine(built_set, sets.Midcast.Enhancing)
+                        merge_into(built_set, sets.Midcast.Enhancing)
                         info('Enhancing Magic Set')
                     else
                         warn('sets.Midcast.Enhancing not found!')
@@ -2166,9 +2240,9 @@ do
                     -- Enfeebling Elemental Magic
                 elseif Elemental_Enfeeble:contains(spell.name) then
                     if sets.Midcast.Enfeebling then
-                        built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                        merge_into(built_set, sets.Midcast.Enfeebling)
                         if sets.Midcast.Enfeebling.MACC then
-                            built_set = set_combine(built_set, sets.Midcast.Enfeebling.MACC)
+                            merge_into(built_set, sets.Midcast.Enfeebling.MACC)
                             info('Enfeebling Magic Set - Magic Accuracy')
                         else
                             warn('sets.Midcast.Enfeebling.MACC not found!')
@@ -2183,13 +2257,13 @@ do
                     if spell.target.id == last_skillchain_id and os.clock() - last_skillchain_time < 8 and last_skillchain_elements[element_name] then
                         info("Burst Detected!")
                         if sets.Midcast.Burst then
-                            built_set = set_combine(built_set, sets.Midcast.Burst)
+                            merge_into(built_set, sets.Midcast.Burst)
                         else
                             warn('sets.Midcast.Burst not found!')
                         end
                     else
                         if sets.Midcast.Nuke then
-                            built_set = set_combine(built_set, sets.Midcast.Nuke)
+                            merge_into(built_set, sets.Midcast.Nuke)
                             info('Nuke Set')
                         else
                             warn('sets.Midcast.Nuke not found!')
@@ -2198,16 +2272,16 @@ do
                     -- Check for Helix
                     if spell.name:contains('helix') then
                         if sets.Helix then
-                            built_set = set_combine(built_set, sets.Helix)
+                            merge_into(built_set, sets.Helix)
                             if spell.element == 'Dark' then
                                 if sets.Helix.Dark then
-                                    built_set = set_combine(built_set, sets.Helix.Dark)
+                                    merge_into(built_set, sets.Helix.Dark)
                                 else
                                     warn('sets.Helix.Dark not found!')
                                 end
                             elseif spell.element == 'Light' then
                                 if sets.Helix.Light then
-                                    built_set = set_combine(built_set, sets.Helix.Light)
+                                    merge_into(built_set, sets.Helix.Light)
                                 else
                                     warn('sets.Helix.Light not found!')
                                 end
@@ -2217,7 +2291,7 @@ do
                         end
                     else
                         if spell.element == "Earth" and sets.Midcast.Nuke.Earth then
-                            built_set = set_combine(built_set, sets.Midcast.Nuke.Earth)
+                            merge_into(built_set, sets.Midcast.Nuke.Earth)
                             windower.add_to_chat(8, 'Earth Element Detected!')
                         end
                         -- Check for an elemental set
@@ -2229,58 +2303,78 @@ do
                 -- Song Count for Dummy Songs
                 if SongCount:contains(spell.name) then
                     if sets.Midcast.DummySongs then
-                        built_set = set_combine(built_set, sets.Midcast.DummySongs)
+                        merge_into(built_set, sets.Midcast.DummySongs)
                         info('[' .. spell.english .. '] Set (Song Count)')
                     else
                         warn('sets.Midcast.DummySongs not found!')
                     end
-                    built_set = set_combine(built_set, { range = Instrument.Count })
+                    merge_into(built_set, { range = Instrument.Count })
                     -- Potency / Instruments
                 else
                     -- Defined Gear Set
                     if sets.Midcast[spell.english] then
-                        built_set = set_combine(built_set, sets.Midcast[spell.english])
+                        merge_into(built_set, sets.Midcast[spell.english])
                         info('[' .. spell.english .. '] Set')
                         -- Equip Harp
                     elseif spell.name:contains('Horde') then
                         if sets.Midcast.Enfeebling then
-                            built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                            merge_into(built_set, sets.Midcast.Enfeebling)
                         else
                             warn('sets.Midcast.Enfeebling not found!')
                         end
-                        built_set = set_combine(built_set, { range = Instrument.AOE_Sleep })
+                        merge_into(built_set, { range = Instrument.AOE_Sleep })
                         info('[' .. spell.english .. '] Set (AOE Sleep)')
                         -- Normal Enfeebles
                     elseif Enfeebling_Song:contains(spell.english) then
                         if sets.Midcast.Enfeebling then
-                            built_set = set_combine(built_set, sets.Midcast.Enfeebling)
+                            merge_into(built_set, sets.Midcast.Enfeebling)
                         else
                             warn('sets.Midcast.Enfeebling not found!')
                         end
-                        built_set = set_combine(built_set, { range = Instrument.Enfeebling })
+                        merge_into(built_set, { range = Instrument.Enfeebling })
                         info('[' .. spell.english .. '] Set (Enfeebling)')
                         -- Augment the buff songs
                     else
                         info('[' .. spell.english .. '] Set (Potency)')
-                        built_set = set_combine(built_set, { range = Instrument.Potency })
+                        merge_into(built_set, { range = Instrument.Potency })
                     end
                     -- Augment the specific Song if set
-                    built_set = set_combine(built_set, equip_song_gear(spell, built_set['range']))
+                    merge_into(built_set, equip_song_gear(spell, built_set['range']))
                 end
                 -- BlueMagic
             elseif spell.type == 'BlueMagic' then
                 -- Defined Set
                 if sets.Midcast[spell.english] then
-                    built_set = set_combine(built_set, sets.Midcast[spell.english])
+                    merge_into(built_set, sets.Midcast[spell.english])
                     -- Check for an elemental set
                     if BlueNuke:contains(spell.english) then built_set = elemental_check(spell, built_set) end
                     info('[' .. spell.english .. '] Set')
                 else
                     if sets.Midcast.BlueMagic then
-                        -- Defined Blue Nukes
-                        if BlueNuke:contains(spell.english) then
+                        -- Physical blue magic: damage comes from mainhand weapon
+                        -- accuracy, DEX/Accuracy and physical Attack.  Deliberately skips
+                        -- elemental_check -- obi and Orpheus scale magic damage only.
+                        if BluePhysical:contains(spell.english) then
+                            if sets.Midcast.BlueMagic.Physical then
+                                merge_into(built_set, sets.Midcast.BlueMagic.Physical)
+                                info('Blue Physical set')
+                            else
+                                warn('sets.Midcast.BlueMagic.Physical not found!')
+                            end
+                            -- Breath damage scales off the caster's HP and level only.
+                            -- MAB, INT and Blue Magic Skill contribute nothing, so this
+                            -- also skips elemental_check.
+                        elseif BlueBreath:contains(spell.english) then
+                            if sets.Midcast.BlueMagic.Breath then
+                                merge_into(built_set, sets.Midcast.BlueMagic.Breath)
+                                info('Blue Breath set')
+                            else
+                                warn('sets.Midcast.BlueMagic.Breath not found!')
+                            end
+                            -- Defined Blue Nukes
+                        elseif BlueNuke:contains(spell.english) then
                             if sets.Midcast.BlueMagic.Nuke then
-                                built_set = set_combine(built_set, sets.Midcast.BlueMagic.Nuke)
+                                merge_into(built_set, sets.Midcast.BlueMagic.Nuke)
                                 info('Blue Nuke set')
                             else
                                 warn('sets.Midcast.BlueMagic.Nuke not found!')
@@ -2289,28 +2383,37 @@ do
                             -- Spells that benifit from Blue Magic Skill
                         elseif BlueSkill:contains(spell.english) then
                             if sets.Midcast.BlueMagic.Skill then
-                                built_set = set_combine(built_set, sets.Midcast.BlueMagic.Skill)
+                                merge_into(built_set, sets.Midcast.BlueMagic.Skill)
                                 info('Blue Skill set')
                             else
                                 warn('sets.Midcast.BlueMagic.Skill not found!')
                             end
+                            -- Fixed-potency buffs: only duration is influenced by gear,
+                            -- so these must not borrow the skill set.
+                        elseif BlueBuff:contains(spell.english) then
+                            if sets.Midcast.BlueMagic.Buff then
+                                merge_into(built_set, sets.Midcast.BlueMagic.Buff)
+                                info('Blue Buff set')
+                            else
+                                warn('sets.Midcast.BlueMagic.Buff not found!')
+                            end
                         elseif BlueTank:contains(spell.english) then
                             if sets.Midcast.BlueMagic.Enmity then
-                                built_set = set_combine(built_set, sets.Midcast.BlueMagic.Enmity)
+                                merge_into(built_set, sets.Midcast.BlueMagic.Enmity)
                                 info('Blue Enmity set')
                             else
                                 warn('sets.Midcast.BlueMagic.Enmity not found!')
                             end
                         elseif BlueHealing:contains(spell.english) then
                             if sets.Midcast.BlueMagic.Healing then
-                                built_set = set_combine(built_set, sets.Midcast.BlueMagic.Healing)
+                                merge_into(built_set, sets.Midcast.BlueMagic.Healing)
                                 info('Blue Cure set')
                             else
                                 warn('sets.Midcast.BlueMagic.Healing not found!')
                             end
                         elseif BlueACC:contains(spell.english) then
                             if sets.Midcast.BlueMagic.ACC then
-                                built_set = set_combine(built_set, sets.Midcast.BlueMagic.ACC)
+                                merge_into(built_set, sets.Midcast.BlueMagic.ACC)
                                 info('Blue Magic Accuracy set')
                             else
                                 warn('sets.Midcast.BlueMagic.ACC not found!')
@@ -2321,7 +2424,7 @@ do
                         end
                         if buffactive["Diffusion"] then
                             if sets.Diffusion then
-                                built_set = set_combine(built_set, sets.Diffusion)
+                                merge_into(built_set, sets.Diffusion)
                                 info('Diffusion Augment')
                             else
                                 warn('sets.Diffusion not found!')
@@ -2336,15 +2439,15 @@ do
                 if sets.Geomancy then
                     -- Defined Set
                     if sets.Geomancy[spell.english] then
-                        built_set = set_combine(built_set, sets.Geomancy[spell.english])
+                        merge_into(built_set, sets.Geomancy[spell.english])
                         info('[' .. spell.english .. '] Set')
                         -- Indi Equipment
                     elseif Indicolure_List:contains(spell.english) then
                         if sets.Geomancy.Indi then
-                            built_set = set_combine(built_set, sets.Geomancy.Indi)
+                            merge_into(built_set, sets.Geomancy.Indi)
                             if spell.target.type ~= "SELF" then
                                 if sets.Geomancy.Indi.Entrust then
-                                    built_set = set_combine(built_set, sets.Geomancy.Indi.Entrust)
+                                    merge_into(built_set, sets.Geomancy.Indi.Entrust)
                                     info('Indicolure set - Entrust')
                                 else
                                     warn('sets.Geomancy.Indi.Entrust not found!')
@@ -2358,7 +2461,7 @@ do
                         -- Bubble Equipment
                     elseif Geomancy_List:contains(spell.english) then
                         if sets.Geomancy.Geo then
-                            built_set = set_combine(built_set, sets.Geomancy.Geo)
+                            merge_into(built_set, sets.Geomancy.Geo)
                             info('Geomancy set')
                         else
                             warn('sets.Geomancy.Geo not found!')
@@ -2378,10 +2481,10 @@ do
                 -- BP Timer gear needs to swap here if not under Astral Conduit
                 if not buffactive["Astral Conduit"] then
                     if sets.Midcast[spell.english] then
-                        built_set = set_combine(built_set, sets.Midcast[spell.english])
+                        merge_into(built_set, sets.Midcast[spell.english])
                         info('[' .. spell.english .. '] Set')
                     elseif sets.Midcast.BP then
-                        built_set = set_combine(built_set, sets.Midcast.BP)
+                        merge_into(built_set, sets.Midcast.BP)
                         info('Blood Pact Set')
                     else
                         warn('sets.Midcast.BP not found!')
@@ -2393,7 +2496,7 @@ do
                 -- Monster
             elseif spell.type == 'Monster' then
                 if sets.Ready then
-                    built_set = set_combine(built_set, sets.Ready)
+                    merge_into(built_set, sets.Ready)
                     info('[Ready] Set')
                 else
                     warn('sets.Ready not found!')
@@ -2401,11 +2504,11 @@ do
                 -- Elemental Siphon
             elseif spell.name == "Elemental Siphon" then
                 if sets.Midcast[spell.english] then
-                    built_set = set_combine(built_set, sets.Midcast[spell.english])
+                    merge_into(built_set, sets.Midcast[spell.english])
                     info('[' .. spell.english .. '] Set')
                 else
                     if sets.Midcast.SummoningMagic then
-                        built_set = set_combine(built_set, sets.Midcast.SummoningMagic)
+                        merge_into(built_set, sets.Midcast.SummoningMagic)
                         info('Summoning Magic Set')
                     else
                         warn('sets.Midcast.SummoningMagic not found!')
@@ -2414,11 +2517,11 @@ do
                 -- Summon Avatar
             elseif spell.type == "SummonerPact" then
                 if sets.Midcast[spell.english] then
-                    built_set = set_combine(built_set, sets.Midcast[spell.english])
+                    merge_into(built_set, sets.Midcast[spell.english])
                     info('[' .. spell.english .. '] Set')
                 else
                     if sets.Midcast.Summon then
-                        built_set = set_combine(built_set, sets.Midcast.Summon)
+                        merge_into(built_set, sets.Midcast.Summon)
                         info('Summon Magic Set')
                     else
                         warn('sets.Midcast.Summon not found!')
@@ -2444,19 +2547,19 @@ do
             if spell.type == 'Geomancy' then
                 log('Swap Weapon due to Geomancy')
             elseif state.WeaponMode.value == "Locked" then
-                built_set = set_combine(built_set,
+                merge_into(built_set,
                     { main = player.equipment.main, sub = player.equipment.sub, range = player.equipment.range })
                 log(built_set)
             else
                 if sets.Weapons then
                     if sets.Weapons[state.WeaponMode.value] then
-                        built_set = set_combine(built_set, sets.Weapons[state.WeaponMode.value])
+                        merge_into(built_set, sets.Weapons[state.WeaponMode.value])
                     else
                         warn('sets.Weapons.' .. state.WeaponMode.value .. ' not found!')
                     end
                     if not TwoHand and not DualWield then
                         if sets.Weapons.Shield then
-                            built_set = set_combine(built_set, sets.Weapons.Shield)
+                            merge_into(built_set, sets.Weapons.Shield)
                         else
                             warn('sets.Weapons.Shield not found!')
                         end
@@ -2471,12 +2574,12 @@ do
         if spell.type == 'BardSong' then --and spell.target.type ~= 'MONSTER' then
             -- Weapons
             if sets.Weapons.Songs then
-                built_set = set_combine(built_set, sets.Weapons.Songs)
+                merge_into(built_set, sets.Weapons.Songs)
                 if sets.Weapons.Songs.Midcast then
-                    built_set = set_combine(built_set, sets.Weapons.Songs.Midcast)
+                    merge_into(built_set, sets.Weapons.Songs.Midcast)
                     if not DualWield and not TwoHand then
                         if sets.Weapons.Shield then
-                            built_set = set_combine(built_set, sets.Weapons.Shield)
+                            merge_into(built_set, sets.Weapons.Shield)
                         else
                             warn('sets.Weapons.Shield not found!')
                         end
@@ -2494,7 +2597,7 @@ do
                 if Instrument then
                     --Check for pianissimo Weapons
                     if Instrument.Pianissimo then
-                        built_set = set_combine(built_set, { range = equip_pianissimo_gear(spell) })
+                        merge_into(built_set, { range = equip_pianissimo_gear(spell) })
                     else
                         warn('Instrument.Pianissimo not found!')
                     end
@@ -2505,7 +2608,7 @@ do
         end
         -- If TH mode is on - check if new mob and then equip TH gear
         if state.TreasureMode.value ~= 'None' and spell.target.type == 'MONSTER' and not th_info.tagged_mobs[spell.target.id] and sets.TreasureHunter then
-            built_set = set_combine(built_set, sets.TreasureHunter)
+            merge_into(built_set, sets.TreasureHunter)
             info('[' .. spell.english .. '] Set with Treasure Hunter')
         end
         -- Built built_set to return
@@ -2539,9 +2642,7 @@ do
         --Calls the function in the include file for basic checks
         pretargetcheck(spell, action)
         --Calls the job specific function
-        if pretarget_custom(spell, action) then
-            pretarget_custom(spell, action)
-        end
+        if pretarget_custom then pretarget_custom(spell, action) end
     end
 
     -------------------------------------------------------------------------------------------------------------------
@@ -2620,15 +2721,24 @@ do
         --Reset state for spell-received gear tracking
         if state.SpellReceived.value ~= 'OFF' and outgoing_cast_active then
             outgoing_cast_active = false
-            if settings.debug then debug(string.format("IPC message sent: MIRDAIN|COMPLETE|%s|%.0f", player.name, get_time())) end
+            if settings.debug then
+                debug(string.format("IPC message sent: MIRDAIN|COMPLETE|%s|%.0f", player.name,
+                    get_time()))
+            end
             send_ipc(string.format("MIRDAIN|COMPLETE|%s|%.0f", player.name, get_time()))
             if accession_predicted and not spell.interrupted and spell.type == "WhiteMagic" then
                 accession_predicted = false
-                if settings.debug then debug("Accessioned spell probably used while tracking. Accession_Predicted = False") end
+                if settings.debug then
+                    debug(
+                        "Accessioned spell probably used while tracking. Accession_Predicted = False")
+                end
             end
             if divine_seal_predicted and not spell.interrupted and spell.type == "WhiteMagic" and spell.skill == "Healing Magic" then
                 divine_seal_predicted = false
-                if settings.debug then debug("Divine Sealed spell probably used while tracking. Divine_Seal_Predicted = False") end
+                if settings.debug then
+                    debug(
+                        "Divine Sealed spell probably used while tracking. Divine_Seal_Predicted = False")
+                end
             end
         end
         --Generate the correct set from the include file and custom function
@@ -2977,12 +3087,13 @@ do
     end
 
     --Helper function for checking if player has an item available to equip.
-    -- 0 = Main Inventory
-    -- 8, 9, 10, 11 = Wardrobes 1-4
-    -- 12, 13, 14, 15 = Wardrobes 5-8
-    local ITEM_SEARCH_BAGS = { 0, 8, 9, 10, 11, 12, 13, 14, 15 }
+    --Bag ids per res/bags.lua:
+    --   0 = Inventory, 8 = Wardrobe, 10-15 = Wardrobes 2-7, 16 = Wardrobe 8.
+    --Bag 9 is Safe 2 (equippable=false) and is deliberately excluded; an item there
+    --cannot be equipped, so reporting it as available would lock slots on nothing.
+    local ITEM_SEARCH_BAGS = { 0, 8, 10, 11, 12, 13, 14, 15, 16 }
     local function has_item(item_id)
-       for _, bag_id in ipairs(ITEM_SEARCH_BAGS) do
+        for _, bag_id in ipairs(ITEM_SEARCH_BAGS) do
             local bag = windower.ffxi.get_items(bag_id)
             if bag then
                 for _, item in ipairs(bag) do
@@ -3987,20 +4098,20 @@ do
 
                 -- Check for bonus
                 if spell.element == world.day_element then
-                    if Obi then built_set = set_combine(built_set, { waist = "Hachirin-no-Obi" }) end
+                    if Obi then merge_into(built_set, { waist = "Hachirin-no-Obi" }) end
                     if Staff then
-                        built_set = set_combine(built_set, sets.Weapons['Light Bonus'],
-                            { main = "Chatoyant Staff" })
+                        merge_into(built_set, sets.Weapons['Light Bonus'])
+                        merge_into(built_set, { main = "Chatoyant Staff" })
                     end
-                    if Cape then built_set = set_combine(built_set, { back = "Twilight Cape" }) end
+                    if Cape then merge_into(built_set, { back = "Twilight Cape" }) end
                     windower.add_to_chat(8, '[' .. world.day_element .. '] day - using Bonus Gear')
                 elseif world.weather_element == spell.element then
-                    if Obi then built_set = set_combine(built_set, { waist = "Hachirin-no-Obi" }) end
+                    if Obi then merge_into(built_set, { waist = "Hachirin-no-Obi" }) end
                     if Staff then
-                        built_set = set_combine(built_set, sets.Weapons['Light Bonus'],
-                            { main = "Chatoyant Staff" })
+                        merge_into(built_set, sets.Weapons['Light Bonus'])
+                        merge_into(built_set, { main = "Chatoyant Staff" })
                     end
-                    if Cape then built_set = set_combine(built_set, { back = "Twilight Cape" }) end
+                    if Cape then merge_into(built_set, { back = "Twilight Cape" }) end
                     windower.add_to_chat(8, 'Weather is [' .. world.weather_element .. '] - using Bonus Gear')
                 end
             end
@@ -4022,20 +4133,20 @@ do
 
             -- Matching double weather (w/o day conflict).
             if spell.element == world.weather_element and world.weather_intensity == 2 and Obi then
-                built_set = set_combine(built_set, { waist = "Hachirin-no-Obi" })
+                merge_into(built_set, { waist = "Hachirin-no-Obi" })
                 info('Weather is Double [' .. world.weather_element .. '] - using Hachirin-no-Obi')
                 -- Matching day and weather.
             elseif spell.element == world.day_element and spell.element == world.weather_element and Obi then
-                built_set = set_combine(built_set, { waist = "Hachirin-no-Obi" })
+                merge_into(built_set, { waist = "Hachirin-no-Obi" })
                 info('[' ..
                     world.day_element .. '] day and weather is [' .. world.weather_element .. '] - using Hachirin-no-Obi')
                 -- Target distance less than 6 yalms
             elseif spell.target.distance < (6 + spell.target.model_size) and Osash then
-                built_set = set_combine(built_set, { waist = "Orpheus's Sash" })
+                merge_into(built_set, { waist = "Orpheus's Sash" })
                 info('Distance is [' .. round(spell.target.distance, 2) .. '] using Orpheus Sash')
                 -- Match day or weather.
             elseif (spell.element == world.day_element or spell.element == world.weather_element) and Obi then
-                built_set = set_combine(built_set, { waist = "Hachirin-no-Obi" })
+                merge_into(built_set, { waist = "Hachirin-no-Obi" })
                 info('[' ..
                     world.day_element .. '] day and weather is [' .. world.weather_element .. '] - using Hachirin-no-Obi')
             end
@@ -4190,8 +4301,10 @@ do
                 local spell_id = split_msg[5] or "Missing Spell ID"
                 local time_sent = tonumber(split_msg[6]) or 9999999999999
                 local time_received = get_time()
-                if settings.debug then debug("Targeted IPC Message Received: " ..
-                    msg .. " after " .. (time_received - time_sent) .. " ms") end
+                if settings.debug then
+                    debug("Targeted IPC Message Received: " ..
+                        msg .. " after " .. (time_received - time_sent) .. " ms")
+                end
 
                 if next(active_incoming_casters) == nil then
                     cast_start_time = time_sent
@@ -4200,10 +4313,16 @@ do
 
                 -- Add caster to active pool and refresh failsafe timer
                 active_incoming_casters[caster_name] = true
-                if settings.debug then debug(caster_name .. " added to Active Incoming Casters (" .. count_keys(active_incoming_casters) .. ")") end
+                if settings.debug then
+                    debug(caster_name ..
+                        " added to Active Incoming Casters (" .. count_keys(active_incoming_casters) .. ")")
+                end
                 failsafe_active = true
                 failsafe_trigger_time = os.clock() + settings.delay
-                if settings.debug then debug(player.name .. " is targeted by " .. caster_name .. ". Gear equipped and timer refreshed.") end
+                if settings.debug then
+                    debug(player.name ..
+                        " is targeted by " .. caster_name .. ". Gear equipped and timer refreshed.")
+                end
             end
         elseif msg:startswith('MIRDAIN|ABILITY|') then
             local split_msg = msg:split("|")
@@ -4213,8 +4332,10 @@ do
                 local spell_id = split_msg[5] or "Missing Spell ID"
                 local time_sent = tonumber(split_msg[6]) or 9999999999999
                 local time_received = get_time()
-                if settings.debug then debug("Targeted IPC Message Received: " ..
-                    msg .. " after " .. (time_received - time_sent) .. " ms") end
+                if settings.debug then
+                    debug("Targeted IPC Message Received: " ..
+                        msg .. " after " .. (time_received - time_sent) .. " ms")
+                end
 
                 if next(active_incoming_casters) == nil then
                     cast_start_time = time_sent
@@ -4223,10 +4344,16 @@ do
 
                 -- Add caster to active pool and refresh failsafe timer
                 active_incoming_casters[caster_name] = true
-                if settings.debug then debug(caster_name .. " added to Active Incoming Casters (" .. count_keys(active_incoming_casters) .. ")") end
+                if settings.debug then
+                    debug(caster_name ..
+                        " added to Active Incoming Casters (" .. count_keys(active_incoming_casters) .. ")")
+                end
                 failsafe_active = true
                 failsafe_trigger_time = os.clock() + settings.delay
-                if settings.debug then debug(player.name .. " is targeted by " .. caster_name .. ". Gear equipped and timer refreshed.") end
+                if settings.debug then
+                    debug(player.name ..
+                        " is targeted by " .. caster_name .. ". Gear equipped and timer refreshed.")
+                end
             end
         elseif msg:startswith('MIRDAIN|COMPLETE|') then
             if next(active_incoming_casters) ~= nil then
@@ -4236,10 +4363,13 @@ do
                 local time_sent = tonumber(split_msg[4])
                 if active_incoming_casters[caster_name] then
                     active_incoming_casters[caster_name] = nil
-                    if settings.debug then debug(caster_name ..
-                        " finished casting after " ..
-                        (time_sent - cast_start_time) ..
-                        " ms and is removed from Active Incoming Casters (" .. count_keys(active_incoming_casters) .. ")") end
+                    if settings.debug then
+                        debug(caster_name ..
+                            " finished casting after " ..
+                            (time_sent - cast_start_time) ..
+                            " ms and is removed from Active Incoming Casters (" ..
+                            count_keys(active_incoming_casters) .. ")")
+                    end
                     if next(active_incoming_casters) == nil then
                         if settings.debug then debug("No active incoming casts remain. Resetting gear.") end
                         if state.SpellReceived.value == 'ON-Locked' then
@@ -4274,7 +4404,6 @@ do
     end)
 
     windower.register_event('gain buff', function(id)
-        local name = res.buffs[id].en
         if id == 6 and (Mage_Job:contains(player.main_job) or Mage_Job:contains(player.sub_job)) then
             if player.inventory['Remedy'] ~= nil then
                 if AutoItem == true then
@@ -4355,7 +4484,8 @@ do
     end)
 
     windower.register_event('lose buff', function(id)
-        local name = res.buffs[id].en
+        local buff = res.buffs[id]
+        local name = buff and buff.en or tostring(id)
         local gain = false
         --Unlock cursna received gear if not tracking party spellcasting through IPC
         if id == 15 and state.SpellReceived.value == "OFF" then -- Doom
@@ -4400,10 +4530,14 @@ do
             windower.send_command('sm on')
         end
     end)
-    ]]--
+    ]] --
 
-    -- Section used to determine if player is performing an action
-    windower.register_event('action', function(data)
+    -- Section used to determine if player is performing an action.
+    -- raw_register_event skips user_equip_sets, which otherwise runs refresh_globals()
+    -- plus a full equip_sets() pass for every action by every entity in range.  This
+    -- handler only reads state and issues send_commands (UnlockByMode, equip_set_command,
+    -- run_burst), so it needs neither.  See GearSwap user_functions.lua:265 vs :284.
+    windower.raw_register_event('action', function(data)
         if data ~= nil then
             --log('cat='..data.category..',param='..data.param)
             if data.actor_id == player.id then
@@ -4494,14 +4628,14 @@ do
         -- Combat Checks
         if player.status == "Engaged" then
             if sets.OffenseMode then
-                built_set = sets.OffenseMode
+                merge_into(built_set, sets.OffenseMode)
                 if sets.OffenseMode[state.OffenseMode.value] then
-                    built_set = set_combine(built_set, sets.OffenseMode[state.OffenseMode.value])
+                    merge_into(built_set, sets.OffenseMode[state.OffenseMode.value])
                     -- Check the weapons
                     if state.WeaponMode.value ~= "Locked" then
                         if sets.Weapons then
                             if sets.Weapons[state.WeaponMode.value] then
-                                built_set = set_combine(built_set, sets.Weapons[state.WeaponMode.value])
+                                merge_into(built_set, sets.Weapons[state.WeaponMode.value])
                             else
                                 warn('sets.Weapons.' .. state.WeaponMode.value .. ' not found!')
                             end
@@ -4511,13 +4645,13 @@ do
                         -- Equip sub weapon based off mode
                         if not DualWield and not TwoHand then
                             if sets.Weapons.Shield then
-                                built_set = set_combine(built_set, sets.Weapons.Shield)
+                                merge_into(built_set, sets.Weapons.Shield)
                             else
                                 warn('sets.Weapons.Shield not found!')
                             end
                         elseif DualWield then
                             if sets.DualWield then
-                                built_set = set_combine(built_set, sets.DualWield)
+                                merge_into(built_set, sets.DualWield)
                             else
                                 warn('sets.DualWield not found!')
                             end
@@ -4527,35 +4661,35 @@ do
                     if state.JobMode.value == "Ranged" then
                         log('Ranged Mode')
                         if sets.Idle and sets.Idle[state.OffenseMode.value] then
-                            built_set = set_combine(built_set, sets.Idle[state.OffenseMode.value])
+                            merge_into(built_set, sets.Idle[state.OffenseMode.value])
                         else
                             warn('sets.Idle.' .. state.OffenseMode.value .. ' not found!')
                         end
                     end
                     -- Check if AM3 is active
                     if buffactive['Aftermath: Lv.3'] and sets.OffenseMode.AM3 and sets.OffenseMode.AM3[state.WeaponMode.value] then
-                        built_set = set_combine(built_set, sets.OffenseMode.AM3[state.WeaponMode.value])
+                        merge_into(built_set, sets.OffenseMode.AM3[state.WeaponMode.value])
                     elseif buffactive['Aftermath: Lv.2'] and sets.OffenseMode.AM2 and sets.OffenseMode.AM2[state.WeaponMode.value] then
-                        built_set = set_combine(built_set, sets.OffenseMode.AM2[state.WeaponMode.value])
+                        merge_into(built_set, sets.OffenseMode.AM2[state.WeaponMode.value])
                     elseif buffactive['Aftermath: Lv.1'] and sets.OffenseMode.AM1 and sets.OffenseMode.AM1[state.WeaponMode.value] then
-                        built_set = set_combine(built_set, sets.OffenseMode.AM1[state.WeaponMode.value])
+                        merge_into(built_set, sets.OffenseMode.AM1[state.WeaponMode.value])
                     elseif buffactive['Aftermath'] and sets.OffenseMode.AM and sets.OffenseMode.AM[state.WeaponMode.value] then
-                        built_set = set_combine(built_set, sets.OffenseMode.AM[state.WeaponMode.value])
+                        merge_into(built_set, sets.OffenseMode.AM[state.WeaponMode.value])
                     end
                     -- Check if TreasureMode is activew
                     if state.TreasureMode.value ~= 'None' then
                         if sets.TreasureHunter then
                             -- Equip TH gear if mob is not marked as tagged
                             if not th_info.tagged_mobs[player.target.id] then
-                                built_set = set_combine(built_set, sets.TreasureHunter)
+                                merge_into(built_set, sets.TreasureHunter)
 
                                 -- Equip TH gear if TreasureMode is Full Time
                             elseif state.TreasureMode.value == 'Full Time' then
-                                built_set = set_combine(built_set, sets.TreasureHunter)
+                                merge_into(built_set, sets.TreasureHunter)
 
                                 -- Equip TH gear if TreasureMode is SATA and either SA, TA or Feint is active
                             elseif state.TreasureMode.value == 'SATA' and (buffactive['Sneak Attack'] or buffactive['Trick Attack'] or buffactive['Feint']) then
-                                built_set = set_combine(built_set, sets.TreasureHunter)
+                                merge_into(built_set, sets.TreasureHunter)
                             end
                         else
                             warn('sets.TreasureHunter not found!')
@@ -4570,11 +4704,11 @@ do
             -- Idle sets
         else
             if sets.Idle then
-                built_set = sets.Idle
+                merge_into(built_set, sets.Idle)
 
                 -- Idle state
                 if sets.Idle[state.OffenseMode.value] then
-                    built_set = set_combine(built_set, sets.Idle[state.OffenseMode.value])
+                    merge_into(built_set, sets.Idle[state.OffenseMode.value])
                 else
                     warn('sets.Idle.' .. state.OffenseMode.value .. ' not found!')
                 end
@@ -4582,7 +4716,7 @@ do
                 -- Resting condition
                 if player.status == "Resting" then
                     if sets.Idle.Resting then
-                        built_set = set_combine(built_set, sets.Idle.Resting)
+                        merge_into(built_set, sets.Idle.Resting)
                     else
                         warn('sets.Idle.Resting not found!')
                     end
@@ -4590,13 +4724,13 @@ do
 
                 -- Check the weapons
                 if state.WeaponMode.value == "Locked" then
-                    built_set = set_combine(built_set,
+                    merge_into(built_set,
                         { main = player.equipment.main, sub = player.equipment.sub, range = player.equipment.range })
                     log(built_set)
                 else
                     if sets.Weapons then
                         if sets.Weapons[state.WeaponMode.value] then
-                            built_set = set_combine(built_set, sets.Weapons[state.WeaponMode.value])
+                            merge_into(built_set, sets.Weapons[state.WeaponMode.value])
                         else
                             warn('sets.Weapons.' .. state.WeaponMode.value .. ' not found!')
                         end
@@ -4607,7 +4741,7 @@ do
                     -- Check for sub weapon
                     if not TwoHand and not DualWield then
                         if sets.Weapons.Shield then
-                            built_set = set_combine(built_set, sets.Weapons.Shield)
+                            merge_into(built_set, sets.Weapons.Shield)
                         else
                             warn('sets.Weapons.Shield not found!')
                         end
@@ -4617,7 +4751,7 @@ do
                 --Pet specific checks
                 if pet.isvalid then
                     if sets.Idle.Pet then
-                        built_set = set_combine(built_set, sets.Idle.Pet)
+                        merge_into(built_set, sets.Idle.Pet)
                     else
                         warn('sets.Idle.Pet not found!')
                     end
@@ -4625,7 +4759,7 @@ do
                 -- Equip Sublimation gear
                 if buffactive[187] then
                     if sets.Idle.Sublimation then
-                        built_set = set_combine(built_set, sets.Idle.Sublimation)
+                        merge_into(built_set, sets.Idle.Sublimation)
                     else
                         warn('sets.Idle.Sublimation not found!')
                     end
@@ -4633,7 +4767,7 @@ do
                 -- Equip movement gear
                 if is_moving then
                     if sets.Movement then
-                        built_set = set_combine(built_set, sets.Movement)
+                        merge_into(built_set, sets.Movement)
                     else
                         warn('sets.Movement not found!')
                     end
@@ -4645,7 +4779,7 @@ do
 
         -- Variable Ammo
         if Ammo and Ammo[state.OffenseMode.value] then
-            built_set = set_combine(built_set,
+            merge_into(built_set,
                 { ammo = Ammo[state.OffenseMode.value] })
         end
 

--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -279,7 +279,6 @@ Ammo_Warning_Limit = 99
 -- User Defined
 
 is_Busy = false
-is_Dragging = false
 AutoItem = false
 Random_Lockstyle = false
 Lockstyle_List = {}
@@ -1132,7 +1131,7 @@ do
                 send_ipc(string.format("MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id, get_time()))
             end
         elseif s_type == TYPE_SCH then
-            available_charges = get_current_stratagem_count()
+            local available_charges = get_current_stratagem_count()
             if available_charges == 0 then
                 cancel_spell()
                 info("Unable to use strategems. Available charges = 0")

--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -13,7 +13,7 @@ Original credit to Mirdain.  Pull request to be submitted after beta testing.
 ]]
 
 -- Global Variables
-Mirdain_GS = '1.6.1'
+Mirdain_GS = '1.6.2'
 
 -- Modes is the include file for a mode-tracking variable class.  Used for state vars, below.
 include('Modes')

--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -13,7 +13,7 @@ Original credit to Mirdain.  Pull request to be submitted after beta testing.
 ]]
 
 -- Global Variables
-Mirdain_GS = '1.6.2'
+Mirdain_GS = '1.6.3'
 
 -- Modes is the include file for a mode-tracking variable class.  Used for state vars, below.
 include('Modes')

--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -3106,8 +3106,12 @@ do
             send_command('terminate')
             -- Saves the location of HUD
         elseif command == 'save' then
-            config.save(settings)
-            add_to_chat(80, 'Settings saved')
+            if windower.ffxi.get_info().logged_in then
+                config.save(settings)
+                add_to_chat(80, 'Settings saved')
+            else
+                add_to_chat(80, 'Cannot save while zoning - try again in a moment.')
+            end
             -- Toggles dispay of the HUD
         elseif command == 'display' then
             if settings.visible == true then
@@ -4154,24 +4158,21 @@ do
     windower.raw_register_event('zone change', on_zone_change_for_th)
 
     local is_dragging = false
+    local drag_sx, drag_sy, drag_dx, drag_dy
     windower.raw_register_event('mouse', function(type, x, y, delta, blocked)
-        -- Mouse move is type 0.  Reject anything other than left click up (2) and down (1).
+        -- Mouse move is type 0.  Reject anything that is not a left button press (1) or release (2).
         if type ~= 1 and type ~= 2 then return end
 
         if type == 1 then
             is_dragging = gs_status:hover(x, y) or gs_debug:hover(x, y)
+            if is_dragging then
+                drag_sx, drag_sy = gs_status:pos_x(), gs_status:pos_y()
+                drag_dx, drag_dy = gs_debug:pos_x(), gs_debug:pos_y()
+            end
         elseif is_dragging then
             is_dragging = false
-            local status_pos = gs_status:settings().pos
-            local debug_pos = gs_debug:settings().pos
-
-            if settings.Display_Box.pos.x ~= status_pos.x or settings.Display_Box.pos.y ~= status_pos.y
-                or settings.Debug_Box.pos.x ~= debug_pos.x or settings.Debug_Box.pos.y ~= debug_pos.y then
-                settings.Display_Box.pos.x = status_pos.x
-                settings.Display_Box.pos.y = status_pos.y
-                settings.Debug_Box.pos.x = debug_pos.x
-                settings.Debug_Box.pos.y = debug_pos.y
-
+            if gs_status:pos_x() ~= drag_sx or gs_status:pos_y() ~= drag_sy
+                or gs_debug:pos_x() ~= drag_dx or gs_debug:pos_y() ~= drag_dy then
                 config.save(settings)
                 windower.add_to_chat(80, "Settings saved")
             end

--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -505,9 +505,6 @@ do
     local TARGET_PARTY1 = '{Self, Party}'
     local TARGET_PARTY2 = '{Self, Party, Ally, NPC}'
 
-    -- Reusable persistent arrays to prevent table generation churn
-    local NEARBY_MEMBERS_BUFFER = {}
-
     -- Tracking vars for TH
     local th_info = {}
     th_info.tagged_mobs = T {}
@@ -664,10 +661,9 @@ do
 
     --Check if a name is currently in the character's party.
     --Return true if target is in party
-    local function is_target_in_party(target_name)
+    local function is_target_in_party(target_name, party_info)
         if not target_name then return false end
 
-        local party_info = get_party()
         if not party_info then return false end
 
         for i = 0, 5 do
@@ -729,7 +725,7 @@ do
     end
 
     local function equip_spell_received_gear(spell_id, spell_type)
-        debug("Equip gear function triggered: " .. spell_id .. ", " .. spell_type)
+        if settings.debug then debug("Equip gear function triggered: " .. spell_id .. ", " .. spell_type) end
         local s_info = {}
         if spell_type == "spell" then
             s_info = spell_info[spell_id]
@@ -738,7 +734,7 @@ do
         end
 
         --Calculate delta since cast start time in milliseconds
-        local elapsed_ms = get_time() - cast_start_time
+        --local elapsed_ms = get_time() - cast_start_time
 
         local spell_received_set = {}
         if s_info.equip == "cure_set" then
@@ -802,7 +798,7 @@ do
                 for slot, item in pairs(spell_received_set) do
                     disable(slot)
 
-                    debug("Locking " .. tostring(slot))
+                    if settings.debug then debug("Locking " .. tostring(slot)) end
                     active_external_locks[slot] = true
                 end
             end
@@ -887,7 +883,7 @@ do
             if state.SpellReceived.value ~= "OFF" then
                 if spell.name == "Divine Seal" then
                     divine_seal_predicted = true
-                    debug("Divine Seal detected while tracking. Divine_Seal_Predicted = True")
+                    if settings.debug then debug("Divine Seal detected while tracking. Divine_Seal_Predicted = True") end
                 end
                 local a_info = ability_info[spell.id]
                 if a_info then
@@ -896,14 +892,14 @@ do
 
                     local target_name = spell.target.name
                     outgoing_cast_active = true
-                    debug(player.name .. ' is using tracked ability measured at pretarget: ' ..
-                        spell.name .. ' on ' .. target_name .. ' at ' .. get_time())
+                    if settings.debug then debug(player.name .. ' is using tracked ability measured at pretarget: ' ..
+                        spell.name .. ' on ' .. target_name .. ' at ' .. get_time()) end
 
                     --AoE Checks
-                    if a_info.aoe and is_target_in_party(target_name) then
-                        debug("AoE Ability Cast Detected.  Calculating targets.")
+                    if a_info.aoe then
+                        if settings.debug then debug("AoE Ability Cast Detected.  Calculating targets.") end
                         local party = get_party()
-                        if party then
+                        if party and is_target_in_party(target_name, party) then
                             local count = 0
                             for k, v in pairs(NEARBY_MEMBERS_BUFFER) do NEARBY_MEMBERS_BUFFER[k] = nil end
 
@@ -914,22 +910,22 @@ do
                                         local dx, dy, dz = m_mob.x - target_mob.x, m_mob.y - target_mob.y,
                                             m_mob.z - target_mob.z
                                         if ((dx * dx) + (dy * dy) + (dz * dz)) <= 100 then
-                                            debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name)
+                                            if settings.debug then debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name) end
                                             count = count + 1
                                             NEARBY_MEMBERS_BUFFER[count] = member.name
                                         else
-                                            debug(member.name .. " is OUT of aoe range from " .. target_mob.name)
+                                            if settings.debug then debug(member.name .. " is OUT of aoe range from " .. target_mob.name) end
                                         end
                                     else
-                                        debug(member.name .. " data unavailable (Too far away).")
+                                        if settings.debug then debug(member.name .. " data unavailable (Too far away).") end
                                     end
                                 end
                             end
                             if count > 0 then target_name = table.concat(NEARBY_MEMBERS_BUFFER, ",") end
                         end
                     end
-                    debug(string.format("IPC message sent: MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name,
-                        spell.id, get_time()))
+                    if settings.debug then debug(string.format("IPC message sent: MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name,
+                        spell.id, get_time())) end
                     send_ipc(string.format("MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name, spell.id,
                         get_time()))
                 end
@@ -1003,9 +999,9 @@ do
                 local target_name = spell.target.name
                 outgoing_cast_active = true
 
-                debug(player.name ..
+                if settings.debug then debug(player.name ..
                     ' is using tracked spell measured at pretarget: ' ..
-                    spell.name .. ' on ' .. target_name .. ' at ' .. get_time())
+                    spell.name .. ' on ' .. target_name .. ' at ' .. get_time()) end
 
                 local accession_active = active_buffs[366] or active_buffs['Accession']
                 local majesty_active = active_buffs[621] or active_buffs['Majesty']
@@ -1013,10 +1009,10 @@ do
 
                 --AoE checks
                 local has_yagrush = (s_info.divine and get_slot_item_name(sets.Midcast["Cursna"], 'main') == "Yagrush")
-                if is_target_in_party(target_name) and (s_info.aoe or ((accession_predicted or accession_active) and s_info.accession) or (majesty_active and s_info.majesty) or ((divine_seal_predicted or divine_veil_active or has_yagrush) and s_info.divine)) then
-                    debug("AoE Spell Cast Detected. Calculating targets.")
+                if (s_info.aoe or ((accession_predicted or accession_active) and s_info.accession) or (majesty_active and s_info.majesty) or ((divine_seal_predicted or divine_veil_active or has_yagrush) and s_info.divine)) then
+                    if settings.debug then debug("AoE Spell Cast Detected. Calculating targets.") end
                     local party = get_party()
-                    if party then
+                    if party and is_target_in_party(target_name, party) then
                         local count = 0
                         for k in pairs(NEARBY_MEMBERS_BUFFER) do NEARBY_MEMBERS_BUFFER[k] = nil end
 
@@ -1028,14 +1024,14 @@ do
                                     local dy = m_mob.y - target_mob.y
                                     local dz = m_mob.z - target_mob.z
                                     if ((dx * dx) + (dy * dy) + (dz * dz)) <= 100 then
-                                        debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name)
+                                        if settings.debug then debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name) end
                                         count = count + 1
                                         NEARBY_MEMBERS_BUFFER[count] = member.name
                                     else
-                                        debug(member.name .. " is OUT of aoe range from " .. target_mob.name)
+                                        if settings.debug then debug(member.name .. " is OUT of aoe range from " .. target_mob.name) end
                                     end
                                 else
-                                    debug(member.name .. " data unavailable (Too far away).")
+                                    if settings.debug then debug(member.name .. " data unavailable (Too far away).") end
                                 end
                             end
                         end
@@ -1045,8 +1041,8 @@ do
                         end
                     end
                 end
-                debug(string.format("IPC message sent: MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id,
-                    get_time()))
+                if settings.debug then debug(string.format("IPC message sent: MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id,
+                    get_time())) end
                 send_ipc(string.format("MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id, get_time()))
             end
         elseif s_type == TYPE_SCH then
@@ -1056,7 +1052,7 @@ do
                 info("Unable to use strategems. Available charges = 0")
             elseif spell.name == "Accession" then
                 accession_predicted = true
-                debug("Accession detected while tracking. Accession_Predicted = True")
+                if settings.debug then debug("Accession detected while tracking. Accession_Predicted = True") end
             end
         end
     end
@@ -1067,10 +1063,10 @@ do
 
     function precastequip(spell)
         log('precastequip Called')
-        debug("spell.type = " ..
+        if settings.debug then debug("spell.type = " ..
             spell.type ..
             " , spell.action_type = " ..
-            spell.action_type .. " , spell.english = " .. spell.english .. " , spell.name = " .. spell.name)
+            spell.action_type .. " , spell.english = " .. spell.english .. " , spell.name = " .. spell.name) end
         --Cancel for SMN if Avatar is mid action
         if pet.isvalid and pet_midaction() then return end
         --Default gearset
@@ -1308,7 +1304,7 @@ do
             end
             if spell.name == "Divine Seal" and not divine_seal_predicted then
                 divine_seal_predicted = true
-                debug("Divine Seal detected while tracking. Divine_Seal_Predicted = True")
+                if settings.debug then debug("Divine Seal detected while tracking. Divine_Seal_Predicted = True") end
             end
             -- Items
         elseif spell.action_type == 'Item' or spell.prefix == '/item' then
@@ -1335,7 +1331,7 @@ do
         elseif spell.type == 'Scholar' then
             if spell.name == "Accession" and not accession_predicted then
                 accession_predicted = true
-                debug("Accession detected while tracking. Accession_Predicted = True")
+                if settings.debug then debug("Accession detected while tracking. Accession_Predicted = True") end
             end
             if sets.JA then
                 built_set = set_combine(built_set, sets.JA)
@@ -1438,14 +1434,14 @@ do
 
                     local target_name = spell.target.name
                     outgoing_cast_active = true
-                    debug(player.name .. ' is using tracked ability measured at precast: ' ..
-                        spell.name .. ' on ' .. target_name .. ' at ' .. get_time())
+                    if settings.debug then debug(player.name .. ' is using tracked ability measured at precast: ' ..
+                        spell.name .. ' on ' .. target_name .. ' at ' .. get_time()) end
 
                     --AoE Checks
-                    if a_info.aoe and is_target_in_party(target_name) then
-                        debug("AoE Ability Cast Detected.  Calculating targets.")
+                    if a_info.aoe then
+                        if settings.debug then debug("AoE Ability Cast Detected.  Calculating targets.") end
                         local party = get_party()
-                        if party then
+                        if party and is_target_in_party(target_name, party) then
                             local count = 0
                             for k, v in pairs(NEARBY_MEMBERS_BUFFER) do NEARBY_MEMBERS_BUFFER[k] = nil end
 
@@ -1456,22 +1452,22 @@ do
                                         local dx, dy, dz = m_mob.x - target_mob.x, m_mob.y - target_mob.y,
                                             m_mob.z - target_mob.z
                                         if ((dx * dx) + (dy * dy) + (dz * dz)) <= 100 then
-                                            debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name)
+                                            if settings.debug then debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name) end
                                             count = count + 1
                                             NEARBY_MEMBERS_BUFFER[count] = member.name
                                         else
-                                            debug(member.name .. " is OUT of aoe range from " .. target_mob.name)
+                                            if settings.debug then debug(member.name .. " is OUT of aoe range from " .. target_mob.name) end
                                         end
                                     else
-                                        debug(member.name .. " data unavailable (Too far away).")
+                                        if settings.debug then debug(member.name .. " data unavailable (Too far away).") end
                                     end
                                 end
                             end
                             if count > 0 then target_name = table.concat(NEARBY_MEMBERS_BUFFER, ",") end
                         end
                     end
-                    debug(string.format("IPC message sent: MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name,
-                        spell.id, get_time()))
+                    if settings.debug then debug(string.format("IPC message sent: MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name,
+                        spell.id, get_time())) end
                     send_ipc(string.format("MIRDAIN|ABILITY|%s|%s|%s|%.0f", player.name, target_name, spell.id,
                         get_time()))
                 end
@@ -1645,9 +1641,9 @@ do
                 local target_name = spell.target.name
                 outgoing_cast_active = true
 
-                debug(player.name ..
+                if settings.debug then debug(player.name ..
                     ' is using tracked spell measured at precast: ' ..
-                    spell.name .. ' on ' .. target_name .. ' at ' .. get_time())
+                    spell.name .. ' on ' .. target_name .. ' at ' .. get_time()) end
                 local active_buffs = buffactive
                 local accession_active = active_buffs[366] or active_buffs['Accession']
                 local majesty_active = active_buffs[621] or active_buffs['Majesty']
@@ -1655,10 +1651,10 @@ do
 
                 --AoE Checks
                 local has_yagrush = (s_info.divine and get_slot_item_name(sets.Midcast["Cursna"], 'main') == "Yagrush")
-                if is_target_in_party(target_name) and (s_info.aoe or ((accession_predicted or accession_active) and s_info.accession) or (majesty_active and s_info.majesty) or (divine_veil_active and s_info.divine) or has_yagrush) then
-                    debug("AoE Spell Cast Detected. Calculating targets.")
+                if (s_info.aoe or ((accession_predicted or accession_active) and s_info.accession) or (majesty_active and s_info.majesty) or ((divine_seal_predicted or divine_veil_active or has_yagrush) and s_info.divine)) then
+                    if settings.debug then debug("AoE Spell Cast Detected. Calculating targets.") end
                     local party = get_party()
-                    if party then
+                    if party and is_target_in_party(target_name, party) then
                         local count = 0
                         for k in pairs(NEARBY_MEMBERS_BUFFER) do NEARBY_MEMBERS_BUFFER[k] = nil end
 
@@ -1670,14 +1666,14 @@ do
                                     local dy = m_mob.y - target_mob.y
                                     local dz = m_mob.z - target_mob.z
                                     if ((dx * dx) + (dy * dy) + (dz * dz)) <= 100 then
-                                        debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name)
+                                        if settings.debug then debug(member.name .. " is WITHIN 10 yalms of " .. target_mob.name) end
                                         count = count + 1
                                         NEARBY_MEMBERS_BUFFER[count] = member.name
                                     else
-                                        debug(member.name .. " is OUT of aoe range from " .. target_mob.name)
+                                        if settings.debug then debug(member.name .. " is OUT of aoe range from " .. target_mob.name) end
                                     end
                                 else
-                                    debug(member.name .. " data unavailable (Too far away).")
+                                    if settings.debug then debug(member.name .. " data unavailable (Too far away).") end
                                 end
                             end
                         end
@@ -1687,8 +1683,7 @@ do
                         end
                     end
                 end
-                debug(string.format("IPC message sent: MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, player.name,
-                    target_name, spell.id, get_time()))
+                if settings.debug then debug(string.format("IPC message sent: MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id, get_time())) end
                 send_ipc(string.format("MIRDAIN|SPELL|%s|%s|%s|%.0f", player.name, target_name, spell.id, get_time()))
             end
         end
@@ -2685,15 +2680,15 @@ do
         --Reset state for spell-received gear tracking
         if state.SpellReceived.value ~= 'OFF' and outgoing_cast_active then
             outgoing_cast_active = false
-            debug(string.format("IPC message sent: MIRDAIN|COMPLETE|%s|%.0f", player.name, get_time()))
+            if settings.debug then debug(string.format("IPC message sent: MIRDAIN|COMPLETE|%s|%.0f", player.name, get_time())) end
             send_ipc(string.format("MIRDAIN|COMPLETE|%s|%.0f", player.name, get_time()))
             if accession_predicted and not spell.interrupted and spell.type == "WhiteMagic" then
                 accession_predicted = false
-                debug("Accessioned spell probably used while tracking. Accession_Predicted = False")
+                if settings.debug then debug("Accessioned spell probably used while tracking. Accession_Predicted = False") end
             end
             if divine_seal_predicted and not spell.interrupted and spell.type == "WhiteMagic" and spell.skill == "Healing Magic" then
                 divine_seal_predicted = false
-                debug("Divine Sealed spell probably used while tracking. Divine_Seal_Predicted = False")
+                if settings.debug then debug("Divine Sealed spell probably used while tracking. Divine_Seal_Predicted = False") end
             end
         end
         --Generate the correct set from the include file and custom function
@@ -4148,7 +4143,7 @@ do
             Location.z = position.z
         end
 
-        if Require_Update and not is_busy then
+        if Require_Update and not is_Busy then
             equip_set_command()
             Require_Update = false
         end
@@ -4161,7 +4156,7 @@ do
         end
 
         -- function used for periodic updates - feature
-        if Cycle_Timer and now - UpdateTime2 > 2 and not is_busy then
+        if Cycle_Timer and now - UpdateTime2 > 2 and not is_Busy then
             Cycle_Timer()
             UpdateTime2 = now
         end
@@ -4205,8 +4200,8 @@ do
                 local spell_id = split_msg[5] or "Missing Spell ID"
                 local time_sent = tonumber(split_msg[6]) or 9999999999999
                 local time_received = get_time()
-                debug("Targeted IPC Message Received: " ..
-                    msg .. " after " .. (time_received - time_sent) .. " ms")
+                if settings.debug then debug("Targeted IPC Message Received: " ..
+                    msg .. " after " .. (time_received - time_sent) .. " ms") end
 
                 if next(active_incoming_casters) == nil then
                     cast_start_time = time_sent
@@ -4215,10 +4210,10 @@ do
 
                 -- Add caster to active pool and refresh failsafe timer
                 active_incoming_casters[caster_name] = true
-                debug(caster_name .. " added to Active Incoming Casters (" .. count_keys(active_incoming_casters) .. ")")
+                if settings.debug then debug(caster_name .. " added to Active Incoming Casters (" .. count_keys(active_incoming_casters) .. ")") end
                 failsafe_active = true
                 failsafe_trigger_time = os.clock() + settings.delay
-                debug(player.name .. " is targeted by " .. caster_name .. ". Gear equipped and timer refreshed.")
+                if settings.debug then debug(player.name .. " is targeted by " .. caster_name .. ". Gear equipped and timer refreshed.") end
             end
         elseif msg:startswith('MIRDAIN|ABILITY|') then
             local split_msg = msg:split("|")
@@ -4228,8 +4223,8 @@ do
                 local spell_id = split_msg[5] or "Missing Spell ID"
                 local time_sent = tonumber(split_msg[6]) or 9999999999999
                 local time_received = get_time()
-                debug("Targeted IPC Message Received: " ..
-                    msg .. " after " .. (time_received - time_sent) .. " ms")
+                if settings.debug then debug("Targeted IPC Message Received: " ..
+                    msg .. " after " .. (time_received - time_sent) .. " ms") end
 
                 if next(active_incoming_casters) == nil then
                     cast_start_time = time_sent
@@ -4238,29 +4233,29 @@ do
 
                 -- Add caster to active pool and refresh failsafe timer
                 active_incoming_casters[caster_name] = true
-                debug(caster_name .. " added to Active Incoming Casters (" .. count_keys(active_incoming_casters) .. ")")
+                if settings.debug then debug(caster_name .. " added to Active Incoming Casters (" .. count_keys(active_incoming_casters) .. ")") end
                 failsafe_active = true
                 failsafe_trigger_time = os.clock() + settings.delay
-                debug(player.name .. " is targeted by " .. caster_name .. ". Gear equipped and timer refreshed.")
+                if settings.debug then debug(player.name .. " is targeted by " .. caster_name .. ". Gear equipped and timer refreshed.") end
             end
         elseif msg:startswith('MIRDAIN|COMPLETE|') then
             if next(active_incoming_casters) ~= nil then
-                debug("Targeted IPC Message Received: " .. msg)
+                if settings.debug then debug("Targeted IPC Message Received: " .. msg) end
                 local split_msg = msg:split("|")
                 local caster_name = split_msg[3]
                 local time_sent = tonumber(split_msg[4])
                 if active_incoming_casters[caster_name] then
                     active_incoming_casters[caster_name] = nil
-                    debug(caster_name ..
+                    if settings.debug then debug(caster_name ..
                         " finished casting after " ..
                         (time_sent - cast_start_time) ..
-                        " ms and is removed from Active Incoming Casters (" .. count_keys(active_incoming_casters) .. ")")
+                        " ms and is removed from Active Incoming Casters (" .. count_keys(active_incoming_casters) .. ")") end
                     if next(active_incoming_casters) == nil then
-                        debug("No active incoming casts remain. Resetting gear.")
+                        if settings.debug then debug("No active incoming casts remain. Resetting gear.") end
                         if state.SpellReceived.value == 'ON-Locked' then
                             for slot, _ in pairs(active_external_locks) do
                                 enable(slot)
-                                debug("Unlocking " .. tostring(slot))
+                                if settings.debug then debug("Unlocking " .. tostring(slot)) end
                             end
                             active_external_locks = {}
                         end
@@ -4279,18 +4274,12 @@ do
             failsafe_active = false
             failsafe_trigger_time = 0
             active_incoming_casters = {}
-            debug("Failsafe triggered! Sending equipment reset command.")
+            if settings.debug then debug("Failsafe triggered! Sending equipment reset command.") end
             for slot, _ in pairs(active_external_locks) do
                 enable(slot)
             end
             active_external_locks = {}
-
-            local built_set = choose_set()
-            if type(choose_set_custom) == 'function' then
-                built_set = set_combine(built_set, choose_set_custom())
-            else
-                warn('[Mirdain Spell-Rec]: choose_set_custom() not found!')
-            end
+            equip_set_command()
         end
     end)
 

--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -764,11 +764,15 @@ do
 
     local function equip_spell_received_gear(spell_id, spell_type)
         if settings.debug then debug("Equip gear function triggered: " .. spell_id .. ", " .. spell_type) end
-        local s_info = {}
+        local s_info
         if spell_type == "spell" then
             s_info = spell_info[spell_id]
         elseif spell_type == "ability" then
             s_info = ability_info[spell_id]
+        end
+        if not s_info then
+            warn("Unknown Spell for Spell Received Gear")
+            return
         end
 
         --Calculate delta since cast start time in milliseconds
@@ -825,7 +829,7 @@ do
                 warn("sets.Waltz_Received not found!")
             end
         else
-            warn("Unknown Spell for Spell Received Gear")
+            warn("Unknown Equip Set for Spell Received Gear")
         end
 
         if type(spell_received_set) == 'table' then
@@ -2569,7 +2573,7 @@ do
             Spellstart = os.clock()
             is_Busy = true
         else
-            log('Player is Busy [' .. spell.english .. ']')
+            log('Player is Busy [', spell.english, ']')
             cancel_spell()
             return
         end
@@ -2582,7 +2586,8 @@ do
             warn('precast_custom() not found!')
         end
         -- Check the gear
-        built_set = set_combine(built_set, check_equipment_spells(spell))
+        local equipment_spell_set = check_equipment_spells(spell)
+        if equipment_spell_set then built_set = set_combine(built_set, equipment_spell_set) end
         -- Here is where gear is actually equipped
         equip(built_set)
     end
@@ -2601,7 +2606,8 @@ do
             warn('midcast_custom() not found!')
         end
         -- Check the gear
-        built_set = set_combine(built_set, check_equipment_spells(spell))
+        local equipment_spell_set = check_equipment_spells(spell)
+        if equipment_spell_set then built_set = set_combine(built_set, equipment_spell_set) end
         -- Here is where gear is actually equipped
         equip(built_set)
     end
@@ -2795,7 +2801,7 @@ do
         if spell and built_set then
             local bullet_name = built_set.ammo
             if bullet_name == 'empty' or not bullet_name then return end
-            log('Ammo name is: ' .. bullet_name)
+            log('Ammo name is: ', bullet_name)
 
             local bullet_min_count = 1
             if spell.action_type == 'Ranged Attack' then
@@ -2847,7 +2853,7 @@ do
                     player.wardrobe8[bullet_name].count
             end
 
-            log('Bullet Count [' .. available_bullets .. ']')
+            log('Bullet Count [', available_bullets, ']')
 
             if available_bullets == 0 then
                 -- If no ammo is available, give appropriate warning and end.
@@ -2933,7 +2939,7 @@ do
     -------------------------------------------------------------------------------------------------------------------
 
     function check_equipment_spells(spell)
-        local built_set = {}
+        local built_set
         --Equip weapon for Dispelga
         if spell.name == "Dispelga" then
             built_set = { main = "Daybreak" }
@@ -2971,13 +2977,12 @@ do
     end
 
     --Helper function for checking if player has an item available to equip.
+    -- 0 = Main Inventory
+    -- 8, 9, 10, 11 = Wardrobes 1-4
+    -- 12, 13, 14, 15 = Wardrobes 5-8
+    local ITEM_SEARCH_BAGS = { 0, 8, 9, 10, 11, 12, 13, 14, 15 }
     local function has_item(item_id)
-        -- 0 = Main Inventory
-        -- 8, 9, 10, 11 = Wardrobes 1-4
-        -- 12, 13, 14, 15 = Wardrobes 5-8
-        local target_bags = { 0, 8, 9, 10, 11, 12, 13, 14, 15 }
-
-        for _, bag_id in ipairs(target_bags) do
+       for _, bag_id in ipairs(ITEM_SEARCH_BAGS) do
             local bag = windower.ffxi.get_items(bag_id)
             if bag then
                 for _, item in ipairs(bag) do
@@ -3020,8 +3025,7 @@ do
                 info('Treasure Hunter Mode: [' .. state.TreasureMode.value .. ']')
                 display_box_update()
             else
-                local mode = {}
-                mode = string.split(cmd, " ", 2)
+                local mode = string.split(cmd, " ", 2)
                 state.TreasureMode:set(mode[2])
                 info('Treasure Hunter Mode: [' .. state.TreasureMode.value .. ']')
                 display_box_update()
@@ -3034,8 +3038,7 @@ do
                 info('Spell Received Mode: [' .. state.SpellReceived.value .. ']')
                 display_box_update()
             else
-                local mode = {}
-                mode = string.split(cmd, " ", 2)
+                local mode = string.split(cmd, " ", 2)
                 if mode[2]:contains("on-locked") then
                     state.SpellReceived:set("ON-Locked")
                 elseif mode[2]:contains("on-unlocked") then
@@ -3056,8 +3059,7 @@ do
                 info('Hoxne Ampulla Mode: [' .. state.Hoxne.value .. ']')
                 display_box_update()
             else
-                local mode = {}
-                mode = string.split(cmd, " ", 2)
+                local mode = string.split(cmd, " ", 2)
                 if mode[2]:contains("on") then
                     state.Hoxne:set("ON")
                 elseif mode[2]:contains("off") then
@@ -3092,8 +3094,7 @@ do
                 state.AutoBuff:cycle()
                 info('Auto Buff is [' .. state.AutoBuff.value .. ']')
             else
-                local mode = {}
-                mode = string.split(cmd, " ", 2)
+                local mode = string.split(cmd, " ", 2)
                 state.AutoBuff:set(mode[2])
                 info('Auto Buff is [' .. state.AutoBuff.value .. ']')
             end
@@ -3185,8 +3186,7 @@ do
                     end
                 end
             else
-                local mode = {}
-                mode = string.split(cmd, " ", 2)
+                local mode = string.split(cmd, " ", 2)
                 state.OffenseMode:set(mode[2])
                 info('Offense Mode: [' .. state.OffenseMode.value .. ']')
                 display_box_update()
@@ -3211,8 +3211,7 @@ do
                     end
                 end
             else
-                local mode = {}
-                mode = string.split(cmd, " ", 2)
+                local mode = string.split(cmd, " ", 2)
                 state.WeaponMode:set(mode[2])
                 info('Weapon Mode: [' .. state.WeaponMode.value .. ']')
                 display_box_update()
@@ -3238,8 +3237,7 @@ do
                     end
                 end
             else
-                local mode = {}
-                mode = string.split(cmd, " ", 2)
+                local mode = string.split(cmd, " ", 2)
                 state.JobMode2:set(mode[2])
                 info(UI_Name2 .. ': [' .. state.JobMode2.value .. ']')
                 display_box_update()
@@ -3265,8 +3263,7 @@ do
                     end
                 end
             else
-                local mode = {}
-                mode = string.split(cmd, " ", 2)
+                local mode = string.split(cmd, " ", 2)
                 state.JobMode:set(mode[2])
                 info(UI_Name .. ': [' .. state.JobMode.value .. ']')
                 display_box_update()
@@ -3518,7 +3515,7 @@ do
     end
 
     function Use_Item()
-        log('/item "' .. Use_Item_Command .. '" ' .. player.id)
+        log('/item "', Use_Item_Command, '" ', player.id)
         windower.chat.input('/item "' .. Use_Item_Command .. '" <me>')
     end
 
@@ -3838,8 +3835,23 @@ do
         add_to_chat("Settings Saved")
     end
 
+    local debug_box_state = {}
     -- Used to help debug issues
     function debug_box_update()
+        if debug_box_state.busy == is_Busy
+            and debug_box_state.moving == is_moving
+            and debug_box_state.dual_wield == DualWield
+            and debug_box_state.two_hand == TwoHand
+            and debug_box_state.casting == outgoing_cast_active
+            and debug_box_state.failsafe == failsafe_active then
+            return
+        end
+        debug_box_state.busy = is_Busy
+        debug_box_state.moving = is_moving
+        debug_box_state.dual_wield = DualWield
+        debug_box_state.two_hand = TwoHand
+        debug_box_state.casting = outgoing_cast_active
+        debug_box_state.failsafe = failsafe_active
         local lines = T {}
         lines:insert('is_Busy' .. string.format('[%s]', tostring(is_Busy)):lpad(' ', 12))
         lines:insert('is_Moving' .. string.format('[%s]', tostring(is_moving)):lpad(' ', 10))
@@ -3852,16 +3864,23 @@ do
         gs_debug:text(lines:concat('\n'))
     end
 
-    function log(msg)
-        if settings.debug then print(80, msg) end
+    local function join(...)
+        if select('#', ...) < 2 then return (...) end
+        local parts = {}
+        for i = 1, select('#', ...) do parts[i] = tostring((select(i, ...))) end
+        return table.concat(parts)
     end
 
-    function info(msg)
-        if settings.info then print(8, msg) end
+    function log(...)
+        if settings.debug then print(80, join(...)) end
     end
 
-    function warn(msg)
-        if settings.warn then print(12, msg) end
+    function info(...)
+        if settings.info then print(8, join(...)) end
+    end
+
+    function warn(...)
+        if settings.warn then print(12, join(...)) end
     end
 
     function print(mode, msg)
@@ -4032,7 +4051,7 @@ do
         elseif data.category == 3 and data.param ~= 0 then
             local t = windower.ffxi.get_mob_by_id(data.targets[1].id)
             if t and t.id == last_skillchain_id then
-                log('Skillchain is closed for [' .. last_skillchain_id .. ']')
+                log('Skillchain is closed for [', last_skillchain_id, ']')
                 last_skillchain_elements = {}
                 last_skillchain_id = 0
                 last_skillchain_time = 0
@@ -4051,18 +4070,24 @@ do
         if now - main_engine_time < .1 then return end
         -- Update the debug UI if visible
         if settings.debug then debug_box_update() end
+        -- Hoist the buff table and status out of the repeated lookups below
+        local active_buffs = buffactive
+        local player_status = player and player.status
         -- Go no farther as you are dead
-        if not player or player.status == "Dead" or player.status == "Engaged dead" or buffactive['Charm'] or buffactive['Sleep'] then return end
+        if not player or player_status == "Dead" or player_status == "Engaged dead" or active_buffs['Charm'] or active_buffs['Sleep'] then return end
         -- Status Ailment Check
-        if not buffactive['Paralysis'] and not buffactive['Silence'] and not buffactive['Muddle'] then
+        if not active_buffs['Paralysis'] and not active_buffs['Silence'] and not active_buffs['Muddle'] then
             check_buff()
         end
-        local position = windower.ffxi.get_mob_by_id(player.id)
-        if position and not buffactive['Mounted'] and not is_Busy then
-            local movement = math.sqrt((position.x - Location.x) ^ 2 + (position.y - Location.y) ^ 2 +
-                (position.z - Location.z) ^ 2) > 0.5
+        local position = get_mob_by_id(player.id)
+        if position and not active_buffs['Mounted'] and not is_Busy then
+            -- Compare squared distance: saves a sqrt and three pow calls per poll.
+            local dx = position.x - Location.x
+            local dy = position.y - Location.y
+            local dz = position.z - Location.z
+            local movement = (dx * dx + dy * dy + dz * dz) > 0.25 -- 0.5 yalms, squared
             if movement and not is_moving then
-                if player.status ~= "Engaged" then
+                if player_status ~= "Engaged" then
                     is_moving = true
                     Require_Update = true
                     --windower.chat.input('/echo Moving! Status: '..player.status..'')
@@ -4095,7 +4120,7 @@ do
             UpdateTime2 = now
         end
 
-        main_engine_time = os.clock()
+        main_engine_time = now
     end
 
     -- Register event section
@@ -4202,7 +4227,7 @@ do
     end)
 
     windower.register_event('prerender', function()
-        if state.SpellReceived.value == "OFF" or not failsafe_active then return end
+        if not failsafe_active or state.SpellReceived.value == "OFF" then return end
 
         if os.clock() >= failsafe_trigger_time then
             failsafe_active = false
@@ -4396,7 +4421,7 @@ do
                     -- Ranged attack start
                 elseif data.category == 12 then
                     if data.param == 24931 then
-                        log('' .. player.name .. ' is Shooting')
+                        log(player.name, ' is Shooting')
                     elseif data.param == 28787 then
                         log('Shooting is interrupted')
                     end

--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -13,7 +13,7 @@ Original credit to Mirdain.  Pull request to be submitted after beta testing.
 ]]
 
 -- Global Variables
-Mirdain_GS = '1.6.4'
+Mirdain_GS = '1.6.5'
 
 -- Modes is the include file for a mode-tracking variable class.  Used for state vars, below.
 include('Modes')
@@ -214,12 +214,12 @@ state.OffenseMode = M { ['description'] = 'Melee Mode' }
 state.OffenseMode:options('TP', 'ACC', 'DT')
 state.OffenseMode:set('TP')
 
---Modes for Spell-Received Tracking via IPC. Locked will keep spell received gear
---slots locked while waiting for spell completion from the caster.
---Unlocks slots at spell completion and defined delay as failsafe.
+--Modes for Spell-Received Tracking via IPC. ON equips the received gear and keeps
+--those slots locked until the caster's spell completes, unlocking at completion
+--or after the configured delay as a failsafe.
 state.SpellReceived = M { ['description'] = "Spell-Received" }
-state.SpellReceived:options('OFF', 'ON-Locked', 'ON-Unlocked')
-state.SpellReceived:set('ON-LOCKED')
+state.SpellReceived:options('OFF', 'ON')
+state.SpellReceived:set('ON')
 
 --Modes for Hoxne Ampulla locking
 state.Hoxne = M { ['description'] = 'Hoxne' }
@@ -461,8 +461,14 @@ Ready_Debuff = S { 'Dust Cloud', 'Sheep Song', 'Scream', 'Dream Flower', 'Roar',
 -- Physical Ready moves that have Multi-Hit
 Ready_Multi = S { 'Sweeping Gouge', 'Tickling Tendrils', 'Chomp Rush', 'Pentapeck', 'Wing Slap', 'Pecking Flurry' }
 
+-- Long names, used in chat messages. Empty hides the mode entirely.
 UI_Name = ''
 UI_Name2 = ''
+
+-- Optional short labels for the status box. Leave empty and the include derives
+-- one from UI_Name, so existing job files need no changes.
+UI_Short = ''
+UI_Short2 = ''
 
 -- Keep local variables to the include
 do
@@ -478,8 +484,8 @@ do
         debug = false,
         info = true,
         warn = true,
-        Display_Box = { text = { size = 11, font = 'Consolas', red = 255, green = 255, blue = 255, alpha = 255 }, pos = { x = 0, y = 0 }, bg = { visible = true, red = 0, green = 0, blue = 0, alpha = 150 }, flags = { bold = true } },
-        Debug_Box = { text = { size = 11, font = 'Consolas', red = 255, green = 255, blue = 255, alpha = 255 }, pos = { x = 0, y = 50 }, bg = { visible = true, red = 0, green = 0, blue = 0, alpha = 150 }, flags = { bold = true } },
+        Display_Box = { text = { size = 11, font = 'Consolas', red = 255, green = 255, blue = 255, alpha = 255, stroke = { width = 2, alpha = 200, red = 0, green = 0, blue = 0 } }, pos = { x = 0, y = 0 }, bg = { visible = true, red = 0, green = 0, blue = 0, alpha = 190 }, flags = { bold = true }, padding = 3 },
+        Debug_Box = { text = { size = 11, font = 'Consolas', red = 255, green = 255, blue = 255, alpha = 255, stroke = { width = 2, alpha = 200, red = 0, green = 0, blue = 0 } }, pos = { x = 0, y = 50 }, bg = { visible = true, red = 0, green = 0, blue = 0, alpha = 190 }, flags = { bold = true }, padding = 3 },
         delay = 3,
     }
 
@@ -516,10 +522,37 @@ do
 
     local settings = config.load(default)
 
-    local gs_status = texts.new("", settings.Display_Box)
-    if settings.visible then gs_status:show() end
+    --Function to apply display box settings.  Used after display creation to ensure settings are tied to the newly created box for auto-saving.
+    local function apply_box_settings(box, cfg)
+        box:pos(cfg.pos.x, cfg.pos.y)
+        box:font(cfg.text.font, unpack(cfg.text.fonts))
+        box:size(cfg.text.size)
+        box:color(cfg.text.red, cfg.text.green, cfg.text.blue)
+        box:alpha(cfg.text.alpha)
+        box:stroke_width(cfg.text.stroke.width)
+        box:stroke_color(cfg.text.stroke.red, cfg.text.stroke.green, cfg.text.stroke.blue)
+        box:stroke_alpha(cfg.text.stroke.alpha)
+        box:bg_color(cfg.bg.red, cfg.bg.green, cfg.bg.blue)
+        box:bg_alpha(cfg.bg.alpha)
+        box:bg_visible(cfg.bg.visible)
+        box:bold(cfg.flags.bold)
+        box:italic(cfg.flags.italic)
+        box:right_justified(cfg.flags.right)
+        box:bottom_justified(cfg.flags.bottom)
+        box:pad(cfg.padding)
+    end
 
-    local gs_debug = texts.new("", settings.Debug_Box)
+    local gs_status = texts.new("", settings.Display_Box, settings)
+    local gs_debug = texts.new("", settings.Debug_Box, settings)
+
+    apply_box_settings(gs_status, settings.Display_Box)
+    apply_box_settings(gs_debug, settings.Debug_Box)
+
+    --Sets status and debug displays to draggable only when displayed
+    gs_status:draggable(settings.visible and true or false)
+    gs_debug:draggable(settings.debug and true or false)
+
+    if settings.visible then gs_status:show() end
     if settings.debug then gs_debug:show() end
 
     local DualWield = false
@@ -937,7 +970,7 @@ do
 
         if type(spell_received_set) == 'table' then
             equip(spell_received_set)
-            if state.SpellReceived.value == "ON-Locked" then
+            if state.SpellReceived.value == "ON" then
                 --Lock the slots of items from the spell received set to prevent other
                 --actions from overwriting until cast completion
                 for slot, item in pairs(spell_received_set) do
@@ -3088,9 +3121,7 @@ do
 
     --Helper function for checking if player has an item available to equip.
     --Bag ids per res/bags.lua:
-    --   0 = Inventory, 8 = Wardrobe, 10-15 = Wardrobes 2-7, 16 = Wardrobe 8.
-    --Bag 9 is Safe 2 (equippable=false) and is deliberately excluded; an item there
-    --cannot be equipped, so reporting it as available would lock slots on nothing.
+    --0 = Inventory, 8 = Wardrobe, 10-15 = Wardrobes 2-7, 16 = Wardrobe 8.
     local ITEM_SEARCH_BAGS = { 0, 8, 10, 11, 12, 13, 14, 15, 16 }
     local function has_item(item_id)
         for _, bag_id in ipairs(ITEM_SEARCH_BAGS) do
@@ -3105,12 +3136,65 @@ do
         end
         return false
     end
+
+    --Command helper functions to validate user-typed arguments are acceptable options for each 'gs c xxxx arg'
+    local function command_arg(cmd)
+        local arg = cmd:match('^%s*%S+%s+(.-)%s*$')
+        if not arg or arg == '' then return nil end
+        return arg
+    end
+
+    local function mode_options(m)
+        local opts = T {}
+        if type(m) == 'table' and m._track and m._track._type == 'list' then
+            for _, v in ipairs(m) do opts:insert(tostring(v)) end
+        end
+        return opts
+    end
+
+    -- Returns the canonical option on an exact match, otherwise nil plus the
+    -- closest option as a suggestion only. Partial and legacy values are never
+    -- silently accepted.
+    local function match_mode_value(m, arg)
+        local opts = mode_options(m)
+        if not arg then return nil, nil, opts end
+        local want = arg:lower()
+        for _, v in ipairs(opts) do
+            if v:lower() == want then return v, nil, opts end
+        end
+        for _, v in ipairs(opts) do
+            local lv = v:lower()
+            if lv:startswith(want) or want:startswith(lv) then return nil, v, opts end
+        end
+        for _, v in ipairs(opts) do
+            local lv = v:lower()
+            if lv:contains(want) or want:contains(lv) then return nil, v, opts end
+        end
+        return nil, nil, opts
+    end
+
+    -- Validate and apply a mode argument. Returns true when the mode was set.
+    local function set_mode_arg(m, label, usage, arg)
+        local value, suggestion, opts = match_mode_value(m, arg)
+        if value then
+            m:set(value)
+            return true
+        end
+        if arg then
+            warn(('%s: "%s" is not a valid mode.%s'):format(
+                label, tostring(arg), suggestion and (' Did you mean [' .. suggestion .. ']?') or ''))
+        else
+            warn(('%s: no mode given.'):format(label))
+        end
+        warn(('Usage: //gs c %s [%s]'):format(usage, opts:concat('|')))
+        return false
+    end
     -------------------------------------------------------------------------------------------------------------------
     -- This function is called by the user via the self command - "gs c XXXX"
     -------------------------------------------------------------------------------------------------------------------
 
     function self_command(cmd)
-        local command = cmd:lower()
+        local command = cmd:lower():trim()
         if command == 'update auto' then
             local built_set = choose_set()
             if choose_set_custom then
@@ -3135,11 +3219,11 @@ do
                 state.TreasureMode:cycle()
                 info('Treasure Hunter Mode: [' .. state.TreasureMode.value .. ']')
                 display_box_update()
-            else
-                local mode = string.split(cmd, " ", 2)
-                state.TreasureMode:set(mode[2])
+            elseif set_mode_arg(state.TreasureMode, 'Treasure Hunter', 'TreasureHunter', command_arg(cmd)) then
                 info('Treasure Hunter Mode: [' .. state.TreasureMode.value .. ']')
                 display_box_update()
+            else
+                return
             end
             equip_set_command()
             return
@@ -3148,19 +3232,11 @@ do
                 state.SpellReceived:cycle()
                 info('Spell Received Mode: [' .. state.SpellReceived.value .. ']')
                 display_box_update()
-            else
-                local mode = string.split(cmd, " ", 2)
-                if mode[2]:contains("on-locked") then
-                    state.SpellReceived:set("ON-Locked")
-                elseif mode[2]:contains("on-unlocked") then
-                    state.SpellReceived:set('ON-Unlocked')
-                elseif mode[2]:contains("off") then
-                    state.SpellReceived:set('OFF')
-                else
-                    warn('Spell Received state not recognized')
-                end
+            elseif set_mode_arg(state.SpellReceived, 'Spell Received', 'SpellReceived', command_arg(cmd)) then
                 info('Spell Received Mode: [' .. state.SpellReceived.value .. ']')
                 display_box_update()
+            else
+                return
             end
             equip_set_command()
             return
@@ -3169,17 +3245,11 @@ do
                 state.Hoxne:cycle()
                 info('Hoxne Ampulla Mode: [' .. state.Hoxne.value .. ']')
                 display_box_update()
-            else
-                local mode = string.split(cmd, " ", 2)
-                if mode[2]:contains("on") then
-                    state.Hoxne:set("ON")
-                elseif mode[2]:contains("off") then
-                    state.Hoxne:set('OFF')
-                else
-                    warn('Hoxne Ampulla locking state not recognized')
-                end
-                info('Spell Received Mode: [' .. state.Hoxne.value .. ']')
+            elseif set_mode_arg(state.Hoxne, 'Hoxne Ampulla', 'Hoxne', command_arg(cmd)) then
+                info('Hoxne Ampulla Mode: [' .. state.Hoxne.value .. ']')
                 display_box_update()
+            else
+                return
             end
             if state.Hoxne.value == "ON" then
                 local hoxne_id = res.items:with('en', "Hoxne Ampulla").id
@@ -3204,10 +3274,10 @@ do
             if command == 'autobuff' then
                 state.AutoBuff:cycle()
                 info('Auto Buff is [' .. state.AutoBuff.value .. ']')
-            else
-                local mode = string.split(cmd, " ", 2)
-                state.AutoBuff:set(mode[2])
+            elseif set_mode_arg(state.AutoBuff, 'Auto Buff', 'AutoBuff', command_arg(cmd)) then
                 info('Auto Buff is [' .. state.AutoBuff.value .. ']')
+            else
+                return
             end
             display_box_update()
             equip_set_command()
@@ -3239,10 +3309,14 @@ do
             if settings.debug == true then
                 settings.debug = false
                 gs_debug:hide()
+                gs_debug:draggable(false)
                 windower.add_to_chat(80, 'The debugging is now [OFF]')
             else
                 settings.debug = true
+                gs_debug:draggable(true)
                 gs_debug:show()
+                debug_box_reset()
+                debug_box_update()
                 log('The debugging is now [ON]')
             end
         elseif command == 'warn' then
@@ -3300,12 +3374,12 @@ do
                         return
                     end
                 end
-            else
-                local mode = string.split(cmd, " ", 2)
-                state.OffenseMode:set(mode[2])
+            elseif set_mode_arg(state.OffenseMode, 'Offense Mode', 'OffenseMode', command_arg(cmd)) then
                 info('Offense Mode: [' .. state.OffenseMode.value .. ']')
                 display_box_update()
                 equip_set_command()
+                return
+            else
                 return
             end
         elseif command:contains('weaponmode') then
@@ -3325,14 +3399,14 @@ do
                         return
                     end
                 end
-            else
-                local mode = string.split(cmd, " ", 2)
-                state.WeaponMode:set(mode[2])
+            elseif set_mode_arg(state.WeaponMode, 'Weapon Mode', 'WeaponMode', command_arg(cmd)) then
                 info('Weapon Mode: [' .. state.WeaponMode.value .. ']')
                 display_box_update()
                 if self_command_custom then self_command_custom(command) end
                 two_hand_check()
                 equip_set_command()
+                return
+            else
                 return
             end
         elseif command:contains('jobmode2') then
@@ -3351,13 +3425,13 @@ do
                         return
                     end
                 end
-            else
-                local mode = string.split(cmd, " ", 2)
-                state.JobMode2:set(mode[2])
+            elseif set_mode_arg(state.JobMode2, UI_Name2 ~= '' and UI_Name2 or 'Job Mode 2', 'JobMode2', command_arg(cmd)) then
                 info(UI_Name2 .. ': [' .. state.JobMode2.value .. ']')
                 display_box_update()
                 if self_command_custom then self_command_custom(command) end
                 equip_set_command()
+                return
+            else
                 return
             end
         elseif command:contains('jobmode') then
@@ -3377,14 +3451,14 @@ do
                         return
                     end
                 end
-            else
-                local mode = string.split(cmd, " ", 2)
-                state.JobMode:set(mode[2])
+            elseif set_mode_arg(state.JobMode, UI_Name ~= '' and UI_Name or 'Job Mode', 'JobMode', command_arg(cmd)) then
                 info(UI_Name .. ': [' .. state.JobMode.value .. ']')
                 display_box_update()
                 -- Issue a command to the lua for the job specific command
                 if self_command_custom then self_command_custom(command) end
                 equip_set_command()
+                return
+            else
                 return
             end
             -- This profile mode is used to load a Silmaril profile and execute a script
@@ -3658,6 +3732,13 @@ do
 
     -- Unbind Keys when the file is unloaded
     function file_unload(file_name)
+        if gs_status then
+            gs_status:destroy()
+        end
+        if gs_debug then
+            gs_debug:destroy()
+        end
+        
         send_command('unbind ^f9')
         send_command('unbind ^f10')
         send_command('unbind ^f11')
@@ -3666,13 +3747,6 @@ do
         send_command('unbind f10')
         send_command('unbind f11')
         send_command('unbind f12')
-
-        if gs_status then
-            gs_status:destroy()
-        end
-        if gs_debug then
-            gs_debug:destroy()
-        end
 
         if active_external_locks and next(active_external_locks) ~= nil then
             for slot, _ in pairs(active_external_locks) do
@@ -3728,6 +3802,7 @@ do
 
     -- Called when the player's subjob changes.
     function sub_job_change(new, old)
+        invalidate_layout()
         coroutine.schedule(dual_wield_check, 2)
         coroutine.schedule(two_hand_check, 2.1)
         coroutine.schedule(equip_set_command, 2.2)
@@ -3900,66 +3975,175 @@ do
     end
 
     -- UI for displaying the current states
+    local GLYPH = {
+        on    = string.char(0xE2, 0x97, 0x8F), -- U+25CF Black Circle
+        off   = string.char(0xE2, 0x97, 0x8B), -- U+25CB White Circle
+        prev  = string.char(0xE2, 0x97, 0x84), -- U+25C4 Black left-pointing arrow
+        next  = string.char(0xE2, 0x96, 0xBA), -- U+25BA Black right-pointing arrow
+        trunc = string.char(0xE2, 0x80, 0xA6), -- U+2026 Elipsis
+    }
+
+    local COLOR = {
+        label = '150,150,150', value = '235,235,235', chev = '110,110,110',
+        idle  = '120,120,120',                        -- Hollow "off" circle
+        good  = '80,220,110',                         -- Fully on - green
+        warn  = '255,170,60',                         -- Partially on - amber for TH tag
+        cyan  = '90,200,255',                         -- TH SATA mode
+    }
+
+    local function cs(color, s) return '\\cs(' .. color .. ')' .. s .. '\\cr' end
+
+    local SEP = '  '
+
+    -- Define glyph variables for displaying mode status as a colored circle
+    local GLYPH_FIELDS = {
+        { label = 'TH',  mode = 'TreasureMode',  off = 'None',
+          colors = { ['Tag'] = COLOR.warn, ['Full Time'] = COLOR.good, ['SATA'] = COLOR.cyan } },
+        { label = 'SR',  mode = 'SpellReceived', off = 'OFF',
+          colors = { ['ON'] = COLOR.good } },
+        { label = 'HOX', mode = 'Hoxne',         off = 'OFF',
+          colors = { ['ON'] = COLOR.good } },
+    }
+
+    --3 letter aliases for known ui names. Backward-compatible.
+    local UI_SHORT_ALIASES = {
+        ['mode']      = 'MDE', ['pet']  = 'PET', ['tp mode'] = 'TPM',
+        ['auto tank'] = 'TNK', ['tank'] = 'TNK',
+        ['runes']     = 'RUN', ['rune'] = 'RUN',
+    }
+
+    -- Derive a three-cell label from a long mode name. Alias first, then a
+    -- generic rule: one word takes its first three letters, several words take
+    -- two letters of the first plus the initial of the last ("TP Mode" -> TPM).
+    local function derive_short(name)
+        local alias = UI_SHORT_ALIASES[name:lower()]
+        if alias then return alias end
+
+        local words = {}
+        for w in name:gmatch('%a+') do words[#words + 1] = w end
+
+        local short
+        if #words == 0 then
+            short = name:upper()
+        elseif #words == 1 then
+            short = words[1]:upper()
+        else
+            short = (words[1]:sub(1, 2) .. words[#words]:sub(1, 1)):upper()
+        end
+        return (short .. '   '):sub(1, 3)
+    end
+
+    -- An explicit UI_Short always wins and is used verbatim. The label column
+    -- widens to fit it.
+    local function status_label(explicit, name)
+        if explicit and explicit ~= '' then return explicit end
+        return derive_short(name)
+    end
+
+    -- Display columns, not bytes: mode values are ASCII, but glyphs are 3 bytes
+    -- each and colour tags are zero-width, so never measure a composed string.
+    local function cells(s)
+        local n = 0
+        for i = 1, #s do
+            local b = s:byte(i)
+            if b < 0x80 or b >= 0xC0 then n = n + 1 end
+        end
+        return n
+    end
+
+    local layout -- nil = rebuild on next draw
+
+    local function option_cells(m)
+        local w = 0
+        if type(m) == 'table' and m._track and m._track._type == 'list' then
+            for _, v in ipairs(m) do
+                local n = #tostring(v)
+                if n > w then w = n end
+            end
+        end
+        return w
+    end
+
+    local function build_layout()
+        -- Modes are referenced by name, not by object, so a job file replacing a
+        -- state table wholesale cannot force holding a stale reference.
+        local fields = {
+            { label = 'STN', mode = 'OffenseMode' },
+            { label = 'DPS', mode = 'WeaponMode' },
+        }
+        if UI_Name ~= '' then
+            fields[#fields + 1] = { label = status_label(UI_Short, UI_Name), mode = 'JobMode' }
+        end
+        if UI_Name2 ~= '' then
+            fields[#fields + 1] = { label = status_label(UI_Short2, UI_Name2), mode = 'JobMode2' }
+        end
+
+        local label_w, value_w = 3, 0
+        for _, f in ipairs(fields) do
+            if #f.label > label_w then label_w = #f.label end
+            value_w = math.max(value_w, option_cells(state[f.mode]))
+        end
+
+        local header_w = 0
+        for i, g in ipairs(GLYPH_FIELDS) do
+            header_w = header_w + #g.label + 2        -- label + space + circle
+            if i > 1 then header_w = header_w + #SEP end
+        end
+
+        layout = {
+            fields = fields, label_w = label_w, header_w = header_w,
+            -- Stretch the value field so the closing chevrons land on the
+            -- header's right edge. Row = label_w + 1 + 1 + value_w + 1.
+            value_w = math.max(value_w, header_w - label_w - 3,
+                settings.Display_MinValueCells or 0),
+        }
+    end
+
+    function invalidate_layout() layout = nil end
+
+    local function glyph_entry(g)
+        local m = state[g.mode]
+        local v = m and tostring(m.value) or ''
+        if v == g.off then
+            return cs(COLOR.label, g.label) .. ' ' .. cs(COLOR.idle, GLYPH.off)
+        end
+        return cs(COLOR.label, g.label) .. ' ' .. cs(g.colors[v] or COLOR.good, GLYPH.on)
+    end
+
+    local function centered(v, w)
+        local n = cells(v)
+        if n > w then
+            v, n = v:sub(1, w - 1) .. GLYPH.trunc, w -- values are ASCII; safe to sub
+        end
+        local pad = w - n
+        local left = math.floor(pad / 2)
+        return string.rep(' ', left) .. v .. string.rep(' ', pad - left)
+    end
+
+    -- UI for displaying the current states
     function display_box_update()
-        local dialog = {}
+        if not layout then build_layout() end
 
-        dialog[1] = { description = 'TH', value = state.TreasureMode.value, color = '255,215,0' } -- Gold
-
-        dialog[2] = {
-            description = 'Spell-Rec',
-            value = state.SpellReceived.value,
-            color = (state.SpellReceived.value:contains('ON') and '0,255,0' or state.SpellReceived.value == 'OFF' and '255,0,0' or '255,255,255')
-        }
-
-        dialog[3] = {
-            description = 'Hoxne',
-            value = state.Hoxne.value,
-            color = (state.Hoxne.value == 'ON' and '0,255,0' or state.Hoxne.value == 'OFF' and '255,0,0' or '255,255,255')
-        }
-
-        dialog[4] = { description = 'Stance', value = state.OffenseMode.value, color = '255,255,255' }
-        dialog[5] = { description = 'DPS', value = state.WeaponMode.value, color = '255,255,255' }
-
-        if UI_Name ~= "" then
-            dialog[6] = { description = UI_Name, value = state.JobMode.value, color = '255,255,255' }
-        end
-        if UI_Name2 ~= "" then
-            dialog[7] = { description = UI_Name2, value = state.JobMode2.value, color = '255,255,255' }
-        end
-
-        local lines = T {}
+        local head = T {}
+        for _, g in ipairs(GLYPH_FIELDS) do head:insert(glyph_entry(g)) end
 
         if settings.oneline then
-            for k, v in ipairs(dialog) do
-                local colored_val = string.format('\\cs(%s)[%s]\\cr', v.color, tostring(v.value))
-                lines:insert(string.format('%s:%s', v.description, colored_val))
+            -- Chevrons sit tight against the value; entries are space separated.
+            for _, f in ipairs(layout.fields) do
+                head:insert(cs(COLOR.label, f.label) .. ' '
+                    .. cs(COLOR.chev, GLYPH.prev)
+                    .. cs(COLOR.value, tostring(state[f.mode].value))
+                    .. cs(COLOR.chev, GLYPH.next))
             end
-            gs_status:text(lines:concat(' '))
+            gs_status:text(head:concat(SEP))
         else
-            local max_desc_len = 0
-            local max_val_len = 0
-
-            for _, v in ipairs(dialog) do
-                local raw_val_str = '[' .. tostring(v.value) .. ']'
-                if string.len(v.description) > max_desc_len then
-                    max_desc_len = string.len(v.description)
-                end
-                if string.len(raw_val_str) > max_val_len then
-                    max_val_len = string.len(raw_val_str)
-                end
+            local lines = T { head:concat(SEP) }
+            for _, f in ipairs(layout.fields) do
+                lines:insert(cs(COLOR.label, f.label .. string.rep(' ', layout.label_w - #f.label))
+                    .. ' ' .. cs(COLOR.chev, GLYPH.prev)
+                    .. cs(COLOR.value, centered(tostring(state[f.mode].value), layout.value_w))
+                    .. cs(COLOR.chev, GLYPH.next))
             end
-
-            local target_desc_width = max_desc_len + 1
-
-            for k, v in ipairs(dialog) do
-                local raw_val_str = '[' .. tostring(v.value) .. ']'
-                local padded_desc = v.description:rpad(' ', target_desc_width)
-                local value_padding_needed = max_val_len - string.len(raw_val_str)
-                local value_spaces = string.rep(' ', value_padding_needed)
-                local colored_val = string.format('\\cs(%s)%s\\cr', v.color, raw_val_str)
-                lines:insert(padded_desc .. value_spaces .. colored_val)
-            end
-
             gs_status:text(lines:concat('\n'))
         end
     end
@@ -3973,6 +4157,8 @@ do
     end
 
     local debug_box_state = {}
+    function debug_box_reset() debug_box_state = {} end
+    
     -- Used to help debug issues
     function debug_box_update()
         if debug_box_state.busy == is_Busy
@@ -4268,28 +4454,6 @@ do
     windower.raw_register_event('outgoing chunk', main_engine)
     windower.raw_register_event('zone change', on_zone_change_for_th)
 
-    local is_dragging = false
-    local drag_sx, drag_sy, drag_dx, drag_dy
-    windower.raw_register_event('mouse', function(type, x, y, delta, blocked)
-        -- Mouse move is type 0.  Reject anything that is not a left button press (1) or release (2).
-        if type ~= 1 and type ~= 2 then return end
-
-        if type == 1 then
-            is_dragging = gs_status:hover(x, y) or gs_debug:hover(x, y)
-            if is_dragging then
-                drag_sx, drag_sy = gs_status:pos_x(), gs_status:pos_y()
-                drag_dx, drag_dy = gs_debug:pos_x(), gs_debug:pos_y()
-            end
-        elseif is_dragging then
-            is_dragging = false
-            if gs_status:pos_x() ~= drag_sx or gs_status:pos_y() ~= drag_sy
-                or gs_debug:pos_x() ~= drag_dx or gs_debug:pos_y() ~= drag_dy then
-                config.save(settings)
-                windower.add_to_chat(80, "Settings saved")
-            end
-        end
-    end)
-
     windower.register_event('ipc message', function(msg)
         if state.SpellReceived.value == 'OFF' then return end
 
@@ -4372,7 +4536,7 @@ do
                     end
                     if next(active_incoming_casters) == nil then
                         if settings.debug then debug("No active incoming casts remain. Resetting gear.") end
-                        if state.SpellReceived.value == 'ON-Locked' then
+                        if state.SpellReceived.value == 'ON' then
                             for slot, _ in pairs(active_external_locks) do
                                 enable(slot)
                                 if settings.debug then debug("Unlocking " .. tostring(slot)) end

--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -3739,7 +3739,7 @@ do
         if gs_debug then
             gs_debug:destroy()
         end
-        
+
         send_command('unbind ^f9')
         send_command('unbind ^f10')
         send_command('unbind ^f11')
@@ -3978,18 +3978,20 @@ do
     -- UI for displaying the current states
     local GLYPH = {
         on    = string.char(0xE2, 0x97, 0x8F), -- U+25CF Black Circle
-        off   = string.char(0xE2, 0x97, 0x8B), -- U+25CB White Circle
+        off   = string.char(0xE2, 0x97, 0x8F), -- U+25CB White Circle
         prev  = string.char(0xE2, 0x97, 0x84), -- U+25C4 Black left-pointing arrow
         next  = string.char(0xE2, 0x96, 0xBA), -- U+25BA Black right-pointing arrow
         trunc = string.char(0xE2, 0x80, 0xA6), -- U+2026 Elipsis
     }
 
     local COLOR = {
-        label = '150,150,150', value = '235,235,235', chev = '110,110,110',
-        idle  = '120,120,120',                        -- Hollow "off" circle
-        good  = '80,220,110',                         -- Fully on - green
-        warn  = '255,170,60',                         -- Partially on - amber for TH tag
-        cyan  = '90,200,255',                         -- TH SATA mode
+        label = '150,150,150',
+        value = '235,235,235',
+        chev = '110,110,110',
+        idle = '120,120,120',  -- Hollow "off" circle
+        good = '80,220,110',   -- Fully on - green
+        warn = '255,170,60',   -- Partially on - amber for TH tag
+        cyan = '90,200,255',   -- TH SATA mode
     }
 
     local function cs(color, s) return '\\cs(' .. color .. ')' .. s .. '\\cr' end
@@ -3998,19 +4000,35 @@ do
 
     -- Define glyph variables for displaying mode status as a colored circle
     local GLYPH_FIELDS = {
-        { label = 'TH',  mode = 'TreasureMode',  off = 'None',
-          colors = { ['Tag'] = COLOR.warn, ['Full Time'] = COLOR.good, ['SATA'] = COLOR.cyan } },
-        { label = 'SR',  mode = 'SpellReceived', off = 'OFF',
-          colors = { ['ON'] = COLOR.good } },
-        { label = 'HOX', mode = 'Hoxne',         off = 'OFF',
-          colors = { ['ON'] = COLOR.good } },
+        {
+            label = 'TH',
+            mode = 'TreasureMode',
+            off = 'None',
+            colors = { ['Tag'] = COLOR.warn, ['Full Time'] = COLOR.good, ['SATA'] = COLOR.cyan }
+        },
+        {
+            label = 'SR',
+            mode = 'SpellReceived',
+            off = 'OFF',
+            colors = { ['ON'] = COLOR.good }
+        },
+        {
+            label = 'HOX',
+            mode = 'Hoxne',
+            off = 'OFF',
+            colors = { ['ON'] = COLOR.good }
+        },
     }
 
     --3 letter aliases for known ui names. Backward-compatible.
     local UI_SHORT_ALIASES = {
-        ['mode']      = 'MDE', ['pet']  = 'PET', ['tp mode'] = 'TPM',
-        ['auto tank'] = 'TNK', ['tank'] = 'TNK',
-        ['runes']     = 'RUN', ['rune'] = 'RUN',
+        ['mode'] = 'MDE',
+        ['pet'] = 'PET',
+        ['tp mode'] = 'TPM',
+        ['auto tank'] = 'TNK',
+        ['tank'] = 'TNK',
+        ['runes'] = 'RUN',
+        ['rune'] = 'RUN',
     }
 
     -- Derive a three-cell label from a long mode name. Alias first, then a
@@ -4087,12 +4105,14 @@ do
 
         local header_w = 0
         for i, g in ipairs(GLYPH_FIELDS) do
-            header_w = header_w + #g.label + 2        -- label + space + circle
+            header_w = header_w + #g.label + 2 -- label + space + circle
             if i > 1 then header_w = header_w + #SEP end
         end
 
         layout = {
-            fields = fields, label_w = label_w, header_w = header_w,
+            fields = fields,
+            label_w = label_w,
+            header_w = header_w,
             -- Stretch the value field so the closing chevrons land on the
             -- header's right edge. Row = label_w + 1 + 1 + value_w + 1.
             value_w = math.max(value_w, header_w - label_w - 3,
@@ -4152,7 +4172,7 @@ do
     -- Zero the display and debug windows
     function display_zero_command()
         gs_status:pos_x(0)
-        gs_status:pos_y(0)        
+        gs_status:pos_y(0)
         gs_debug:pos_x(0)
         gs_debug:pos_y(100)
         config.save(settings)
@@ -4161,7 +4181,7 @@ do
 
     local debug_box_state = {}
     function debug_box_reset() debug_box_state = {} end
-    
+
     -- Used to help debug issues
     function debug_box_update()
         if debug_box_state.busy == is_Busy

--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -2192,7 +2192,7 @@ do
                             built_set = set_combine(built_set, sets.Midcast.Nuke)
                             info('Nuke Set')
                         else
-                            warnd('sets.Midcast.Nuke not found!')
+                            warn('sets.Midcast.Nuke not found!')
                         end
                     end
                     -- Check for Helix

--- a/Mirdain-Include.lua
+++ b/Mirdain-Include.lua
@@ -3311,7 +3311,27 @@ do
                 feet = empty
             })
             Lock()
-
+            --Perform instant unequip that will be immediately undone through equip_set_command on the next action or timing
+            --Use for cure cheating, sortie objective, etc
+        elseif command == 'nakedunlocked' then
+            equip({
+                main = empty,
+                sub = empty,
+                range = empty,
+                ammo = empty,
+                head = empty,
+                neck = empty,
+                ear1 = empty,
+                ear2 = empty,
+                body = empty,
+                hands = empty,
+                ring1 = empty,
+                ring2 = empty,
+                back = empty,
+                waist = empty,
+                legs = empty,
+                feet = empty
+            })
             --Disable all slots but weapons, range and ammo
         elseif command == 'weaponsonly' then
             equip({
@@ -3340,10 +3360,12 @@ do
             })
             --disable('head', 'neck', 'ear1', 'ear2', 'body', 'hands', 'ring1', 'ring2', 'back', 'waist', 'legs', 'feet')
             disable('head', 'hands', 'legs', 'feet')
-
             --Enable All Slots
         elseif command == 'enableall' then
             Unlock()
+            --Enable slots that aren't locked by the current mode or zone
+        elseif command == 'enablebymode' then
+            UnlockByMode()
         end
 
         --use below for custom Job commands
@@ -4008,7 +4030,7 @@ do
                 built_set = set_combine(built_set, { waist = "Orpheus's Sash" })
                 info('Distance is [' .. round(spell.target.distance, 2) .. '] using Orpheus Sash')
                 -- Match day or weather.
-            elseif spell.element == world.day_element or spell.element == world.weather_element and Obi then
+            elseif (spell.element == world.day_element or spell.element == world.weather_element) and Obi then
                 built_set = set_combine(built_set, { waist = "Hachirin-no-Obi" })
                 info('[' ..
                     world.day_element .. '] day and weather is [' .. world.weather_element .. '] - using Hachirin-no-Obi')
@@ -4025,7 +4047,9 @@ do
     end
 
     function run_burst(data)
-        local action = data.targets[1].actions[1]
+        local target = data.targets[1]
+        local action = target and target.actions[1]
+        if not action then return end
         if (action.add_effect_message > 287 and action.add_effect_message < 302)     -- Normal SC DMG
             or (action.add_effect_message > 384 and action.add_effect_message < 399) -- SC Heals
             or (action.add_effect_message > 766 and action.add_effect_message < 771) -- Umbra/Radiance
@@ -4360,12 +4384,13 @@ do
         end
     end)
 
+    --[[
     windower.register_event('chat message', function(message, sender, mode, gm)
         --Future Hooks for PT chat or tells
         -- Mode 3 is tell
         -- Mode 4 is party
         --Ignore it if it's not party chat or a tell
-        if mode ~= 3 or mode ~= 4 then
+        if mode ~= 3 and mode ~= 4 then
             return
         end
         message = message:lower()
@@ -4374,6 +4399,7 @@ do
             windower.send_command('sm on')
         end
     end)
+    ]]--
 
     -- Section used to determine if player is performing an action
     windower.register_event('action', function(data)
@@ -4395,32 +4421,20 @@ do
                     elseif data.param == 28787 then
                         log('Item Use Interupted')
                         UnlockByMode()
-                        if choose_set_custom then
-                            equip(set_combine(choose_set(), choose_set_custom()))
-                        else
-                            equip(set_combine(choose_set()))
-                        end
+                        equip_set_command()
                     end
                     -- Item use Finished
                 elseif data.category == 5 then
                     if data.param == 4154 then
                         log('Item Use Finished')
                         UnlockByMode()
-                        if choose_set_custom then
-                            equip(set_combine(choose_set(), choose_set_custom()))
-                        else
-                            equip(set_combine(choose_set()))
-                        end
+                        equip_set_command()
                     end
                     -- Casting Start
                 elseif data.category == 8 then
                     if data.param == 28787 then
                         log('Spell Interupt')
-                        if choose_set_custom then
-                            equip(set_combine(choose_set(), choose_set_custom()))
-                        else
-                            equip(set_combine(choose_set()))
-                        end
+                        equip_set_command()
                     elseif data.param == 24931 then
                         log('Casting Spell')
                     end
@@ -4434,25 +4448,21 @@ do
                 end
                 -- If player takes action, adjust TH tagging information
                 if state.TreasureMode.value ~= 'None' and TaggingCategories:contains(data.category) then
-                    if windower.ffxi.get_mob_by_id(data.targets[1].id).is_npc then
-                        th_info.tagged_mobs[data.targets[1].id] = os.clock()
+                    local target = data.targets[1]
+                    local target_mob = target and windower.ffxi.get_mob_by_id(target.id)
+                    if target_mob and target_mob.is_npc then
+                        th_info.tagged_mobs[target.id] = os.clock()
                         if state.TreasureMode.value ~= 'Full Time' then
-                            if choose_set_custom then
-                                equip(set_combine(choose_set(), choose_set_custom()))
-                            else
-                                equip(set_combine(choose_set()))
-                            end
+                            equip_set_command()
                         end
                     elseif th_info.tagged_mobs[data.actor_id] then
                         th_info.tagged_mobs[data.actor_id] = os.clock()
-                    else
-                        if th_info.tagged_mobs[data.targets[1].id] then
-                            th_info.tagged_mobs[data.targets[1].id] = os.clock()
-                        end
+                    elseif target and th_info.tagged_mobs[target.id] then
+                        th_info.tagged_mobs[target.id] = os.clock()
                     end
                 end
             end
-            -- Casting Spell
+            --[[ Casting Spell
             if data.category == 8 then
                 if data.param == 24931 then
                     if data.targets[1].actions[1].param ~= 0 then
@@ -4463,7 +4473,8 @@ do
                 elseif data.param == 28787 then
                 end
                 -- Weaponskill Finished
-            elseif data.category == 3 and data.param ~= 0 then
+            else]]
+            if data.category == 3 and data.param ~= 0 then
                 run_burst(data)
                 -- Casting finish
             elseif data.category == 4 then

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ TH .  SR .  HOX o  STN <DT>  DPS <Black Halo>  MDE <Melee>
 | Hollow circle, grey | Mode is off (`None` / `OFF`) |
 | Value between triangles | A cycling mode — press its key, or `//gs c <mode> <value>` |
 
-TH, SR (SpellReceived) and HOX (Hoxne) are drawn as a circle only. Their whole state fits in one colour, which is what keeps the box narrow. Every other mode keeps its **full text**, so the weapon or job function currently selected is always readable.
+TH, SR (SpellReceived) and HOX (Hoxne) status is indicated by a colored circle. Every other mode shows **full text**, so the weapon or job function currently selected is always readable.
 
 **Sizing.** Column widths come from each mode's complete list of options rather than its current value, so cycling a mode never resizes the stacked box — it stays a fixed width for as long as a job is loaded. The glyph header sets a 17-cell floor that most jobs never exceed, which also keeps the box near-identical across job changes. The one-line layout deliberately flexes with the current values to stay as short as possible.
 
@@ -140,7 +140,7 @@ TH, SR (SpellReceived) and HOX (Hoxne) are drawn as a circle only. Their whole s
 
 ### Moving and saving the boxes
 
-Drag either box with the left mouse button. The position is written to disk automatically when you release, and the save is **silent** — there is no chat confirmation. This is handled by Windower's own text library rather than by a mouse hook in the include, so moving the cursor costs nothing extra.
+Drag either box with the left mouse button. The position is written to disk automatically when you release, and the save is **silent** — there is no chat confirmation. Display position saving is performed via Windower's text library and not by an explicit config.save.
 
 You can also save manually with `//gs c save`, reset a lost box to the top-left corner with `//gs c zero`, hide the status box with `//gs c display`, and switch between one-line and stacked layouts with `//gs c displaymode`.
 
@@ -217,7 +217,7 @@ Defaults to `Full Time` on THF and `None` on every other job. Tagged monsters ar
 
 ### AutoBuff — self-buffing
 
-When on, the engine checks roughly ten times a second whether you are missing a buff it can reapply, and uses it. Disabled in towns, and while asleep, stunned, terrorized, paralyzed, silenced or muddled.  This is leftover from development prior to the use of other automation tools.  Usable if manually single boxing.  Leave off if using other automation software.
+When on, the engine checks roughly ten times a second whether you are missing a buff it can reapply, and uses it. Disabled in towns, and while asleep, stunned, terrorized, paralyzed, silenced or muddled.  This is leftover from development prior to the use of other automation tools.  Usable if manually playing.  Leave this setting turned off if using other automation software.
 
 - **Options:** `OFF` `ON`
 - **Command:** `//gs c AutoBuff ON`
@@ -755,7 +755,7 @@ Exactly what it says — the engine wanted a set you have not defined. Add it to
 sets.Weapons.Sleep = {}
 ```
 
-Silence these with `//gs c warn` once your file is finished.
+Silence these with `//gs c warn` once your file is finished loading.
 
 ### Gear is not swapping
 

--- a/README.md
+++ b/README.md
@@ -1,487 +1,731 @@
-# Version 1.6
-Enhanced version of Mirdain-Include created by Rahvin
+# Mirdain-Include
 
-Use //gs c version to check your active version
+**Version 1.6.3** · A GearSwap engine for Final Fantasy XI (Windower 4)
 
-##Discord Link: https://discord.gg/kt68622p
+Enhanced version of Mirdain-Include, created by Rahvin. Check your running version in game with `//gs c version`.
 
-### Write up: `Rahvin` 
-
-# Keybinds
-## Spell Received Gear Tracking
-Cycle via Keybind: <kbd><kbd>CTRL</kbd> + <kbd>F9</kbd></kbd>
-
-This feature enables multiboxers to automatically equip spell-received potency and duration gear when a locally connected character is casting on you.  This action occurs at the pretargetcheck and precast phases, ensuring instantaneous swapping before the spell lands, even with Quick Magic.
-
-Supported Spells: `Cure` `Cursna` `Protect` `Shell` `Phalanx` `Regen` `Refresh` `Waltz`
-
-Changed in game via command: `gs c SpellReceived  <mode>`
-
-Ex: `gs c SpellReceived ON-Locked`
-
-Available Modes: `ON-Locked` `ON-Unlocked` `OFF`
-
-## Hoxne Ampulla Mode
-Cycle via Keybind: <kbd><kbd>CTRL</kbd> + <kbd>F10</kbd></kbd>
-
-This feature locks Hoxne Ampulla to your ammo slot and prevents automated unlocks until disabled.  Persists through zoning.  Hoxne Ampulla must be manually used after engaging Hoxne Mode to gain the benefit of the buff.
-
-Changed in game via command: `gs c hoxne`
-
-Available Modes: `ON` `OFF`
-
-## OffenseMode
-Cycle via Keybind: <kbd>F12</kbd>
-
-Changed in game via command: `gs c OffenseMode  <mode>`
-
-Ex: `gs c OffenseMode PDL`
-
-## WeaponMode
-Cycle via Keybind: <kbd>F9</kbd>
-
-Changed in game via command: `gs c WeaponMode <mode>`
-
-Ex: `gs c WeaponMode "Savage Blade"`
-
-## TreasureHunter
-Cycle via Keybind: <kbd>F11</kbd>
-
-Changed in game via command: `gs c TreasureHunter <mode>`
-
-Ex: `gs c TreasureHunter "Full Time"`
-
-## AutoBuff
-Cycle via Keybind: <kbd>F10</kbd>
-
-Changed in game via command: `gs c AutoBuff <mode>`
-
-Ex: `gs c AutoBuff On`
-
-## JobMode
-Cycle via Keybind: <kbd><kbd>CTRL</kbd> + <kbd>F12</kbd></kbd>
-
-Ex: PLD can have `Auto Tank` or `Ranged Mode` for RNG
-
-Changed in game via command: `gs c JobMode <mode>`
-
-Ex: `gs c JobMode Ranged`
-
-## JobMode2
-Cycle via Keybind: <kbd><kbd>CTRL</kbd> + <kbd>F11</kbd></kbd>
-
-Ex: PLD sub RUN can have a element specified for `Rune Enhancement`
-
-Changed in game via command: `gs c JobMode2 <mode>`
-
-Ex: `gs c JobMode2 Water`
+**Discord:** https://discord.gg/kt68622p
 
 ---
 
-# Settings specified in `<job>.lua`
+## Table of Contents
 
-## Ammo_Warning_Limit
-When below the specified threshold, will log a warning on precast. The default is 99x items.
-
-Ex: `Ammo_Warning_Limit = 66`
-
-## AutoItem
-Enable the use of Remedy, Holy Water, and Echo Drops automatically.
-
-Ex: `AutoItem = true`
-
-## Food
-Allows a command to use a specified type of food.
-
-Ex: `Food = "Miso Ramen"`
-
-Command: `gs c food`
-
-## Buff_Delay
-Used to control frequency of buff usage with Auto Buff.
-
-Ex: `Buff_Delay = 2`
-
-## Tank_Delay
-Used to control frequency of buff usage with Auto Tank.
-
-Ex: `Tank_Delay = 1`
-
-## LockstylePallet
-Allows the character to set the lockstyle specified in the in-game `Equip Sets`.
-
-Ex: `LockStylePallet = "6"`
-
-## MacroBook
-Set the in-game macro book upon loading the gearswap file.
-
-Ex: `MacroBook = "6"`
-
-## MacroSet
-Set the macro page upon loading the gearswap file.
-
-Ex: `MacroSet = "1"`
-
-## Random_Lockstyle
-Enables a random lockstyle to use.
-
-Ex: `Random_Lockstyle = true`
-
-## Lockstyle_List
-Lockstyle sets to randomly equip when `Random_Lockstyle` is enabled.
-
-Ex: `Lockstyle_List = { 1, 6, 7 }`
+1. [What This Is](#1-what-this-is)
+2. [Installation](#2-installation)
+3. [How It Works](#3-how-it-works)
+4. [The On-Screen Display](#4-the-on-screen-display)
+5. [Keybinds](#5-keybinds)
+6. [Modes](#6-modes)
+7. [Commands](#7-commands)
+8. [Job File Settings](#8-job-file-settings)
+9. [Gear Sets Reference](#9-gear-sets-reference)
+10. [Automatic Engine Checks](#10-automatic-engine-checks)
+11. [Action and Spell Tracking](#11-action-and-spell-tracking)
+12. [Customization Hooks](#12-customization-hooks)
+13. [Troubleshooting](#13-troubleshooting)
 
 ---
 
-# Self Commands
-Called with `gs c <command>`
+## 1. What This Is
 
-All commands are case insensitive
+GearSwap is a Windower addon that changes your equipment automatically as you play. Normally you would write all of that swapping logic yourself, for every job. This suite does it for you.
 
-## `update auto`
-Updates the player's gear given the current state of the player.
+**Mirdain-Include.lua** is the engine. It contains all the rules: which gear to wear while idle, while fighting, while casting, while moving, and so on. It is the same file for every job and you should not need to edit it.
 
-## `shutdown`
-Sends `terminate` command to kill the game
+**Job files** (`WAR.lua`, `WHM.lua`, `BLM.lua`, …) are yours. They contain your gear, your modes, and your preferences. You will spend all of your time in these.
 
-## `save`
-Saves the current settings for the character.
-Ex: `Display Location`
-
-## `zero`
-Resets HUD position
-
-## `display`
-Toggles the in game HUD visibility.
-
-## `displaymode`
-Toggles one line or full view for HUD.
-
-## `spellreceived`
-Cycle through spell-received modes.  ON-Locked temporarily locks your spell-recieved potency gear in place until the spell lands or is interrupted (Recommended).  ON-Unlocked allows gear to be overwritten by other combat actions (Niche Uses). OFF disables spell-received gear checking (Not Recommended)
-Set up your gear-received sets for proper functionality.
-
-## `hoxne`
-Toggle on Hoxne Ampulla locking.  Will not turn on if the character is missing Hoxne Ampulla in inventory or wardrobe. Persists through zoning.  Must manually use the item to gain the buff.
-
-## `debug`
-Toggles the debug state to enable in-game logs and a HUD.
-
-## `info`
-Toggles on/off in-game message info
-
-Ex: `Skillchain` and `Equipment Set` messages
-
-## `two_hand_check`
-Runs a check to see if user is equipped with a two handed weapon. Impacts which gearset is used.
-
-Can be viewed in the debug HUD when trouble shooting
-
-## `temps`
-Shortcut to use the following items, with a 2.5 second delay:
-- Monarch's Drink
-- Braver's Drink
-- Fighter's Drink
-- Champion's Drink
-- Soldier's Drink
-- Barbarian's Drink
-
-## `warp`
-Uses the Warp Ring
-
-## `warp club`
-Uses a Warp Cudgel
-
-## `holla`
-Uses the Dim. Ring (Holla)
-
-## `dem`
-Uses the Dim. Ring (Dem)
-
-## `mea`
-Uses the Dim. Ring (Mea)
-
-## `cp`
-Uses the Trizek Ring
-
-
-## `profile`
-Executes a script file when called with option for folders
-
-Ex: `gs c profile folder1 folder2`
-
-## `food`
-Uses food item defined in gearswap file.
-
-Ex: `Food = "Miso Ramen"` will use Miso Ramen
-
-## `use <enchantment item>`
-Equip and uses an item with an enchantment value.
-
-Ex: `gs c use "Empress Band"`
+If you have never used GearSwap before: you only need to fill in gear sets in your job file. The engine handles the rest.
 
 ---
 
-# Engine Checks
+## 2. Installation
 
-## Weapon dual wield and two handed checks
-### Dual Wield
-Checks if the user has the dual wield trait.
+1. Install Windower 4 and enable the **GearSwap** addon.
+2. Copy `Mirdain-Include.lua` into:
+   ```
+   Windower4/addons/GearSwap/data/
+   ```
+3. Copy the job files you want from `Sample Job Files/` into:
+   ```
+   Windower4/addons/GearSwap/data/
+   ```
+4. Rename each job file to match your character, or leave it as the job name to share across characters:
+   - `WAR.lua` — used by any character on Warrior
+   - `Yourname_WAR.lua` — used only by that character on Warrior
+5. Log in and change to that job. GearSwap loads the file automatically.
 
-Enables the use of `sets.DualWield`
+Verify it worked by typing `//gs c version` — you should see the include version echoed back.
 
-Ex: When `DualWield = true`, `sets.DualWield` will be layered on top of the current set.
+> **Upgrading?** Replace `Mirdain-Include.lua` only. Your job files are yours and are not overwritten. If you are upgrading from 1.5.X to any later version, delete the settings.xml file within Windower4/addons/GearSwap/data and reload GearSwap in game with `lua r gearswap`
 
-### Two Hand Check
-Checks if the user has a two handed weapon.
+---
 
-### Shield
-When both Dual Wield and Two Handed modes come back as false, it will layer `sets.Weapons.Shield` on top of the current set.
+## 3. How It Works
 
-Ex: Inside Odyssey without a subjob, as a COR you can have the following and it will automatically equip the shield as you are using a single handed weapon without access to the dual wield trait.
+Every job file begins by loading the engine:
+
 ```lua
-sets.Weapons['Death Penalty'] = 
-{
-	main = "Rostam",
-	sub = "Tauret",
-	range = "Death Penalty",
-}
-
-sets.Weapons.Shield = 
-{
-	sub = "Nusku Shield"
-}
+include('Mirdain-Include')
 ```
 
-## Elemental Checks
-Checks for the following, in the priority listed:
-- Double Weather
-	- auto equip Hachirin-no-Obi
-- Day and Weather
-	- auto equip Hachirin-no-Obi
-- Distance less than 6 yalms
-	- auto equip Orpheus's Sash
-- Match Day or Weather
-	- auto equip Hachirin-no-Obi
+From that point the engine drives everything, calling into your job file at specific moments. The flow for any action looks like this:
+
+```
+You press a macro
+        │
+        ▼
+   pretarget ──► engine validates the action (enough TP? spell on cooldown? asleep?)
+        │        cancels it and tells you why if not
+        ▼
+    precast  ──► engine equips Fast Cast / weaponskill gear
+        │
+        ▼
+    midcast  ──► engine equips potency / accuracy / recast gear
+        │
+        ▼
+   aftercast ──► engine returns you to idle or melee gear
+```
+
+At each step the engine builds a gear set from its own rules, then calls **your** matching `_custom` function so you can add or override anything. See [Customization Hooks](#12-customization-hooks).
+
+Separately, a background loop (the "engine") runs about ten times a second to handle things that are not tied to an action — movement gear, auto-buffing, weapon checks. See [Automatic Engine Checks](#10-automatic-engine-checks).
 
 ---
 
-## Predefined Spell, Buff, Elemental WS, and more
-Useful if you want different logic based on spell sets. I'm not going to list all of them, but you can find all the sets defined towards the top of the include file, underneath all the predefined sets and states.
+## 4. The On-Screen Display
 
-The most useful in my opinion is `SongCount`. `SongCount` is a dictionary of specific songs, which when used, will automatically equip your defined song count instrument, specified with `Instrument.Count` in your `BRD.lua`. 
+The suite draws two boxes on screen.
 
-These songs are:
-- Knight's Minne
-- Knight's Minne II
-- Army's Paeon
-- Army's Paeon II
-- Army's Paeon III
-- Army's Paeon IV
-- Fowl Aubade
-- Herb Pastoral
-- Shining Fantasia
-- Scop's Operetta
-- Puppet's Operetta
-- Gold Capriccio
-- Warding Round
-- Goblin Gavotte
+**Status box** — always available, shows your current modes:
 
-If your Dummy Songs in Silmaril are set to any of the above, you do not need to worry about equipping the appropriate weapon yourself, it will be handled for you.
+```
+TH:[None] Spell-Rec:[ON-Locked] Hoxne:[OFF] Stance:[DT] DPS:[Chango]
+```
+
+**Debug box** — hidden by default, shows internal engine state. Useful when something is not swapping as expected:
+
+| Field | Meaning |
+|---|---|
+| `is_Busy` | Engine is mid-action and will not overwrite gear |
+| `is_Moving` | You are moving; movement gear is active |
+| `DualWield` | Dual Wield trait detected |
+| `TwoHand` | Your current main weapon is two-handed |
+| `Casting` | An outgoing tracked cast is in progress |
+| `Failsafe` | Spell-received gear is waiting on a timeout |
+
+### Moving and saving the boxes
+
+Drag either box with the left mouse button. The position saves to disk automatically when you release. You can also save manually with `//gs c save`, reset a lost box to the top-left corner with `//gs c zero`, hide the status box with `//gs c display`, and switch between one-line and stacked layouts with `//gs c displaymode`.
+
+> Saving is skipped while you are zoning. If you see *"Cannot save while zoning"*, wait a moment and try again.
 
 ---
 
-# Predefined Sets
+## 5. Keybinds
 
-## Weapons
+Bound automatically when your job file loads.
+
+| Key | Action |
+|---|---|
+| <kbd>F9</kbd> | Cycle **WeaponMode** |
+| <kbd>F10</kbd> | Cycle **AutoBuff** |
+| <kbd>F11</kbd> | Cycle **TreasureHunter** |
+| <kbd>F12</kbd> | Cycle **OffenseMode** |
+| <kbd>Ctrl</kbd>+<kbd>F9</kbd> | Cycle **SpellReceived** |
+| <kbd>Ctrl</kbd>+<kbd>F10</kbd> | Cycle **Hoxne** |
+| <kbd>Ctrl</kbd>+<kbd>F11</kbd> | Cycle **JobMode2** |
+| <kbd>Ctrl</kbd>+<kbd>F12</kbd> | Cycle **JobMode** |
+
+Every keybind has an equivalent command, so you can bind your own keys or build macros instead. Keybinds are released when the job file unloads.
+
+---
+
+## 6. Modes
+
+A "mode" is a named switch the engine reads when choosing gear. Cycle a mode with its keybind, or jump straight to a value with a command.
+
+### OffenseMode — your melee gear set
+
+The main damage-vs-survival switch. Drives `sets.OffenseMode`, `sets.WS`, and ammo selection.
+
+- **Default options:** `TP` `ACC` `DT`
+- **Set your own in your job file:**
+  ```lua
+  state.OffenseMode:options('TP','PDL','ACC','DT','PDT','MEVA','CRIT','SB')
+  state.OffenseMode:set('DT')
+  ```
+- **Command:** `//gs c OffenseMode PDL`
+
+Every option you list needs a matching `sets.OffenseMode.<Name>`, or the engine warns you.
+
+### WeaponMode — which weapon to equip
+
+Lets you swap weapon sets without touching your gear sets.
+
+- **Options are entirely yours:**
+  ```lua
+  state.WeaponMode:options('Chango','Shining One','Naegling','Unlocked')
+  state.WeaponMode:set('Chango')
+  ```
+- **Command:** `//gs c WeaponMode "Shining One"`
+- Each option needs a matching `sets.Weapons.<Name>`.
+- The special value `Locked` stops the engine from changing weapons at all.
+
+### TreasureHunter — Treasure Hunter gear handling
+
+The engine remembers which monsters you have already tagged, so it only wears TH gear when it will actually do something.
+
+| Mode | Behavior |
+|---|---|
+| `None` | Never equip TH gear |
+| `Tag` | Equip TH gear only until the current target is tagged, then swap back to full damage |
+| `Full Time` | Always wear TH gear while engaged |
+| `SATA` | THF only — wear TH gear when Sneak Attack, Trick Attack or Feint is active |
+
+Defaults to `Full Time` on THF and `None` on every other job. Tagged monsters are forgotten after 3 minutes of inactivity, and cleared entirely when you zone.
+
+**Command:** `//gs c TreasureHunter "Full Time"`
+
+### AutoBuff — self-buffing
+
+When on, the engine checks roughly ten times a second whether you are missing a buff it can reapply, and uses it. Disabled in towns, and while asleep, stunned, terrorized, paralyzed, silenced or muddled.
+
+- **Options:** `OFF` `ON`
+- **Command:** `//gs c AutoBuff ON`
+- Automatically switched **off** when you zone.
+- What gets buffed is defined by you — see [`check_buff_JA` / `check_buff_SP`](#12-customization-hooks).
+
+### SpellReceived — multibox spell-received gear
+
+For players running more than one character. When another of your characters casts a supported spell on you, this character equips its "received" gear *before the spell lands* — even through Quick Magic.
+
+| Mode | Behavior |
+|---|---|
+| `ON-Locked` | Equip received gear and lock those slots until the spell resolves *(recommended)* |
+| `ON-Unlocked` | Equip received gear but allow other actions to overwrite it |
+| `OFF` | Disabled |
+
+**Command:** `//gs c SpellReceived ON-Locked`
+
+Requires the corresponding `*_Received` sets. See [Spell-Received Tracking](#spell-received-tracking-multibox).
+
+### Hoxne — Hoxne Ampulla lock
+
+Locks Hoxne Ampulla into your ammo slot and stops the engine from unlocking it. Persists through zoning. You must still use the item manually to gain the buff.
+
+- **Options:** `OFF` `ON`
+- **Command:** `//gs c hoxne`
+- Will refuse to turn on if the item is not in your inventory or wardrobes.
+
+### JobMode and JobMode2 — your own switches
+
+Two free-form modes for anything a job needs. The engine only tracks the value; what it means is up to your job file.
+
 ```lua
-sets.Weapons = {}
+UI_Name  = 'Tank'          -- label shown in the status box
+state.JobMode:options('OFF','Auto Tank')
+
+UI_Name2 = 'Rune'
+state.JobMode2:options('Ignis','Gelus','Flabra')
+```
+
+**Commands:** `//gs c JobMode "Auto Tank"` · `//gs c JobMode2 Ignis`
+
+If `UI_Name` is left empty the mode is hidden from the status box.
+
+### RAMode — ranged ammunition type
+
+Selects which ammo table the engine reads: `Bullet`, `Arrow` or `Bolt`. Defaults to `Bullet`. See [Ammunition](#ammunition).
+
+---
+
+## 7. Commands
+
+All commands are typed as `//gs c <command>` and are **case-insensitive**.
+
+### Modes
+
+| Command | Description |
+|---|---|
+| `gs c OffenseMode [mode]` | Cycle, or jump to a specific mode |
+| `gs c WeaponMode [mode]` | Cycle, or jump to a specific weapon set |
+| `gs c TreasureHunter [mode]` | Cycle, or jump to a TH mode |
+| `gs c AutoBuff [mode]` | Cycle, or set auto-buffing |
+| `gs c SpellReceived [mode]` | Cycle, or set spell-received tracking |
+| `gs c hoxne [on\|off]` | Toggle or set Hoxne Ampulla lock |
+| `gs c JobMode [mode]` | Cycle, or jump to a job-specific mode |
+| `gs c JobMode2 [mode]` | Cycle, or jump to a second job-specific mode |
+
+Quote any value containing a space: `//gs c WeaponMode "Savage Blade"`
+
+### Display
+
+| Command | Description |
+|---|---|
+| `gs c display` | Show/hide the status box |
+| `gs c displaymode` | Toggle one-line vs. stacked layout |
+| `gs c zero` | Move the status box to the top-left corner and save |
+| `gs c save` | Save current settings to disk |
+| `gs c debug` | Toggle the debug box and verbose logging |
+| `gs c info` | Toggle informational messages (skillchains, set changes) |
+| `gs c warn` | Toggle missing-gear-set warnings |
+
+### Gear
+
+| Command | Description |
+|---|---|
+| `gs c update auto` | Re-evaluate and equip the correct set for your current state |
+| `gs c naked` | Unequip everything and lock the slots |
+| `gs c nakedunlocked` | Unequip everything, leave slots unlocked |
+| `gs c weaponsonly` | Keep weapons only, empty every other slot |
+| `gs c abysseaproc` | Empty head/hands/legs/feet and lock them, for Abyssea red procs |
+| `gs c enableall` | Unlock every slot |
+| `gs c enablebymode` | Unlock every slot the current mode and zone allow |
+| `gs c two_hand_check` | Re-detect whether your main weapon is two-handed |
+
+### Items
+
+| Command | Description |
+|---|---|
+| `gs c food` | Use the item named in your `Food` variable |
+| `gs c use <item>` | Use any enchanted item; auto-detects slot and cast time |
+| `gs c temps` | Use the six Escha temporary drinks in sequence |
+| `gs c warp` | Use Warp Ring |
+| `gs c warp club` | Use Warp Cudgel |
+| `gs c holla` | Use Dim. Ring (Holla) |
+| `gs c dem` | Use Dim. Ring (Dem) |
+| `gs c mea` | Use Dim. Ring (Mea) |
+| `gs c cp` | Use Trizek Ring |
+
+### Other
+
+| Command | Description |
+|---|---|
+| `gs c version` | Print the include version |
+| `gs c shutdown` | Terminate the game client |
+| `gs c profile <name>` | Load a Silmaril profile script for your job/subjob/character |
+
+You can add your own commands with [`self_command_custom`](#12-customization-hooks).
+
+---
+
+## 8. Job File Settings
+
+Plain variables you set near the top of your job file.
+
+### Startup
+
+| Variable | Type | Description |
+|---|---|---|
+| `LockStylePallet` | string | In-game Equip Set number applied on load — `"8"` |
+| `MacroBook` | string | Macro book to switch to — `"4"` |
+| `MacroSet` | string | Macro page to switch to — `"1"` |
+| `Random_Lockstyle` | boolean | Pick a random lockstyle from the list below on each job change |
+| `Lockstyle_List` | table | Candidates for random selection — `{1, 2, 6, 12}` |
+
+### Behavior
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `AutoItem` | boolean | `false` | Automatically use Remedy and Holy Water for status ailments |
+| `Food` | string | — | Item used by `//gs c food` — `"Sublime Sushi"` |
+| `Ammo_Warning_Limit` | number | `99` | Warn on precast when ranged ammo falls below this count |
+| `Buff_Delay` | number | — | Minimum seconds between AutoBuff attempts |
+| `Tank_Delay` | number | — | Minimum seconds between auto-tank ability attempts |
+| `UI_Name` | string | `''` | Status box label for JobMode; empty hides it |
+| `UI_Name2` | string | `''` | Status box label for JobMode2; empty hides it |
+
+> **Performance tip:** `Buff_Delay` matters. Without it, AutoBuff queries every ability and spell recast about ten times a second for the whole session. One check per second is plenty — job ability recasts are minutes long. The PLD and RUN sample files show the pattern.
+
+### Ammunition
+
+Ranged jobs define ammo per OffenseMode. The engine reads `Ammo[state.OffenseMode.value]` when building ranged and weaponskill sets, so your gear sets can stay generic.
+
+```lua
+Ammo.Bullet.TP   = "Chrono Bullet"
+Ammo.Bullet.ACC  = "Eradicating Bullet"
+Ammo.Bullet.CRIT = "Eradicating Bullet"
+Ammo.Bullet.WS   = "Chrono Bullet"
+
+Ammo.Arrow.TP    = "Chrono Arrow"
+-- and so on for Ammo.Bolt
+```
+
+### Instruments (BRD)
+
+Bard files map song categories to instruments, which the engine equips automatically during song midcast:
+
+```lua
+Instrument.Count      = "Blurred Harp +1"
+Instrument.Potency    = "Gjallarhorn"
+Instrument.Pianissimo = "Marsyas"
+Instrument.Enfeebling = "Marsyas"
+Instrument.AOE_Sleep  = "Blurred Harp +1"
+Instrument.FastCast   = "Eminent Flute"
+```
+
+Also available: `Idle`, `TP`, `Mordant`, `QuickMagic`, `MAB`.
+
+---
+
+## 9. Gear Sets Reference
+
+Every set below is pre-created as an empty table by the engine, so you only fill in the ones you use. If the engine needs a set you have not defined, it prints a warning naming the exact set — turn these on with `//gs c warn` while building your file.
+
+All sets go inside `function get_sets()` in your job file.
+
+### Core
+
+| Set | When used |
+|---|---|
+| `sets.Idle` | Standing still, not engaged |
+| `sets.Idle.Resting` | Resting (healing MP) |
+| `sets.Idle.Pet` | Idle while you have a pet |
+| `sets.Idle.Sublimation` | Idle with Sublimation active |
+| `sets.Idle.TP` / `.ACC` / `.DT` | Idle variants matched to OffenseMode |
+| `sets.Movement` | Layered on top of idle while moving |
+| `sets.OffenseMode` | Base melee set, always applied when engaged |
+| `sets.OffenseMode.<Mode>` | Per-mode melee set — one per OffenseMode option |
+| `sets.OffenseMode.AM1` / `.AM2` / `.AM3` | Aftermath tiers |
+| `sets.DualWield` | Layered when the Dual Wield trait is detected |
+| `sets.Enmity` | Enmity-focused gear |
+
+### Weapons
+
+| Set | When used |
+|---|---|
+| `sets.Weapons.<Mode>` | One per WeaponMode option |
+| `sets.Weapons.Sleep` | Locked on automatically when you fall asleep |
+| `sets.Weapons.Shield` | Shield swap |
+| `sets.Weapons.Songs` | BRD instrument handling |
+
+### Precast
+
+| Set | When used |
+|---|---|
+| `sets.Precast` | Base precast |
+| `sets.Precast.FastCast` | Magic precast |
+| `sets.Precast.Cure` | Cure precast |
+| `sets.Precast.Enhancing` | Enhancing magic precast |
+| `sets.Precast.Utsusemi` | Utsusemi precast |
+| `sets.Precast.Blue_Magic` | Blue magic precast |
+| `sets.Precast.Songs` | Song precast |
+| `sets.Precast.RA` | Ranged attack precast (Snapshot) |
+| `sets.Precast.RA.Flurry` / `.Flurry_II` | With Flurry active |
+| `sets.JA` | Job abilities |
+
+### Midcast — offensive magic
+
+| Set | When used |
+|---|---|
+| `sets.Midcast.Nuke` | Elemental nukes |
+| `sets.Midcast.Burst` | Nukes during an open skillchain window |
+| `sets.Midcast.Enfeebling.MACC` | Accuracy-based enfeebles (Dispel, Aspir, Drain, Frazzle, Stun, Poison) |
+| `sets.Midcast.Enfeebling.Potency` | Potency-based enfeebles (Paralyze, Slow, Addle, Distract, Blind, Gravity) |
+| `sets.Midcast.Enfeebling.Duration` | Duration-based enfeebles (Sleep, Dia, Bio, Silence, Bind, Break) |
+| `sets.Midcast.Dark.MACC` | Death, Kaustra, Stun |
+| `sets.Midcast.Dark.Absorb` | Absorb, Aspir, Drain |
+| `sets.Midcast.Dark.Enhancing` | Dread Spikes, Endark, Klimaform, Tractor |
+| `sets.Midcast.Aspir` / `.Drain` | Aspir and Drain specifically |
+| `sets.Midcast.Helix` | Helix spells |
+
+### Midcast — healing and enhancing
+
+| Set | When used |
+|---|---|
+| `sets.Midcast.Cure` / `.Curaga` / `.Cura` | Cure family |
+| `sets.Midcast.Regen` / `.Refresh` | Regen and Refresh |
+| `sets.Midcast.Enhancing` | Base enhancing magic |
+| `sets.Midcast.Enhancing.Others` | Cast on party members |
+| `sets.Midcast.Enhancing.Skill` | Skill-scaling buffs (Temper, En-spells, Boost-*) |
+| `sets.Midcast.Enhancing.Elemental` | Barfire, Barblizzard, … |
+| `sets.Midcast.Enhancing.Status` | Barsleep, Barpoison, … |
+| `sets.Midcast.Enhancing.Gain` | Gain-STR and friends |
+| `sets.Midcast.SIRD` | Spell Interruption Rate Down |
+| `sets.Midcast.Skill` | Generic magic skill |
+| `sets.Midcast.ACC` | Generic magic accuracy |
+
+### Midcast — ranged and pets
+
+| Set | When used |
+|---|---|
+| `sets.Midcast.RA` | Ranged attack |
+| `sets.Midcast.RA.TripleShot` / `.DoubleShot` / `.Barrage` | With the matching buff active |
+| `sets.Midcast.RA['True Shot']` | True Shot |
+| `sets.Midcast.RA.AM1` / `.AM2` / `.AM3` | Ranged aftermath tiers |
+| `sets.Midcast.BP` | Blood Pacts |
+| `sets.Midcast.Summon` / `.SummoningMagic` | Summoning |
+| `sets.Pet_Midcast` | Pet actions |
+
+### Weaponskills
+
+| Set | When used |
+|---|---|
+| `sets.WS` | Base, always applied |
+| `sets.WS.<Mode>` | Per OffenseMode — `ACC`, `PDL`, `SB`, `CRIT`, `MEVA` |
+| `sets.WS['<Weaponskill Name>']` | A specific weaponskill — e.g. `sets.WS['Savage Blade']` |
+| `sets.WS['<Name>'].<Mode>` | A specific weaponskill in a specific mode |
+| `sets.WS.RA` | Ranged weaponskills, plus `.ACC`, `.PDL`, `.AM1`–`.AM3` |
+
+Named weaponskill sets layer on top of the generic ones, so you only specify what differs.
+
+### Job-specific
+
+| Set | Job |
+|---|---|
+| `sets.Waltz`, `sets.Jig`, `sets.Samba`, `sets.Step`, `sets.Flourish` | DNC |
+| `sets.PhantomRoll`, `sets.QuickDraw` | COR |
+| `sets.Jugs`, `sets.Ready`, `sets.Ready.Magic` / `.TP` / `.Debuff` / `.Standard` | BST |
+| `sets.Geomancy`, `.Geo`, `.Indi`, `.Indi.Entrust` | GEO |
+| `sets.Storms` | SCH |
+| `sets.Diffusion` | BLU |
+| `sets.Midcast.DummySongs`, `.Lullaby`, `.Madrigal`, `.March`, … | BRD (one per song family) |
+| `sets.TreasureHunter` | THF and anyone using TH modes |
+
+### Spell-received (multibox)
+
+Only needed if you use `SpellReceived`.
+
+| Set | Received spell |
+|---|---|
+| `sets.Cure_Received` | Cure I–VI, Curaga I–V, Cura I–III |
+| `sets.Cursna_Received` | Cursna |
+| `sets.Phalanx_Received` | Phalanx, Phalanx II |
+| `sets.Protect_Shell_Received` | Protect I–V, Protectra I–V, Shell I–V, Shellra I–V |
+| `sets.Regen_Received` | Regen I–V |
+| `sets.Refresh_Received` | Refresh I–III |
+| `sets.Waltz_Received` | Curing Waltz I–V, Divine Waltz I–II |
+| `sets.Holy_Water` | Worn when using Holy Water |
+
+---
+
+## 10. Automatic Engine Checks
+
+These run without you asking. Most produce a chat message explaining what happened.
+
+### The background loop
+
+Runs about ten times a second:
+
+- **Movement detection** — compares your position frame to frame; more than half a yalm of movement swaps in `sets.Movement`, stopping swaps it back.
+- **Auto-buff** — if AutoBuff is on and you are not in a town, asleep, stunned, terrorized, paralyzed, silenced or muddled, calls your buff-check functions.
+- **Spell timeout** — clears the busy flag if an action never reported completion, so the engine cannot get stuck.
+- **Every 2 seconds** — calls your `Cycle_Timer()` if you defined one.
+- **Every 30 seconds** — re-checks the Dual Wield trait and expires stale Treasure Hunter entries.
+
+### Action validation (pretarget)
+
+The engine cancels actions that would fail, and tells you why:
+
+| Check | Result |
+|---|---|
+| Asleep, KO'd or charmed | Action cancelled |
+| Pet is mid-action | Action cancelled |
+| Weaponskill below 1000 TP | Cancelled |
+| Weaponskill with Amnesia | Cancelled, with message |
+| Ability or spell still on cooldown | Cancelled, remaining time shown as `m:ss` |
+| Waltz without enough TP | Cancelled, shows current vs. required TP |
+| Paralyzed using an ability, or silenced casting | Uses a Remedy instead, if `AutoItem` is on |
+
+### Resource warnings
+
+- **Ranged ammo** — counts your ammo across inventory and all eight wardrobes on precast. Warns below `Ammo_Warning_Limit`, and cancels the action at zero with a message naming what is missing.
+- **Ninja tools** — warns when Shihei or Shikanofuda drops below 10, and echoes the warning to your other characters.
+
+### Automatic gear rules
+
+- **Weather and day bonus** — on elemental magic, equips Hachirin-no-Obi, Orpheus's Sash, Chatoyant Staff or Twilight Cape when day, weather or target distance makes them worthwhile. Only if you actually own the item.
+- **Required equipment** — Dispelga equips Daybreak, Honor March equips Marsyas, Aria of Passion equips Loughnashade, Impact equips Crepuscular Cloak or Twilight Cloak.
+- **Two-handed detection** — inspects your WeaponMode weapon and sets the two-hand flag, which suppresses sub-slot swaps.
+
+### Status ailment responses
+
+| Ailment | Response |
+|---|---|
+| **Sleep** | Equips idle + `sets.Weapons.Sleep`, locks main and ranged, cancels Stoneskin so you can be woken |
+| **Doom** | Equips and locks `sets.Cursna_Received`; uses Holy Water if `AutoItem` is on, warns if you have none |
+| **Silence** (mage jobs) | Uses a Remedy if `AutoItem` is on |
+| **Paralysis** | Uses a Remedy if `AutoItem` is on |
+| **Petrification / Stun** | Re-evaluates and re-equips your correct set |
+
+Sleep and Doom locks are released automatically when the status wears off.
+
+---
+
+## 11. Action and Spell Tracking
+
+### Treasure Hunter tracking
+
+The engine keeps a list of monsters you have already tagged, so `Tag` mode can drop TH gear and return to full damage once the tag lands. Entries are added when you act on a monster, removed when it dies, expired after 3 minutes of no activity, and cleared entirely on zone.
+
+### Skillchain and magic burst tracking
+
+The engine watches every skillchain that happens on your target — including ones made by other players. When one closes it records the elements and opens an 8-second burst window. Nukes cast into that window with a matching element use `sets.Midcast.Burst` instead of `sets.Midcast.Nuke`.
+
+Radiance and Umbra skillchains are recognized. A weaponskill that closes the window clears it.
+
+### Spell-received tracking (multibox)
+
+For players running several characters at once. When one of your characters begins casting a supported spell, it broadcasts over Windower's IPC channel. Any of your other characters targeted by that spell equips its "received" gear immediately — at pretarget and precast, before the spell lands.
+
+**Supported spells:** Cure I–VI · Curaga I–V · Cura I–III · Cursna · Phalanx I–II · Protect I–V · Protectra I–V · Shell I–V · Shellra I–V · Regen I–V · Refresh I–III
+
+**Supported abilities:** Curing Waltz I–V · Divine Waltz I–II
+
+The engine also predicts area-of-effect coverage, so `-ga` and `-ra` spells, Accession, Divine Veil and Majesty reach every affected character rather than only the direct target.
+
+A failsafe timer releases any locked gear if a completion message never arrives, so you cannot get stuck wearing cure-potency gear in a fight. The delay is configurable in `data/settings.xml` as `delay` (default 3 seconds).
+
+---
+
+## 12. Customization Hooks
+
+The engine builds a gear set, then calls your function and merges whatever you return. Define only the hooks you need — the engine will tell you which are missing when `warn` is on.
+
+### Required
+
+```lua
+function get_sets()
+    -- all of your sets.* definitions go here
+end
+```
+
+### Gear hooks
+
+| Function | Called | Return |
+|---|---|---|
+| `choose_set_custom()` | Whenever gear is re-evaluated | Extra gear for your current state |
+| `precast_custom(spell)` | Before an action | Extra precast gear |
+| `midcast_custom(spell)` | During an action | Extra midcast gear |
+| `aftercast_custom(spell)` | After an action | Extra aftercast gear |
+| `pretarget_custom(spell, action)` | Before targeting | — (validation and retargeting) |
+| `buff_change_custom(name, gain)` | A buff is gained or lost | Extra gear |
+| `status_change_custom(new, old)` | Engaged, idle, resting, … | Extra gear |
+
+Example:
+
+```lua
+function choose_set_custom()
+    local built_set = {}
+    if buffactive['Aftermath: Lv.3'] then
+        built_set = set_combine(built_set, sets.OffenseMode.AM3)
+    end
+    return built_set
+end
+```
+
+### Auto-buff hooks
+
+Return the **name** of an ability or spell to use, or `'None'`.
+
+```lua
+function check_buff_JA()
+    local buff = 'None'
+    if os.clock() - buff_time > Buff_Delay then          -- throttle the recast lookup
+        local ja_recasts = windower.ffxi.get_ability_recasts()
+        if not buffactive['Berserk'] and ja_recasts[1] == 0 then
+            buff = "Berserk"
+        end
+        if buff ~= 'None' then buff_time = os.clock() end
+    end
+    return buff
+end
+
+function check_buff_SP()
+    local buff = 'None'
+    return buff
+end
+```
+
+`check_buff_SP` is only called while you are standing still, so movement is not interrupted by casting.
+
+### Pet hooks
+
+| Function | Called |
+|---|---|
+| `pet_change_custom(pet, gain)` | Pet summoned or dismissed |
+| `pet_midcast_custom(spell)` | Pet action midcast |
+| `pet_aftercast_custom(spell)` | Pet action complete |
+
+### Other hooks
+
+| Function | Called |
+|---|---|
+| `self_command_custom(command)` | Any `gs c` command the engine did not recognize — add your own |
+| `sub_job_change_custom()` | Subjob changed |
+| `Cycle_Timer()` | Every 2 seconds, for periodic work |
+| `user_file_unload()` | Job file unloading — clean up anything you created |
+
+`Cycle_Timer` is useful for time-of-day gear:
+
+```lua
+function Cycle_Timer()
+    if world.time >= 17*60 or world.time <= 7*60 then
+        sets.Movement = set_combine(sets.Movement, sets.Movement.Night)
+    else
+        sets.Movement = set_combine(sets.Movement, sets.Movement.Day)
+    end
+end
+```
+
+### Startup
+
+Call this once, outside `get_sets()`, to apply your lockstyle, macro book and keybinds:
+
+```lua
+jobsetup(LockStylePallet, MacroBook, MacroSet)
+```
+
+---
+
+## 13. Troubleshooting
+
+### "sets.X not found!" in chat
+
+Exactly what it says — the engine wanted a set you have not defined. Add it to `get_sets()`, even as an empty table:
+
+```lua
 sets.Weapons.Sleep = {}
-sets.Weapons.Shield = {}
-sets.Weapons.Songs = {}
-sets.Weapons.Songs.Midcast = {}
 ```
 
-## Idle Sets
+Silence these with `//gs c warn` once your file is finished.
 
-```lua
-sets.Idle = {}
-sets.Idle.Pet = {}
-sets.Idle.Sublimation = {}
-sets.Idle.Resting = {}
-```
+### Gear is not swapping
 
-## Engaged Sets
+1. `//gs c debug` and watch the debug box.
+2. If `is_Busy` is stuck on, an action never reported completion — it clears itself within a couple of seconds.
+3. If `is_Moving` is stuck on, you may be on a mount or in an area where position updates are unreliable.
+4. `//gs c enableall` releases every locked slot.
+5. `//gs c update auto` forces a re-evaluation.
 
-```lua
-sets.OffenseMode = {}
-sets.OffenseMode.Ranged = {}
-sets.OffenseMode.AM = {}
-sets.OffenseMode.AM1 = {}
-sets.OffenseMode.AM2 = {}
-sets.OffenseMode.AM3 = {}
-```
-## Spell Received Sets
-These must be defined per character in each job.lua
+### A slot is stuck
 
-```lua
-sets.Cure_Received = {}
-sets.Cursna_Received = {}
-sets.Phalanx_Received = {}
-sets.Protect_Shell_Received = {}
-sets.Regen_Received = {}
-sets.Refresh_Received = {}
-sets.Waltz_Received = {}
-sets.Holy_Water = {}
-```
+Some features deliberately lock slots — Sleep locks main and ranged, Doom locks your Cursna set, `SpellReceived ON-Locked` locks the received set, Hoxne mode locks ammo. Use `//gs c enablebymode` to release what the current mode allows, or `//gs c enableall` to release everything.
 
-## Misc Sets
+### An item is not equipping
 
-```lua
-sets.Waltz = {}
-sets.Jig = {}
-sets.Samba = {}
-sets.Step = {}
-sets.Flourish = {}
-sets.Jugs = {}
-sets.PhantomRoll = {}
-sets.TreasureHunter = {}
-sets.QuickDraw = {}
-sets.JA = {}
-sets.Storms = {}
-sets.Enmity = {}
-sets.Diffusion = {}
-sets.Geomancy = {}
-sets.Geomancy.Geo = {}
-sets.Geomancy.Indi = {}
-sets.Geomancy.Indi.Entrust = {}
-sets.Pet_Midcast = {}
-sets.DualWield = {}
-sets.Cursna_Received = {}
-sets.Movement = {}
-```
+The engine can only equip items you own. Check spelling exactly as the item appears in game, and confirm it is in inventory or a wardrobe — not in storage, a satchel or a sack.
 
-## Precast
-```lua
-sets.Precast = {}
-sets.Precast.FastCast = {}
-sets.Precast.FastCast.Enhancing = {}
-sets.Precast.Cure = {}
-sets.Precast.Utsusemi = {}
-sets.Precast.RA = {}
-sets.Precast.RA.Flurry = {}
-sets.Precast.RA.Flurry_II = {}
-sets.Precast.Songs = {}
-```
+### The display box is gone
 
-## Weaponskills
-```lua
-sets.WS = {}
-sets.WS.ACC =  {}
-sets.WS.ACC.RA = {}
-sets.WS.PDL = {}
-sets.WS.PDL.RA = {}
-sets.WS.SB = {}
-sets.WS.SB.RA = {}
-sets.WS.CRIT = {}
-sets.WS.CRIT.RA = {}
-sets.WS.MEVA = {}
-sets.WS.MEVA.RA = {}
-sets.WS.AM = {}
-sets.WS.AM.RA = {}
-sets.WS.AM1 = {}
-sets.WS.AM1.RA = {}
-sets.WS.AM2 = {}
-sets.WS.AM2.RA = {}
-sets.WS.AM3 = {}
-sets.WS.AM3.RA = {}
-```
+`//gs c zero` moves it back to the top-left corner. If it is hidden rather than lost, `//gs c display`.
 
-## Midcast Ranged Attack
+### Settings are not saving
 
-```lua
-sets.Midcast = {}
-sets.Midcast.RA = {}
-sets.Midcast.RA.ACC = {}
-sets.Midcast.RA.PDL = {}
-sets.Midcast.RA.SB = {}
-sets.Midcast.RA.CRIT = {}
-sets.Midcast.RA['True Shot'] = {}
-sets.Midcast.RA.TripleShot = {}
-sets.Midcast.RA.DoubleShot = {}
-sets.Midcast.RA.Barrage = {}
-```
+Saving is skipped while zoning. Wait until you are fully loaded, then `//gs c save`. Settings live in `Windower4/addons/GearSwap/data/settings.xml`.
 
-## Midcast for Aftermath (Ranged Attack)
+### Auto-buff is not working
 
-```lua
-sets.Midcast.AM = {}
-sets.Midcast.AM.RA = {}
-sets.Midcast.AM1 = {}
-sets.Midcast.AM1.RA = {}
-sets.Midcast.AM2 = {}
-sets.Midcast.AM2.RA = {}
-sets.Midcast.AM3 = {}
-sets.Midcast.AM3.RA = {}
-```
+Check that AutoBuff is `ON` in the status box, that you are not in a town, and that your job file's `check_buff_JA` / `check_buff_SP` actually return an ability name. AutoBuff switches itself off when you zone.
 
-## Midcast for Magic
+### Nothing loads at all
 
-```lua
-sets.Midcast.Nuke = {}
-sets.Midcast.Burst = {}
-sets.Midcast.Cure = {}
-sets.Midcast.Curaga = {}
-sets.Midcast.Cura = {}
-sets.Midcast.Regen = {}
-sets.Midcast.Enhancing = {}
-sets.Midcast.Enhancing.Others = {}
-sets.Midcast.Refresh = {}
-sets.Midcast.Enhancing.Gain = {}
-sets.Midcast.Enhancing.Elemental = {}
-sets.Midcast.Enhancing.Status = {}
-sets.Midcast.Enhancing.Skill = {}
-sets.Midcast.Enfeebling = {}
-sets.Midcast.Enfeebling.MACC = {}
-sets.Midcast.Enfeebling.Potency = {}
-sets.Midcast.Enfeebling.Duration = {}
-sets.Midcast.Aspir = {}
-sets.Midcast.Drain = {}
-sets.Midcast.Dark = {}
-sets.Midcast.Dark.MACC = {}
-sets.Midcast.Dark.Absorb = {}
-sets.Midcast.Dark.Enhancing = {}
-sets.Midcast.Skill = {}
-sets.Midcast.SIRD = {}
-sets.Midcast.ACC = {}
-sets.Midcast.BP = {}
-sets.Midcast.SummoningMagic = {}
-sets.Midcast.Summon = {}
-sets.Midcast.DummySongs = {}
-sets.Midcast.Enfeebling = {}
-```
-## Midcast for Songs
+Confirm `Mirdain-Include.lua` is in `GearSwap/libs/` and your job file is in `GearSwap/data/`. Then `//gs reload` and watch for errors in the Windower console.
 
-```lua
-sets.Midcast.Finale = {}
-sets.Midcast.Lullaby = {}
-sets.Midcast.Threnody = {}
-sets.Midcast.Elegy = {}
-sets.Midcast.Requiem = {}
-sets.Midcast.March = {}
-sets.Midcast.Minuet = {}
-sets.Midcast.Madrigal = {}
-sets.Midcast.Ballad = {}
-sets.Midcast.Scherzo = {}
-sets.Midcast.Mazurka = {}
-sets.Midcast.Paeon = {}
-sets.Midcast.Carol = {}
-sets.Midcast.Minne = {}
-sets.Midcast.Mambo = {}
-sets.Midcast.Etude = {}
-sets.Midcast.Prelude = {}
-sets.Midcast.Dirge ={}
-sets.Midcast.Sirvente = {}
-sets.Midcast.Aria = {}
-```
+---
+
+## Credits
+
+Original concept and engine by **Mirdain**. This enhanced revision conceived and programmed by **Rahvin**.
+
+Contributions and issue reports welcome via the [Discord](https://discord.gg/kt68622p).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mirdain-Include Enhanced
 
-**Version 1.6.3** · A GearSwap engine for Final Fantasy XI (Windower 4)
+**Version 1.6.4** · A GearSwap engine for Final Fantasy XI (Windower 4)
 
 Enhanced version of Mirdain-Include, created by Rahvin. Check your running version in game with `//gs c version`.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mirdain-Include
+# Mirdain-Include Enhanced
 
 **Version 1.6.3** · A GearSwap engine for Final Fantasy XI (Windower 4)
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,30 @@
-# Version 1.4
+# Version 1.6
+Enhanced version of Mirdain-Include created by Rahvin
 Use //gs c version to check your active version
 
 ##Discord Link: https://discord.gg/kt68622p
 
-### Write up: `Sotel` 
+### Write up: `Rahvin` 
 
 # Keybinds
+## Spell Received Gear Tracking
+Cycle via Keybind: <kbd><kbd>CTRL</kbd> + <kbd>F9</kbd></kbd>
+
+This feature enables multiboxers to automatically equip spell-received potency and duration gear when a locally connected character is casting on you.  This action occurs at the pretargetcheck and precast phases, ensuring instantaneous swapping before the spell lands, even with Quick Magic.
+Supported Spells: `Cure` `Cursna` `Protect` `Shell` `Phalanx` `Regen` `Refresh` `Waltz`
+Changed in game via command: `gs c SpellReceived  <mode>`
+
+Ex: `gs c SpellReceived ON-Locked`
+Available Modes: `ON-Locked` `ON-Unlocked` `OFF`
+
+## Hoxne Ampulla Mode
+Cycle via Keybind: <kbd><kbd>CTRL</kbd> + <kbd>F10</kbd></kbd>
+
+This feature locks Hoxne Ampulla to your ammo slot and prevents automated unlocks until disabled.  Persists through zoning.  Hoxne Ampulla must be manually used after engaging Hoxne Mode to gain the benefit of the buff.
+Changed in game via command: `gs c hoxne`
+
+Available Modes: `ON` `OFF`
+
 ## OffenseMode
 Cycle via Keybind: <kbd>F12</kbd>
 
@@ -123,12 +142,25 @@ Sends `terminate` command to kill the game
 
 ## `save`
 Saves the current settings for the character.
-
 Ex: `Display Location`
+
+## `zero`
+Resets HUD position
 
 ## `display`
 
 Toggles the in game HUD visibility.
+
+## `displaymode`
+
+Toggles one line or full view for HUD.
+
+## `spellreceived`
+Cycle through spell-received modes.  ON-Locked temporarily locks your spell-recieved potency gear in place until the spell lands or is interrupted (Recommended).  ON-Unlocked allows gear to be overwritten by other combat actions (Niche Uses). OFF disables spell-received gear checking (Not Recommended)
+Set up your gear-received sets for proper functionality.
+
+## `hoxne`
+Toggle on Hoxne Ampulla locking.  Will not turn on if the character is missing Hoxne Ampulla in inventory or wardrobe. Persists through zoning.  Must manually use the item to gain the buff.
 
 ## `debug`
 Toggles the debug state to enable in-game logs and a HUD.
@@ -286,6 +318,18 @@ sets.OffenseMode.AM = {}
 sets.OffenseMode.AM1 = {}
 sets.OffenseMode.AM2 = {}
 sets.OffenseMode.AM3 = {}
+```
+## Spell Received Sets
+
+```lua
+sets.Cure_Received = {}
+sets.Cursna_Received = {}
+sets.Phalanx_Received = {}
+sets.Protect_Shell_Received = {}
+sets.Regen_Received = {}
+sets.Refresh_Received = {}
+sets.Waltz_Received = {}
+sets.Holy_Water = {}
 ```
 
 ## Misc Sets

--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ sets.OffenseMode.AM2 = {}
 sets.OffenseMode.AM3 = {}
 ```
 ## Spell Received Sets
+These must be defined per character in each job.lua
 
 ```lua
 sets.Cure_Received = {}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mirdain-Include Enhanced
 
-**Version 1.6.4** · A GearSwap engine for Final Fantasy XI (Windower 4)
+**Version 1.6.5** · A GearSwap engine for Final Fantasy XI (Windower 4)
 
 Enhanced version of Mirdain-Include, created by Rahvin. Check your running version in game with `//gs c version`.
 
@@ -94,11 +94,38 @@ Separately, a background loop (the "engine") runs about ten times a second to ha
 
 The suite draws two boxes on screen.
 
-**Status box** — always available, shows your current modes:
+**Status box** — always available, shows your current modes. Two layouts, toggled with `//gs c displaymode`.
+
+Stacked:
 
 ```
-TH:[None] Spell-Rec:[ON-Locked] Hoxne:[OFF] Stance:[DT] DPS:[Chango]
+TH .  SR .  HOX o
+STN <    DT     >
+DPS <Black Halo >
+MDE <   Melee   >
 ```
+
+One-line:
+
+```
+TH .  SR .  HOX o  STN <DT>  DPS <Black Halo>  MDE <Melee>
+```
+
+*(The box draws filled/hollow circles and solid triangles. They are transcribed above as `.`, `o`, `<` and `>` so this file stays readable in a plain-text editor.)*
+
+**Reading the indicators**
+
+| Indicator | Meaning |
+|---|---|
+| Filled circle, green | Mode is fully on |
+| Filled circle, amber | Partially on — currently only TH `Tag` |
+| Filled circle, cyan | THF-only TH `SATA` |
+| Hollow circle, grey | Mode is off (`None` / `OFF`) |
+| Value between triangles | A cycling mode — press its key, or `//gs c <mode> <value>` |
+
+TH, SR (SpellReceived) and HOX (Hoxne) are drawn as a circle only. Their whole state fits in one colour, which is what keeps the box narrow. Every other mode keeps its **full text**, so the weapon or job function currently selected is always readable.
+
+**Sizing.** Column widths come from each mode's complete list of options rather than its current value, so cycling a mode never resizes the stacked box — it stays a fixed width for as long as a job is loaded. The glyph header sets a 17-cell floor that most jobs never exceed, which also keeps the box near-identical across job changes. The one-line layout deliberately flexes with the current values to stay as short as possible.
 
 **Debug box** — hidden by default, shows internal engine state. Useful when something is not swapping as expected:
 
@@ -113,9 +140,13 @@ TH:[None] Spell-Rec:[ON-Locked] Hoxne:[OFF] Stance:[DT] DPS:[Chango]
 
 ### Moving and saving the boxes
 
-Drag either box with the left mouse button. The position saves to disk automatically when you release. You can also save manually with `//gs c save`, reset a lost box to the top-left corner with `//gs c zero`, hide the status box with `//gs c display`, and switch between one-line and stacked layouts with `//gs c displaymode`.
+Drag either box with the left mouse button. The position is written to disk automatically when you release, and the save is **silent** — there is no chat confirmation. This is handled by Windower's own text library rather than by a mouse hook in the include, so moving the cursor costs nothing extra.
 
-> Saving is skipped while you are zoning. If you see *"Cannot save while zoning"*, wait a moment and try again.
+You can also save manually with `//gs c save`, reset a lost box to the top-left corner with `//gs c zero`, hide the status box with `//gs c display`, and switch between one-line and stacked layouts with `//gs c displaymode`.
+
+Positions are stored **per character** in `Windower4/addons/GearSwap/data/settings.xml`.
+
+> Saving is skipped while you are zoning. A drag released mid-zone is not persisted — drop the box again once you have finished loading. `//gs c save` will tell you outright if it cannot save yet.
 
 ---
 
@@ -199,11 +230,12 @@ For players running more than one character. When another of your characters cas
 
 | Mode | Behavior |
 |---|---|
-| `ON-Locked` | Equip received gear and lock those slots until the spell resolves *(recommended)* |
-| `ON-Unlocked` | Equip received gear but allow other actions to overwrite it |
+| `ON` | Equip received gear and lock those slots until the spell resolves |
 | `OFF` | Disabled |
 
-**Command:** `//gs c SpellReceived ON-Locked`
+**Command:** `//gs c SpellReceived ON`
+
+> **Changed.** The former `ON-Locked` and `ON-Unlocked` values were collapsed into a single `ON`. `ON-Locked` is now just `ON` and behaves identically; `ON-Unlocked` has been removed as unnecessary. Any macro or script still passing an old value is rejected with a suggestion rather than silently doing the wrong thing — update it to `ON`.
 
 Requires the corresponding `*_Received` sets. See [Spell-Received Tracking](#spell-received-tracking-multibox).
 
@@ -220,16 +252,37 @@ Locks Hoxne Ampulla into your ammo slot and stops the engine from unlocking it. 
 Two free-form modes for anything a job needs. The engine only tracks the value; what it means is up to your job file.
 
 ```lua
-UI_Name  = 'Tank'          -- label shown in the status box
+UI_Name  = 'Auto Tank'     -- name used in chat messages
 state.JobMode:options('OFF','Auto Tank')
 
-UI_Name2 = 'Rune'
+UI_Name2 = 'Runes'
 state.JobMode2:options('Ignis','Gelus','Flabra')
 ```
 
 **Commands:** `//gs c JobMode "Auto Tank"` · `//gs c JobMode2 Ignis`
 
 If `UI_Name` is left empty the mode is hidden from the status box.
+
+#### Status box labels
+
+The status box needs a short label, and the include derives one from `UI_Name` automatically — **existing job files need no changes**. A table of known names is checked first, then a general rule: a single word takes its first three letters, several words take two letters of the first plus the initial of the last.
+
+| `UI_Name` | Derived label |
+|---|---|
+| `Mode` | `MDE` |
+| `Pet` | `PET` |
+| `TP Mode` | `TPM` |
+| `Auto Tank` | `TNK` |
+| `Runes` | `RUN` |
+| `Blood Pact` | `BLP` |
+| `Skillchain` | `SKI` |
+
+If you dislike what it picks, set `UI_Short` (and `UI_Short2`) in your job file to override it. An explicit value is used verbatim, and the label column widens to fit if it is longer than three characters:
+
+```lua
+UI_Name  = 'Auto Tank'
+UI_Short = 'ATK'           -- optional; overrides the derived TNK
+```
 
 ### RAMode — ranged ammunition type
 
@@ -249,12 +302,26 @@ All commands are typed as `//gs c <command>` and are **case-insensitive**.
 | `gs c WeaponMode [mode]` | Cycle, or jump to a specific weapon set |
 | `gs c TreasureHunter [mode]` | Cycle, or jump to a TH mode |
 | `gs c AutoBuff [mode]` | Cycle, or set auto-buffing |
-| `gs c SpellReceived [mode]` | Cycle, or set spell-received tracking |
-| `gs c hoxne [on\|off]` | Toggle or set Hoxne Ampulla lock |
+| `gs c SpellReceived [ON\|OFF]` | Cycle, or set spell-received tracking |
+| `gs c hoxne [ON\|OFF]` | Toggle or set Hoxne Ampulla lock |
 | `gs c JobMode [mode]` | Cycle, or jump to a job-specific mode |
 | `gs c JobMode2 [mode]` | Cycle, or jump to a second job-specific mode |
 
-Quote any value containing a space: `//gs c WeaponMode "Savage Blade"`
+Values containing a space work either way: `//gs c WeaponMode "Savage Blade"` and `//gs c WeaponMode Savage Blade` are equivalent.
+
+#### Argument validation
+
+**With no argument, every mode command cycles forward one step**, exactly as it always has — `//gs c TreasureHunter` steps `None` to `Tag` to `Full Time` and wraps. A stray trailing space still counts as no argument.
+
+**With an argument**, the value must be one of that mode's options, matched case-insensitively. Anything else changes nothing and reports why:
+
+```
+//gs c SpellReceived on-locked
+Spell Received: "on-locked" is not a valid mode. Did you mean [ON]?
+Usage: //gs c SpellReceived [OFF|ON]
+```
+
+Partial values are offered as a suggestion but never accepted, so `//gs c TreasureHunter full` is rejected in favour of `Full Time`. Previously an unrecognised value raised a raw Lua error, or — for `SpellReceived` and `hoxne` — was matched loosely enough that a wrong value could set the wrong mode.
 
 ### Display
 
@@ -330,8 +397,10 @@ Plain variables you set near the top of your job file.
 | `Ammo_Warning_Limit` | number | `99` | Warn on precast when ranged ammo falls below this count |
 | `Buff_Delay` | number | — | Minimum seconds between AutoBuff attempts |
 | `Tank_Delay` | number | — | Minimum seconds between auto-tank ability attempts |
-| `UI_Name` | string | `''` | Status box label for JobMode; empty hides it |
-| `UI_Name2` | string | `''` | Status box label for JobMode2; empty hides it |
+| `UI_Name` | string | `''` | Name used for JobMode in chat; empty hides the mode entirely |
+| `UI_Name2` | string | `''` | Name used for JobMode2 in chat; empty hides the mode entirely |
+| `UI_Short` | string | `''` | Optional status box label for JobMode; derived from `UI_Name` when empty |
+| `UI_Short2` | string | `''` | Optional status box label for JobMode2 |
 
 > **Performance tip:** `Buff_Delay` matters. Without it, AutoBuff queries every ability and spell recast about ten times a second for the whole session. One check per second is plenty — job ability recasts are minutes long. The PLD and RUN sample files show the pattern.
 
@@ -698,7 +767,7 @@ Silence these with `//gs c warn` once your file is finished.
 
 ### A slot is stuck
 
-Some features deliberately lock slots — Sleep locks main and ranged, Doom locks your Cursna set, `SpellReceived ON-Locked` locks the received set, Hoxne mode locks ammo. Use `//gs c enablebymode` to release what the current mode allows, or `//gs c enableall` to release everything.
+Some features deliberately lock slots — Sleep locks main and ranged, Doom locks your Cursna set, `SpellReceived ON` locks the received set, Hoxne mode locks ammo. Use `//gs c enablebymode` to release what the current mode allows, or `//gs c enableall` to release everything.
 
 ### An item is not equipping
 
@@ -710,7 +779,13 @@ The engine can only equip items you own. Check spelling exactly as the item appe
 
 ### Settings are not saving
 
-Saving is skipped while zoning. Wait until you are fully loaded, then `//gs c save`. Settings live in `Windower4/addons/GearSwap/data/settings.xml`.
+Saving is skipped while zoning. Wait until you are fully loaded, then `//gs c save`. Settings live in `Windower4/addons/GearSwap/data/settings.xml`, under a node named for your character.
+
+Dragging a box saves silently, so no chat message on release is normal — confirm by checking the `pos` values in `settings.xml`, or reload GearSwap and see whether the box returns to where you dropped it.
+
+### The status box shows blank squares or the columns are ragged
+
+The box uses circle and triangle characters that exist in Consolas, Lucida Console and Courier New. If you have changed `font` in `settings.xml` to a font lacking them, Windows substitutes a glyph from another font at a different width, which knocks the columns out of alignment. Switch back to a monospaced font that covers them.
 
 ### Auto-buff is not working
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 Enhanced version of Mirdain-Include, created by Rahvin. Check your running version in game with `//gs c version`.
 
-**Discord:** https://discord.gg/kt68622p
-
 ---
 
 ## Table of Contents
@@ -728,4 +726,4 @@ Confirm `Mirdain-Include.lua` is in `GearSwap/libs/` and your job file is in `Ge
 
 Original concept and engine by **Mirdain**. This enhanced revision conceived and programmed by **Rahvin**.
 
-Contributions and issue reports welcome via the [Discord](https://discord.gg/kt68622p).
+Contributions and issue reports welcome via the Silmaril or Vinland discords.  IYKYK.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Version 1.6
 Enhanced version of Mirdain-Include created by Rahvin
+
 Use //gs c version to check your active version
 
 ##Discord Link: https://discord.gg/kt68622p
@@ -11,16 +12,20 @@ Use //gs c version to check your active version
 Cycle via Keybind: <kbd><kbd>CTRL</kbd> + <kbd>F9</kbd></kbd>
 
 This feature enables multiboxers to automatically equip spell-received potency and duration gear when a locally connected character is casting on you.  This action occurs at the pretargetcheck and precast phases, ensuring instantaneous swapping before the spell lands, even with Quick Magic.
+
 Supported Spells: `Cure` `Cursna` `Protect` `Shell` `Phalanx` `Regen` `Refresh` `Waltz`
+
 Changed in game via command: `gs c SpellReceived  <mode>`
 
 Ex: `gs c SpellReceived ON-Locked`
+
 Available Modes: `ON-Locked` `ON-Unlocked` `OFF`
 
 ## Hoxne Ampulla Mode
 Cycle via Keybind: <kbd><kbd>CTRL</kbd> + <kbd>F10</kbd></kbd>
 
 This feature locks Hoxne Ampulla to your ammo slot and prevents automated unlocks until disabled.  Persists through zoning.  Hoxne Ampulla must be manually used after engaging Hoxne Mode to gain the benefit of the buff.
+
 Changed in game via command: `gs c hoxne`
 
 Available Modes: `ON` `OFF`
@@ -148,11 +153,9 @@ Ex: `Display Location`
 Resets HUD position
 
 ## `display`
-
 Toggles the in game HUD visibility.
 
 ## `displaymode`
-
 Toggles one line or full view for HUD.
 
 ## `spellreceived`

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Defaults to `Full Time` on THF and `None` on every other job. Tagged monsters ar
 
 ### AutoBuff — self-buffing
 
-When on, the engine checks roughly ten times a second whether you are missing a buff it can reapply, and uses it. Disabled in towns, and while asleep, stunned, terrorized, paralyzed, silenced or muddled.
+When on, the engine checks roughly ten times a second whether you are missing a buff it can reapply, and uses it. Disabled in towns, and while asleep, stunned, terrorized, paralyzed, silenced or muddled.  This is leftover from development prior to the use of other automation tools.  Usable if manually single boxing.  Leave off if using other automation software.
 
 - **Options:** `OFF` `ON`
 - **Command:** `//gs c AutoBuff ON`

--- a/Sample Job Files/BLM.lua
+++ b/Sample Job Files/BLM.lua
@@ -88,7 +88,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -247,7 +247,7 @@ function get_sets()
 		hands="Wicce Gloves +3",
 		legs="Wicce Chausses +3",
 		feet="Wicce Sabots +3",
-		left_ring={name="Stikini Ring +1", bag="wardrobe1"},
+		left_ring={name="Stikini Ring +1", bag="wardrobe"},
 		right_ring={name="Stikini Ring +1", bag="wardrobe2"},
 	})
 

--- a/Sample Job Files/BLM.lua
+++ b/Sample Job Files/BLM.lua
@@ -84,12 +84,21 @@ function get_sets()
 		feet="Herald's Gaiters",
 	}
 
-	-- Set to be used if you get 
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	sets.OffenseMode = {}

--- a/Sample Job Files/BLU.lua
+++ b/Sample Job Files/BLU.lua
@@ -113,12 +113,21 @@ function get_sets()
 		legs={ name="Carmine Cuisses +1", augments={'HP+80','STR+12','INT+12',}, priority=1},
     }
 
-	-- Set to be used if you get cursna casted on you
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	sets.Subtle_Blow = {

--- a/Sample Job Files/BLU.lua
+++ b/Sample Job Files/BLU.lua
@@ -30,11 +30,49 @@ state.OffenseMode:set('DT')
 --Command to Lock Style and Set the correct macros
 jobsetup (LockStylePallet,MacroBook,MacroSet)
 
-BlueNuke = S{'Spectral Floe','Entomb', 'Magic Hammer', 'Tenebral Crush','Embalming Earth'}
-BlueACC = S{'Cruel Joke','Dream Flower'}
-BlueHealing = S{'Magic Fruit','Healing Breeze','Wild Carrot','Plenilune Embrace'}
-BlueSkill = S{'Occultation','Erratic Flutter','Nature\'s Meditation','Cocoon','Barrier Tusk','Matellic Body','Mighty Guard'}
-BlueTank = S{}
+-- Blue Magic classification.  Buckets follow the spell's mechanic, because the
+-- mechanics do not share gear.  See the header in Mirdain-Include.lua.
+BluePhysical = S { 'Amorphic Spikes', 'Asuran Claws', 'Barbed Crescent', 'Battle Dance',
+    'Benthic Typhoon', 'Bilgestorm', 'Bloodrake', 'Bludgeon', 'Body Slam', 'Cannonball',
+    'Claw Cyclone', 'Death Scissors', 'Delta Thrust', 'Dimensional Death', 'Disseverment',
+    'Empty Thrash', 'Feather Storm', 'Final Sting', 'Foot Kick', 'Frenetic Rip', 'Frypan',
+    'Glutinous Dart', 'Goblin Rush', 'Grand Slam', 'Head Butt', 'Heavy Strike', 'Helldive',
+    'Hydro Shot', 'Hysteric Barrage', 'Jet Stream', 'Mandibular Bite', 'Paralyzing Triad',
+    'Pinecone Bomb', 'Power Attack', 'Quad. Continuum', 'Quadrastrike', 'Queasyshroom',
+    'Ram Charge', 'Saurian Slide', 'Screwdriver', 'Seedspray', 'Sickle Slash', 'Sinker Drill',
+    'Smite of Rage', 'Spinal Cleave', 'Spiral Spin', 'Sprout Smack', 'Sub-zero Smash',
+    'Sudden Lunge', 'Sweeping Gouge', 'Tail Slap', 'Terror Touch', 'Thrashing Assault',
+    'Tourbillion', 'Uppercut', 'Vanity Dive', 'Vertical Cleave', 'Whirl of Rage', 'Wild Oats' }
+BlueBreath = S { 'Bad Breath', 'Flying Hip Press', 'Frost Breath', 'Heat Breath',
+    'Hecatomb Wave', 'Magnetite Cloud', 'Poison Breath', 'Radiant Breath', 'Self-Destruct',
+    'Thunder Breath', 'Vapor Spray', 'Wind Breath' }
+BlueNuke = S { 'Acrid Stream', 'Anvil Lightning', 'Blastbomb', 'Blazing Bound',
+    'Blinding Fulgor', 'Blitzstrahl', 'Bomb Toss', 'Cesspool', 'Charged Whisker',
+    'Crashing Thunder', 'Cursed Sphere', 'Dark Orb', 'Death Ray', 'Diffusion Ray',
+    'Droning Whirlwind', 'Embalming Earth', 'Entomb', 'Evryone. Grudge', 'Eyes On Me',
+    'Firespit', 'Foul Waters', 'Gates of Hades', 'Ice Break', 'Leafstorm', 'Maelstrom',
+    'Magic Hammer', 'Mind Blast', 'Molting Plumage', 'Mysterious Light', 'Nectarous Deluge',
+    'Palling Salvo', 'Polar Roar', 'Rail Cannon', 'Regurgitation', 'Rending Deluge',
+    'Retinal Glare', 'Scouring Spate', 'Searing Tempest', 'Silent Storm', 'Spectral Floe',
+    'Subduction', 'Tearing Gust', 'Tem. Upheaval', 'Temporal Shift', 'Tenebral Crush',
+    'Thermal Pulse', 'Thunderbolt', 'Uproot', 'Water Bomb' }
+BlueSkill = S { 'Atra. Libations', 'Barrier Tusk', 'Diamondhide', 'Magic Barrier',
+    'Metallic Body', 'Occultation', 'Plasma Charge', 'Pyric Bulwark', 'Reactor Cool' }
+BlueBuff = S { 'Amplification', 'Animating Wail', 'Battery Charge', 'Carcharian Verve',
+    'Cocoon', 'Erratic Flutter', 'Exuviation', 'Fantod', 'Feather Barrier', 'Harden Shell',
+    'Memento Mori', 'Mighty Guard', 'Nat. Meditation', 'O. Counterstance', 'Refueling',
+    'Regeneration', 'Saline Coat', 'Triumphant Roar', 'Warm-Up', 'Winds of Promy.',
+    'Zephyr Mantle' }
+BlueHealing = S { 'Healing Breeze', 'Magic Fruit', 'Plenilune Embrace', 'Pollen', 'Restoral',
+    'Wild Carrot' }
+BlueTank = S { 'Actinic Burst', 'Blank Gaze', 'Demoralizing Roar', 'Frightful Roar',
+    'Geist Wall', 'Jettatura', 'Sheep Song', 'Soporific', 'Stinking Gas' }
+BlueACC = S { '1000 Needles', 'Absolute Terror', 'Auroral Drape', 'Awful Eye',
+    'Blistering Roar', 'Blood Drain', 'Blood Saber', 'Chaotic Eye', 'Cimicine Discharge',
+    'Cold Wave', 'Corrosive Ooze', 'Cruel Joke', 'Digest', 'Dream Flower', 'Enervation',
+    'Feather Tickle', 'Filamented Hold', 'Infrasonics', 'Light of Penance', 'Lowing',
+    'MP Drainkiss', 'Mortal Ray', 'Osmosis', 'Reaving Wind', 'Sandspin', 'Sandspray',
+    'Sound Blast', 'Venom Shell', 'Voracious Trunk', 'Yawn' }
 
 --Weapons specific to Blue Mage
 state.WeaponMode:options('Almace','Naegling','Black Halo','Cleave')
@@ -356,6 +394,10 @@ function get_sets()
     sets.Midcast["Refresh"] = set_combine(sets.Midcast.Enhancing, {
 		waist="Gishdubar Sash"
 	})
+	
+    -- White Wind heals floor(MaxHP/7)*2 and is affected by Cure Potency, but NOT by
+    -- Blue Magic Skill or MND.  Prioritize max HP, then Cure Potency.
+    sets.Midcast["White Wind"] = {}
 
     sets.Midcast["Aquaveil"] = set_combine(sets.Midcast.Enhancing, {
 	})

--- a/Sample Job Files/BLU.lua
+++ b/Sample Job Files/BLU.lua
@@ -607,13 +607,13 @@ function user_file_unload()
 end
 
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	--local ja_recasts = windower.ffxi.get_ability_recasts()
 	return buff
 end
 
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	local sp_recasts = windower.ffxi.get_spell_recasts()
 	if not buffactive['Phalanx'] and sp_recasts[517] == 0 and player.mp >= 19 then
 		buff = "Metallic Body"

--- a/Sample Job Files/BLU.lua
+++ b/Sample Job Files/BLU.lua
@@ -552,7 +552,7 @@ function pretarget_custom(spell,action)
 end
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 	if spell.type == 'WeaponSkill' then
 		if state.OffenseMode.value == "MEVA" then
 			equipSet = set_combine(equipSet, { neck="Warder's Charm +1", })
@@ -562,31 +562,31 @@ function precast_custom(spell)
 end
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
@@ -626,19 +626,19 @@ function check_buff_SP()
 end
 
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 	
 	return equipSet
 end
 
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end

--- a/Sample Job Files/BLU.lua
+++ b/Sample Job Files/BLU.lua
@@ -132,7 +132,7 @@ function get_sets()
 		waist="Carrier's Sash",
 		left_ear="Etiolation Earring",
 		right_ear={ name="Odnowa Earring +1", augments={'Path: A',}},
-		left_ring={name="Stikini Ring +1", bag="wardrobe1"}, -- +1 Refresh
+		left_ring={name="Stikini Ring +1", bag="wardrobe"}, -- +1 Refresh
 		right_ring={name="Stikini Ring +1", bag="wardrobe2"}, -- +1 Refresh
 		back={ name="Rosmerta's Cape", augments={'DEX+20','Accuracy+20 Attack+20','DEX+10','"Dbl.Atk."+10','Damage taken-5%',}},
     }
@@ -155,7 +155,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -239,7 +239,7 @@ function get_sets()
 	})
 
 	sets.OffenseMode.SB = set_combine ( sets.OffenseMode,{
-		left_ring={ name="Chirich Ring +1", bag="wardrobe1", priority=2},
+		left_ring={ name="Chirich Ring +1", bag="wardrobe", priority=2},
 		right_ring={ name="Chirich Ring +1", bag="wardrobe2", priority=1},
 	})
 
@@ -337,7 +337,7 @@ function get_sets()
 		waist="Olympus Sash",
 		left_ear="Mimir Earring",
 		right_ear={ name="Odnowa Earring +1", augments={'Path: A',}, priority=1},
-		left_ring={name="Stikini Ring +1", bag="wardrobe1"},
+		left_ring={name="Stikini Ring +1", bag="wardrobe"},
 		right_ring={name="Stikini Ring +1", bag="wardrobe2"},
 		back={ name="Rosmerta's Cape", augments={'INT+20','Mag. Acc+20 /Mag. Dmg.+20','Mag. Acc.+10','"Fast Cast"+10','Spell interruption rate down-10%',}},
 	}
@@ -378,14 +378,14 @@ function get_sets()
 		waist="Null Belt",
 		left_ear="Telos Earring",
 		right_ear="Hashi. Earring +1",
-		left_ring={name="Stikini Ring +1", bag="wardrobe1"},
+		left_ring={name="Stikini Ring +1", bag="wardrobe"},
 		right_ring={name="Stikini Ring +1", bag="wardrobe2"},
 		back="Null Shawl",
 	})
 
 	-- Specific gear for spells
 	sets.Midcast["Stoneskin"] = set_combine(sets.Midcast.Enhancing, {
-		left_ring={name="Stikini Ring +1", bag="wardrobe1"},
+		left_ring={name="Stikini Ring +1", bag="wardrobe"},
 		right_ring={name="Stikini Ring +1", bag="wardrobe2"},
 		waist="Siegel Sash",
 		neck="Nodens Gorget",
@@ -413,7 +413,7 @@ function get_sets()
 		waist="Null Belt",
 		left_ear="Crep. Earring",
 		right_ear="Hashi. Earring +1",
-		left_ring={name="Stikini Ring +1", bag="wardrobe1"},
+		left_ring={name="Stikini Ring +1", bag="wardrobe"},
 		right_ring="Weather. Ring",
 		back={ name="Rosmerta's Cape", augments={'INT+20','Mag. Acc+20 /Mag. Dmg.+20','Mag. Acc.+10','"Fast Cast"+10','Spell interruption rate down-10%',}},
 	})
@@ -429,7 +429,7 @@ function get_sets()
 		waist="Null Belt",
 		left_ear="Crep. Earring",
 		right_ear="Hashi. Earring +1",
-		left_ring={name="Stikini Ring +1", bag="wardrobe1"},
+		left_ring={name="Stikini Ring +1", bag="wardrobe"},
 		right_ring="Weather. Ring",
 		back={ name="Rosmerta's Cape", augments={'INT+20','Mag. Acc+20 /Mag. Dmg.+20','Mag. Acc.+10','"Fast Cast"+10','Spell interruption rate down-10%',}},
 	})
@@ -445,7 +445,7 @@ function get_sets()
 		waist="Null Belt",
 		left_ear="Crep. Earring",
 		right_ear="Hashi. Earring +1",
-		left_ring={name="Stikini Ring +1", bag="wardrobe1"},
+		left_ring={name="Stikini Ring +1", bag="wardrobe"},
 		right_ring="Weather. Ring",
 		back={ name="Rosmerta's Cape", augments={'INT+20','Mag. Acc+20 /Mag. Dmg.+20','Mag. Acc.+10','"Fast Cast"+10','Spell interruption rate down-10%',}},
 	})

--- a/Sample Job Files/BRD.lua
+++ b/Sample Job Files/BRD.lua
@@ -131,12 +131,21 @@ function get_sets()
 	--Used to swap into movement gear when the player is detected movement when not engaged
 	sets.Movement = { feet="Fili Cothurnes +3"}
 
-	-- Set to be used if you get cursna casted on you
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	--The following sets augment the base TP set 

--- a/Sample Job Files/BRD.lua
+++ b/Sample Job Files/BRD.lua
@@ -546,13 +546,13 @@ function self_command_custom(command)
 end
 
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	--local sp_recasts = windower.ffxi.get_spell_recasts()
 	return buff
 end
 
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	--local ja_recasts = windower.ffxi.get_ability_recasts()
 	return buff
 end

--- a/Sample Job Files/BRD.lua
+++ b/Sample Job Files/BRD.lua
@@ -135,7 +135,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -195,7 +195,7 @@ function get_sets()
 
 	--This set is used when OffenseMode is SB and Enaged (Augments the TP base set)
 	sets.OffenseMode.SB = set_combine(sets.OffenseMode, {
-		left_ring={ name="Chirich Ring +1", bag="wardrobe1", priority=1},
+		left_ring={ name="Chirich Ring +1", bag="wardrobe", priority=1},
 		right_ring={ name="Chirich Ring +1", bag="wardrobe2", priority=2},
 	})
 
@@ -452,7 +452,7 @@ function get_sets()
 	})
 
 	sets.WS.SB = {
-		left_ring={ name="Chirich Ring +1", bag="wardrobe1", priority=1},
+		left_ring={ name="Chirich Ring +1", bag="wardrobe", priority=1},
 		right_ring={ name="Chirich Ring +1", bag="wardrobe2", priority=2},
 	}
 

--- a/Sample Job Files/BRD.lua
+++ b/Sample Job Files/BRD.lua
@@ -506,37 +506,37 @@ function pretarget_custom(spell,action)
 end
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
@@ -563,19 +563,19 @@ function user_file_unload()
 end
 
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 	
 	return equipSet
 end
 
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end

--- a/Sample Job Files/BST.lua
+++ b/Sample Job Files/BST.lua
@@ -109,12 +109,21 @@ function get_sets()
 		--feet="Hermes' Sandals",
 	}
 
-    -- Set to be used if you get cursna casted on you
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	sets.OffenseMode = {

--- a/Sample Job Files/BST.lua
+++ b/Sample Job Files/BST.lua
@@ -83,7 +83,7 @@ function get_sets()
 		waist="Carrier's Sash",
 		left_ear="Etiolation Earring",
 		right_ear={ name="Odnowa Earring +1", augments={'Path: A',}},
-		left_ring={ name="Moonlight Ring", bag="wardrobe1", priority=2},
+		left_ring={ name="Moonlight Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Moonlight Ring", bag="wardrobe2", priority=1},
 		back={ name="Artio's Mantle", augments={'Pet: Acc.+20 Pet: R.Acc.+20 Pet: Atk.+20 Pet: R.Atk.+20','Accuracy+20 Attack+20','Accuracy+10','"Store TP"+10','Damage taken-5%',}},
     }
@@ -113,7 +113,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -149,7 +149,7 @@ function get_sets()
 	sets.OffenseMode.DT = set_combine(sets.OffenseMode, {
 		body="Malignance Tabard",
 		legs="Malignance Tights",
-		left_ring={ name="Moonlight Ring", bag="wardrobe1", priority=2},
+		left_ring={ name="Moonlight Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Moonlight Ring", bag="wardrobe2", priority=1},
 		back={ name="Artio's Mantle", augments={'Pet: Acc.+20 Pet: R.Acc.+20 Pet: Atk.+20 Pet: R.Atk.+20','Accuracy+20 Attack+20','Accuracy+10','"Store TP"+10','Damage taken-5%',}},
 	})

--- a/Sample Job Files/BST.lua
+++ b/Sample Job Files/BST.lua
@@ -339,7 +339,7 @@ function pretarget_custom(spell,action)
 end
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 	if spell.name:contains('Maneuver') then
 		equipSet = sets.JA.Maneuver
 	elseif spell.type == 'WeaponSkill' then
@@ -351,27 +351,27 @@ function precast_custom(spell)
 end
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return choose_gear()
 end
 
 -- Called when the pet dies or is summoned
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 -- Called during a pet midcast
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 		local message = 'Pet Not Set'
 		if Ready_Standard[spell.name] then
 			equipSet = set_combine(equipSet, sets.Pet_Midcast)
@@ -399,27 +399,27 @@ end
 
 -- Called after the performs an action
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = {}
+	local equipSet = {}
 
 	return choose_gear()
 end
 
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = {}
+	local equipSet = {}
 
 	return choose_gear()
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = {}
+	local equipSet = {}
 
 	return choose_gear()
 end
@@ -429,7 +429,7 @@ function self_command_custom(command)
 end
 --Custom Function
 function choose_gear()
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end

--- a/Sample Job Files/BST.lua
+++ b/Sample Job Files/BST.lua
@@ -435,7 +435,7 @@ function choose_gear()
 end
 
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	local ja_recasts = windower.ffxi.get_ability_recasts()
 
 	-- Sub job has least priority
@@ -453,7 +453,7 @@ function check_buff_JA()
 end
 
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	--local sp_recasts = windower.ffxi.get_spell_recasts()
 	return buff
 end

--- a/Sample Job Files/COR.lua
+++ b/Sample Job Files/COR.lua
@@ -140,12 +140,21 @@ function get_sets()
 		right_ring="Defending Ring",
 	}
 
-	-- Set to be used if you get 
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	sets.Subtle_Blow = {

--- a/Sample Job Files/COR.lua
+++ b/Sample Job Files/COR.lua
@@ -693,7 +693,7 @@ function user_file_unload()
 end
 
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	local ja_recasts = windower.ffxi.get_ability_recasts()
 	if player.sub_job == 'WAR' then
 		if not buffactive['Berserk'] and ja_recasts[1] == 0 then
@@ -708,7 +708,7 @@ function check_buff_JA()
 end
 
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	return buff
 end
 

--- a/Sample Job Files/COR.lua
+++ b/Sample Job Files/COR.lua
@@ -647,7 +647,7 @@ end
 
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 	if spell.english == 'Fold' and buffactive['Bust'] == 2 then
 		equipSet = set_combine(equipSet, sets.Fold)
     end
@@ -656,7 +656,7 @@ function precast_custom(spell)
 end
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 	if spell.english == 'Fold' and buffactive['Bust'] == 2 then
 		equipSet = set_combine(equipSet, sets.Fold)
     end
@@ -665,22 +665,22 @@ function midcast_custom(spell)
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = Job_Mode_Check(equipSet)
+	local equipSet = Job_Mode_Check(equipSet)
 	return equipSet
 end
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = Job_Mode_Check(equipSet)
+	local equipSet = Job_Mode_Check(equipSet)
 	return equipSet
 end
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = Job_Mode_Check(equipSet)
+	local equipSet = Job_Mode_Check(equipSet)
 	return equipSet
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = Job_Mode_Check(equipSet)
+	local equipSet = Job_Mode_Check(equipSet)
 	return equipSet
 end
 
@@ -729,16 +729,16 @@ function Job_Mode_Check(equipSet)
 end
 
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 	return equipSet
 end
 
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 	return equipSet
 end
 
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 	return equipSet
 end

--- a/Sample Job Files/COR.lua
+++ b/Sample Job Files/COR.lua
@@ -665,22 +665,22 @@ function midcast_custom(spell)
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	local equipSet = Job_Mode_Check(equipSet)
+	local equipSet = Job_Mode_Check({})
 	return equipSet
 end
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	local equipSet = Job_Mode_Check(equipSet)
+	local equipSet = Job_Mode_Check({})
 	return equipSet
 end
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	local equipSet = Job_Mode_Check(equipSet)
+	local equipSet = Job_Mode_Check({})
 	return equipSet
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	local equipSet = Job_Mode_Check(equipSet)
+	local equipSet = Job_Mode_Check({})
 	return equipSet
 end
 

--- a/Sample Job Files/COR.lua
+++ b/Sample Job Files/COR.lua
@@ -144,7 +144,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -223,7 +223,7 @@ function get_sets()
 		legs="Chas. Culottes +3",
 		neck="Null Loop",
 		right_ear={ name="Odnowa Earring +1", augments={'Path: A',}},
-		left_ring={ name="Chirich Ring +1", bag="wardrobe1", priority=2},
+		left_ring={ name="Chirich Ring +1", bag="wardrobe", priority=2},
 		right_ring={ name="Chirich Ring +1", bag="wardrobe2", priority=1},
 	})
 
@@ -326,7 +326,7 @@ function get_sets()
 		-- 10 II from gleti's Knife
 		head={ name="Ikenga's Hat", augments={'Path: A',}}, -- 5 II
 		hands={ name="Ikenga's Gloves", augments={'Path: A',}}, -- 15
-		left_ring={ name="Chirich Ring +1",  bag="wardrobe1"}, -- 10
+		left_ring={ name="Chirich Ring +1",  bag="wardrobe"}, -- 10
 		right_ring={ name="Chirich Ring +1",  bag="wardrobe2"}, -- 10
     })
 

--- a/Sample Job Files/DNC.lua
+++ b/Sample Job Files/DNC.lua
@@ -434,7 +434,7 @@ end
 
 --Function used to automate Job Ability use
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	local ja_recasts = windower.ffxi.get_ability_recasts()
 
 	if player.sub_job == 'SAM' and player.sub_job_level > 8 then
@@ -459,7 +459,7 @@ function check_buff_JA()
 end
 
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	--local sp_recasts = windower.ffxi.get_spell_recasts()
 	return buff
 end

--- a/Sample Job Files/DNC.lua
+++ b/Sample Job Files/DNC.lua
@@ -90,12 +90,21 @@ function get_sets()
 
 	sets.Movement = {right_ring="Shneddick Ring",}
 
-	-- Set to be used if you get cursna casted on you
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	--This set is used when OffenseMode is DT and Enaged (Augments the TP base set)

--- a/Sample Job Files/DNC.lua
+++ b/Sample Job Files/DNC.lua
@@ -94,7 +94,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -389,37 +389,37 @@ function pretarget_custom(spell,action)
 end
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return Weapon_Check(equipSet)
 end
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return Weapon_Check(equipSet)
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return Weapon_Check(equipSet)
 end
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = {}
+	local equipSet = {}
 
 	return Weapon_Check(equipSet)
 end
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = {}
+	local equipSet = {}
 
 	return Weapon_Check(equipSet)
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = {}
+	local equipSet = {}
 
 	return Weapon_Check(equipSet)
 end
@@ -465,19 +465,19 @@ function check_buff_SP()
 end
 
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 	
 	return equipSet
 end
 
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
@@ -489,19 +489,19 @@ function Weapon_Check(equipSet)
 end
 
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 	
 	return equipSet
 end
 
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end

--- a/Sample Job Files/DRG.lua
+++ b/Sample Job Files/DRG.lua
@@ -96,12 +96,21 @@ function get_sets()
 		legs={ name="Carmine Cuisses +1", augments={'HP+80','STR+12','INT+12',}},
 	}
 
-	-- Set to be used if you get 
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	sets.OffenseMode = {

--- a/Sample Job Files/DRG.lua
+++ b/Sample Job Files/DRG.lua
@@ -100,7 +100,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -464,37 +464,37 @@ function pretarget_custom(spell,action)
 end
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
@@ -540,19 +540,19 @@ function check_buff_SP()
 end
 
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 	
 	return equipSet
 end
 
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end

--- a/Sample Job Files/DRG.lua
+++ b/Sample Job Files/DRG.lua
@@ -509,7 +509,7 @@ end
 
 --Function used to automate Job Ability use
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	local ja_recasts = windower.ffxi.get_ability_recasts()
 
 	if player.sub_job == 'SAM' and player.sub_job_level == 49 then
@@ -534,7 +534,7 @@ function check_buff_JA()
 end
 
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	--local sp_recasts = windower.ffxi.get_spell_recasts()
 	return buff
 end

--- a/Sample Job Files/DRK.lua
+++ b/Sample Job Files/DRK.lua
@@ -412,7 +412,7 @@ end
 
 --Function used to automate Job Ability use
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	local ja_recasts = windower.ffxi.get_ability_recasts()
 
 	if player.sub_job == 'SAM' and player.sub_job_level == 49 then
@@ -437,7 +437,7 @@ function check_buff_JA()
 end
 
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	--local sp_recasts = windower.ffxi.get_spell_recasts()
 	return buff
 end

--- a/Sample Job Files/DRK.lua
+++ b/Sample Job Files/DRK.lua
@@ -104,7 +104,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -365,13 +365,13 @@ function pretarget_custom(spell,action)
 end
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 	if spell.name == "Dread Spikes" then
 		equipSet = set_combine( sets.Max_HP, { main="Crepuscular Scythe" })
 	end
@@ -379,25 +379,25 @@ function midcast_custom(spell)
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
@@ -443,19 +443,19 @@ function check_buff_SP()
 end
 
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 	
 	return equipSet
 end
 
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end

--- a/Sample Job Files/DRK.lua
+++ b/Sample Job Files/DRK.lua
@@ -100,12 +100,21 @@ function get_sets()
 		legs={ name="Carmine Cuisses +1", augments={'HP+80','STR+12','INT+12',}},
 	}
 
-	-- Set to be used if you get 
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	-- This caps with Auspice from WHM

--- a/Sample Job Files/GEO.lua
+++ b/Sample Job Files/GEO.lua
@@ -105,12 +105,21 @@ function get_sets()
 		feet="Geo. Sandals +4",
 	}
 
-	-- Set to be used if you get 
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	sets.TreasureHunter = {

--- a/Sample Job Files/GEO.lua
+++ b/Sample Job Files/GEO.lua
@@ -76,7 +76,7 @@ function get_sets()
 		waist="Carrier's Sash",
 		left_ear="Sanare Earring",
 		right_ear="Lugalbanda Earring",
-		left_ring={ name="Stikini Ring +1",  bag="wardrobe1"},
+		left_ring={ name="Stikini Ring +1",  bag="wardrobe"},
 		right_ring={ name="Stikini Ring +1",  bag="wardrobe2"},
 		back={ name="Nantosuelta's Cape", augments={'HP+60','Eva.+20 /Mag. Eva.+20','Mag. Evasion+10','Pet: "Regen"+10','Pet: "Regen"+5',}},
     } -- 50 PDT / 52 MDT (including shield)
@@ -109,7 +109,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -291,7 +291,7 @@ function get_sets()
 
 	-- Specific gear for spells
 	sets.Midcast["Stoneskin"] = set_combine(sets.Midcast.Enhancing, {
-		left_ring={ name="Stikini Ring +1",  bag="wardrobe1"},
+		left_ring={ name="Stikini Ring +1",  bag="wardrobe"},
 		right_ring={ name="Stikini Ring +1",  bag="wardrobe3"},
 		waist="Siegel Sash",
 	})

--- a/Sample Job Files/MNK.lua
+++ b/Sample Job Files/MNK.lua
@@ -164,13 +164,22 @@ function get_sets()
 	sets.Boost = {
 		waist="Ask Sash",
 	}
-
-	-- Set to be used if you get cursed
+	
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	sets.Enmity = {

--- a/Sample Job Files/MNK.lua
+++ b/Sample Job Files/MNK.lua
@@ -169,7 +169,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}

--- a/Sample Job Files/NIN.lua
+++ b/Sample Job Files/NIN.lua
@@ -453,7 +453,7 @@ function user_file_unload()
 end
 
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	local ja_recasts = windower.ffxi.get_ability_recasts()
 	if player.sub_job == 'WAR' then
 		if not buffactive['Berserk'] and ja_recasts[1] == 0 then
@@ -468,7 +468,7 @@ function check_buff_JA()
 end
 
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	--local sp_recasts = windower.ffxi.get_spell_recasts()
 	return buff
 end

--- a/Sample Job Files/NIN.lua
+++ b/Sample Job Files/NIN.lua
@@ -112,12 +112,21 @@ function get_sets()
 		feet="Hachi. Kyahan +1",
 	}
 
-	-- Set to be used if you get 
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	sets.OffenseMode = {}

--- a/Sample Job Files/NIN.lua
+++ b/Sample Job Files/NIN.lua
@@ -116,7 +116,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -248,7 +248,7 @@ function get_sets()
 		waist="Eschan Stone",
 		left_ear="Hermetic Earring",
 		right_ear="Crep. Earring",
-		left_ring={ name="Stikini Ring +1", bag="wardrobe1",},
+		left_ring={ name="Stikini Ring +1", bag="wardrobe",},
 		right_ring={ name="Stikini Ring +1", bag="wardrobe2",},
 		back={ name="Andartia's Mantle", augments={'INT+20','Mag. Acc+20 /Mag. Dmg.+20','Mag. Acc.+10','"Fast Cast"+10',}},
 	}
@@ -264,7 +264,7 @@ function get_sets()
     waist="Orpheus's Sash",
     left_ear="Hermetic Earring",
     right_ear="Friomisi Earring",
-	left_ring={ name="Stikini Ring +1", bag="wardrobe1",},
+	left_ring={ name="Stikini Ring +1", bag="wardrobe",},
 	right_ring={ name="Stikini Ring +1", bag="wardrobe2",},
     back={ name="Andartia's Mantle", augments={'INT+20','Mag. Acc+20 /Mag. Dmg.+20','Mag. Acc.+10','"Fast Cast"+10',}},
 	}
@@ -412,34 +412,34 @@ function pretarget_custom(spell,action)
 end
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 	return equipSet
 end
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = {}
+	local equipSet = {}
 	return equipSet
 end
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = {}
+	local equipSet = {}
 	return equipSet
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = {}
+	local equipSet = {}
 	return equipSet
 end
 --Function is called by the gearswap command
@@ -490,19 +490,19 @@ function Cycle_Timer()
 end
 
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 	
 	return equipSet
 end
 
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end

--- a/Sample Job Files/PLD.lua
+++ b/Sample Job Files/PLD.lua
@@ -174,12 +174,21 @@ function get_sets()
 		right_ear="Chev. Earring +1",
     }
 
-	-- Set to be used if you get cursna casted on you
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	sets.OffenseMode = set_combine( sets.Idle, {

--- a/Sample Job Files/PLD.lua
+++ b/Sample Job Files/PLD.lua
@@ -524,7 +524,7 @@ end
 
 --Function used to automate Job Ability use
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	if os.clock() - buff_time > Buff_Delay then
 		local ja_recasts = windower.ffxi.get_ability_recasts()
 
@@ -569,7 +569,7 @@ end
 
 --Function used to automate Spell use
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	if os.clock() - buff_time > Buff_Delay then
 		local sp_recasts = windower.ffxi.get_spell_recasts()
 		if not buffactive['Enmity Boost'] and sp_recasts[476] == 0 and player.mp > 18 and player.main_job_level > 87 then
@@ -596,7 +596,7 @@ function check_buff_SP()
 end
 
 function check_tank()
-	buff = 'None'
+	local buff = 'None'
 	if os.clock() - tank_time > Tank_Delay then
 		if (player.status == "Engaged" or windower.ffxi.get_player().target_locked) and state.JobMode.value == "ON" then
 			local sp_recasts = windower.ffxi.get_spell_recasts()

--- a/Sample Job Files/PLD.lua
+++ b/Sample Job Files/PLD.lua
@@ -128,7 +128,7 @@ function get_sets()
 		waist="Carrier's Sash",
 		left_ear={ name="Odnowa Earring +1", augments={'Path: A',}}, -- 3
 		right_ear="Sanare Earring",
-		left_ring={ name="Moonlight Ring", bag="wardrobe1", priority=2},
+		left_ring={ name="Moonlight Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Moonlight Ring", bag="wardrobe2", priority=3},
 		back={ name="Rudianos's Mantle", augments={'HP+60','Eva.+20 /Mag. Eva.+20','HP+20','Enmity+10','Mag. Evasion+15',}, priority=4},
 	}
@@ -178,7 +178,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -202,7 +202,7 @@ function get_sets()
 		waist={ name="Sailfi Belt +1", augments={'Path: A',}},
 		left_ear="Telos Earring",
 		right_ear="Crep. Earring",
-		left_ring={ name="Moonlight Ring", bag="wardrobe1", priority=2},
+		left_ring={ name="Moonlight Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Moonlight Ring", bag="wardrobe2", priority=3},
 		back={ name="Rudianos's Mantle", augments={'DEX+20','Accuracy+20 Attack+20','Accuracy+10','"Dbl.Atk."+10','Damage taken-5%',}},
 	})
@@ -312,7 +312,7 @@ function get_sets()
 		waist={ name="Plat. Mog. Belt", priority=2}, -- 3 DT
 		left_ear={ name="Nourish. Earring +1", augments={'Path: A',}}, -- 5 SIRD / 6 Cure
 		right_ear="Chev. Earring +1", -- 3 DT / 11 Cure
-		left_ring={ name="Moonlight Ring", bag="wardrobe1", priority=1}, -- 5 DT
+		left_ring={ name="Moonlight Ring", bag="wardrobe", priority=1}, -- 5 DT
 		right_ring="Defending Ring", -- 10 DT
 		back={ name="Rudianos's Mantle", augments={'HP+60','Eva.+20 /Mag. Eva.+20','HP+20','"Cure" potency +10%','Spell interruption rate down-10%',}}, -- 10 SIRD / 10 Cure
 	} -- 91 + 10 Merits = 101 SIRD / 49 DT / 56 Cure
@@ -329,7 +329,7 @@ function get_sets()
 		waist="Audumbla Sash",
 		left_ear={ name="Odnowa Earring +1", augments={'Path: A',}},
 		right_ear="Chev. Earring +1",
-		left_ring={ name="Moonlight Ring", bag="wardrobe1", priority=2},
+		left_ring={ name="Moonlight Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Moonlight Ring", bag="wardrobe2", priority=3},
 		back={ name="Rudianos's Mantle", augments={'HP+60','Eva.+20 /Mag. Eva.+20','HP+20','"Cure" potency +10%','Spell interruption rate down-10%',}},
 	}
@@ -464,13 +464,13 @@ function pretarget_custom(spell,action)
 end
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 		if buffactive['Rampart'] and (spell.type == 'WhiteMagic' or spell.type == 'BlueMagic') then
 			equipSet = sets.Midcast.Rampart
 		end
@@ -481,13 +481,13 @@ function midcast_custom(spell)
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = {}
+	local equipSet = {}
 
 	if buffactive['Cover'] and gain then
 		equipSet = sets.Cover
@@ -505,7 +505,7 @@ function buff_change_custom(name,gain)
 end
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = {}
+	local equipSet = {}
 	 if buffactive['Cover'] then
 		equipSet = sets.Cover
 	 end
@@ -513,7 +513,7 @@ function choose_set_custom()
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
@@ -625,19 +625,19 @@ function user_file_unload()
 end
 
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 	
 	return equipSet
 end
 
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end

--- a/Sample Job Files/PUP.lua
+++ b/Sample Job Files/PUP.lua
@@ -90,7 +90,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -245,7 +245,7 @@ function pretarget_custom(spell,action)
 end
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 	if spell.name:contains('Maneuver') then
 		equipSet = sets.JA.Maneuver
 	elseif spell.type == 'WeaponSkill' then
@@ -257,53 +257,53 @@ function precast_custom(spell)
 end
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return choose_gear()
 end
 
 -- Called when the pet dies or is summoned
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 -- Called during a pet midcast
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 -- Called after the performs an action
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = {}
+	local equipSet = {}
 
 	return choose_gear()
 end
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = {}
+	local equipSet = {}
 
 	return choose_gear()
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = {}
+	local equipSet = {}
 
 	return choose_gear()
 end
@@ -313,7 +313,7 @@ function self_command_custom(command)
 end
 --Custom Function
 function choose_gear()
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end

--- a/Sample Job Files/PUP.lua
+++ b/Sample Job Files/PUP.lua
@@ -86,12 +86,21 @@ function get_sets()
 		feet="Hermes' Sandals",
 	}
 
-    -- Set to be used if you get cursna casted on you
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	sets.OffenseMode = {

--- a/Sample Job Files/PUP.lua
+++ b/Sample Job Files/PUP.lua
@@ -319,7 +319,7 @@ function choose_gear()
 end
 
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	local ja_recasts = windower.ffxi.get_ability_recasts()
 
 	-- Sub job has least priority
@@ -337,7 +337,7 @@ function check_buff_JA()
 end
 
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	--local sp_recasts = windower.ffxi.get_spell_recasts()
 	return buff
 end

--- a/Sample Job Files/RDM.lua
+++ b/Sample Job Files/RDM.lua
@@ -116,7 +116,7 @@ function get_sets()
 		waist="Carrier's Sash",
 		left_ear={ name="Etiolation Earring", priority=1}, -- Used to Keep HP/MP pool
 		right_ear={ name="Odnowa Earring +1", augments={'Path: A',}, priority=2}, --3/5
-		left_ring={name="Stikini Ring +1", bag="wardrobe1"}, -- +1 Refresh
+		left_ring={name="Stikini Ring +1", bag="wardrobe"}, -- +1 Refresh
 		right_ring={name="Stikini Ring +1", bag="wardrobe2"}, -- +1 Refresh
 		back={ name="Sucellos's Cape", augments={'MND+20','Mag. Acc+20 /Mag. Dmg.+20','Mag. Acc.+10','"Fast Cast"+10','Phys. dmg. taken-10%',}}, -- 10/0
     }
@@ -144,7 +144,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -173,7 +173,7 @@ function get_sets()
 		waist={ name="Sailfi Belt +1", augments={'Path: A',}},
 		left_ear="Sherida Earring",
 		right_ear={ name="Leth. Earring +1",},
-		left_ring={name="Chirich Ring +1", bag="wardrobe1"},
+		left_ring={name="Chirich Ring +1", bag="wardrobe"},
 		right_ring={name="Chirich Ring +1", bag="wardrobe2"},
 		back="Null Shawl",
 	}
@@ -348,7 +348,7 @@ function get_sets()
 		waist="Embla Sash", --10
 		left_ear={ name="Etiolation Earring", priority=1}, -- Used to Keep HP/MP pool
 		right_ear="Leth. Earring +1", -- 8
-		left_ring={name="Stikini Ring +1", bag="wardrobe1"},
+		left_ring={name="Stikini Ring +1", bag="wardrobe"},
 		right_ring={name="Stikini Ring +1", bag="wardrobe2"},
 		back={ name="Sucellos's Cape", augments={'MND+20','Mag. Acc+20 /Mag. Dmg.+20','Mag. Acc.+10','"Fast Cast"+10','Phys. dmg. taken-10%',}}, -- 20
 	} -- 150% Duration
@@ -406,7 +406,7 @@ function get_sets()
 		left_ear="Regal Earring",
 		right_ear="Snotra Earring",
 		left_ring={name="Stikini Ring +1", bag="wardrobe2"},
-		right_ring={name="Stikini Ring +1", bag="wardrobe1"},
+		right_ring={name="Stikini Ring +1", bag="wardrobe"},
 		back={ name="Sucellos's Cape", augments={'MND+20','Mag. Acc+20 /Mag. Dmg.+20','Mag. Acc.+10','"Fast Cast"+10','Phys. dmg. taken-10%',}},
 	}
 

--- a/Sample Job Files/RDM.lua
+++ b/Sample Job Files/RDM.lua
@@ -140,12 +140,21 @@ function get_sets()
 		legs={ name="Carmine Cuisses +1", augments={'HP+80','STR+12','INT+12',}},
 	}
 
-	-- Set to be used if you get 
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	-- ===================================================================================================================

--- a/Sample Job Files/RNG.lua
+++ b/Sample Job Files/RNG.lua
@@ -198,13 +198,22 @@ function get_sets()
 	sets.Movement = {
 		legs={ name="Carmine Cuisses +1", augments={'HP+80','STR+12','INT+12',}},
 	}
-
-	-- Set to be used if you get cursna casted on you
+	
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	--Base TP set to build off when melee'n

--- a/Sample Job Files/RNG.lua
+++ b/Sample Job Files/RNG.lua
@@ -742,7 +742,7 @@ function user_file_unload()
 end
 
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	local ja_recasts = windower.ffxi.get_ability_recasts()
 	if player.sub_job == 'WAR' then
 		if not buffactive['Berserk'] and ja_recasts[1] == 0 then
@@ -757,7 +757,7 @@ function check_buff_JA()
 end
 
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	--local sp_recasts = windower.ffxi.get_spell_recasts()
 	return buff
 end

--- a/Sample Job Files/RNG.lua
+++ b/Sample Job Files/RNG.lua
@@ -203,7 +203,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -391,7 +391,7 @@ function get_sets()
 		left_ear="Odr Earring",
 		hands={ name="Ikenga's Gloves", augments={'Path: A',}}, -- 15
 		waist={ name="Tellen Belt", augments={'Path: A',}}, -- 5
-		left_ring={ name="Chirich Ring +1",  bag="wardrobe1"}, -- 10
+		left_ring={ name="Chirich Ring +1",  bag="wardrobe"}, -- 10
 		right_ring={ name="Chirich Ring +1",  bag="wardrobe2"}, -- 10
     })
 
@@ -557,7 +557,7 @@ function get_sets()
 		head={ name="Ikenga's Hat", augments={'Path: A',}}, -- 5 II
 		right_ear="Sherida Earring", -- 5 II
 		hands={ name="Ikenga's Gloves", augments={'Path: A',}}, -- 15
-		left_ring={ name="Chirich Ring +1",  bag="wardrobe1"}, -- 10
+		left_ring={ name="Chirich Ring +1",  bag="wardrobe"}, -- 10
 		right_ring={ name="Chirich Ring +1",  bag="wardrobe2"}, -- 10
 	})
 

--- a/Sample Job Files/RNG.lua
+++ b/Sample Job Files/RNG.lua
@@ -696,37 +696,37 @@ function pretarget_custom(spell,action)
 end
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 	equipSet = Job_Mode_Check(equipSet)
 	return equipSet
 end
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 	equipSet = Job_Mode_Check(equipSet)
 	return equipSet
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 	equipSet = Job_Mode_Check(equipSet)
 	return equipSet
 end
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = {}
+	local equipSet = {}
 	equipSet = Job_Mode_Check(equipSet)
 	return equipSet
 end
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = {}
+	local equipSet = {}
 	equipSet = Job_Mode_Check(equipSet)
 	return equipSet
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = {}
+	local equipSet = {}
 	equipSet = Job_Mode_Check(equipSet)
 	return equipSet
 end

--- a/Sample Job Files/RNG.lua
+++ b/Sample Job Files/RNG.lua
@@ -793,19 +793,19 @@ function Job_Mode_Check(equipSet)
 end
 
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 	
 	return equipSet
 end
 
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end

--- a/Sample Job Files/RUN.lua
+++ b/Sample Job Files/RUN.lua
@@ -111,7 +111,7 @@ function get_sets()
 		waist="Plat. Mog. Belt",
 		left_ear={ name="Odnowa Earring +1", augments={'Path: A',}, priority=1}, -- 3/5
 		right_ear="Sanare Earring", -- Upgrade to +1/+2 Earring
-		left_ring={name="Moonlight Ring", bag="wardrobe1", priority=4},
+		left_ring={name="Moonlight Ring", bag="wardrobe", priority=4},
 		right_ring={name="Moonlight Ring", bag="wardrobe2", priority=5},
 		back={ name="Ogma's Cape", augments={'HP+60','Eva.+20 /Mag. Eva.+20','Mag. Evasion+10','Enmity+10','Damage taken-5%',}}, -- 5/5
     } -- 75 PDT / 58 MDT		3571 HP/ 1149 MP
@@ -138,7 +138,7 @@ function get_sets()
 		head="Erilaz Galea +3",
 		waist={ name="Plat. Mog. Belt", priority=2},
 		left_ear={ name="Tuisto Earring", priority=3},
-		left_ring={name="Moonlight Ring", bag="wardrobe1", priority=4},
+		left_ring={name="Moonlight Ring", bag="wardrobe", priority=4},
 		right_ring={name="Moonlight Ring", bag="wardrobe2", priority=5},
 	})
 
@@ -151,7 +151,7 @@ function get_sets()
 		legs="Eri. Leg Guards +3", -- 13/13
 		feet="Erilaz Greaves +3", -- 11/11
 		waist="Plat. Mog. Belt",
-		left_ring={name="Moonlight Ring", bag="wardrobe1", priority=4},
+		left_ring={name="Moonlight Ring", bag="wardrobe", priority=4},
 		right_ring={name="Moonlight Ring", bag="wardrobe2", priority=5},
 		left_ear={ name="Odnowa Earring +1", augments={'Path: A',}, priority=1}, -- 3/5
 	}
@@ -163,7 +163,7 @@ function get_sets()
 
 	-- This gear will be equiped when the player is moving and not engaged
 	sets.Movement = {
-		left_ring={name="Moonlight Ring", bag="wardrobe1"},
+		left_ring={name="Moonlight Ring", bag="wardrobe"},
 		right_ring={name="Moonlight Ring", bag="wardrobe2"},
 		legs={ name="Carmine Cuisses +1", augments={'HP+80','STR+12','INT+12',}, priority=1},
     } -- 73 PDT / 33 MDT		3028 HP / 963 MP
@@ -172,7 +172,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -307,7 +307,7 @@ function get_sets()
 		waist="Carrier's Sash",
 		left_ear="Tuisto Earring",
 		right_ear="Mimir Earring",
-		left_ring={name="Moonlight Ring", bag="wardrobe1", priority=4},
+		left_ring={name="Moonlight Ring", bag="wardrobe", priority=4},
 		right_ring={name="Moonlight Ring", bag="wardrobe2", priority=5},
 		back={ name="Ogma's Cape", augments={'HP+60','Eva.+20 /Mag. Eva.+20','Mag. Evasion+10','Enmity+10','Damage taken-5%',}}, -- 5/5
 	}
@@ -358,7 +358,7 @@ function get_sets()
 		left_ear="Tuisto Earring",
 		right_ear={ name="Etiolation Earring", priority=1},
 		body="Runeist Coat +3",
-		left_ring={name="Moonlight Ring", bag="wardrobe1", priority=4},
+		left_ring={name="Moonlight Ring", bag="wardrobe", priority=4},
 		right_ring={name="Moonlight Ring", bag="wardrobe2", priority=5},
 	})
 
@@ -369,7 +369,7 @@ function get_sets()
 		hands="Erilaz Gauntlets +3",
 		body="Runeist Coat +3",
 		right_ear={ name="Etiolation Earring", priority=1},
-		left_ring={name="Moonlight Ring", bag="wardrobe1", priority=4},
+		left_ring={name="Moonlight Ring", bag="wardrobe", priority=4},
 		right_ring={name="Moonlight Ring", bag="wardrobe2", priority=5},
 	})
 
@@ -380,7 +380,7 @@ function get_sets()
 		hands="Erilaz Gauntlets +3",
 		body="Runeist Coat +3",
 		right_ear={ name="Etiolation Earring", priority=1},
-		left_ring={name="Moonlight Ring", bag="wardrobe1", priority=4},
+		left_ring={name="Moonlight Ring", bag="wardrobe", priority=4},
 		right_ring={name="Moonlight Ring", bag="wardrobe2", priority=5},
 	})
 
@@ -472,13 +472,13 @@ function pretarget_custom(spell,action)
 end
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 	equipSet = set_combine(equipSet, Embolden_Check(spell))
 
 	if state.OffenseMode.value == 'MEVA' then
@@ -489,25 +489,25 @@ function midcast_custom(spell)
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
@@ -627,7 +627,7 @@ end
 
 -- Swaps back when embolden buff is active to extend duration
 function Embolden_Check(spell)
-	equipSet = {}
+	local equipSet = {}
 	if spell.target.id == player.id then
 		if buffactive['Embolden'] then
 			equipSet = sets.Embolden
@@ -638,19 +638,19 @@ function Embolden_Check(spell)
 end
 
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 	
 	return equipSet
 end
 
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end

--- a/Sample Job Files/RUN.lua
+++ b/Sample Job Files/RUN.lua
@@ -168,12 +168,21 @@ function get_sets()
 		legs={ name="Carmine Cuisses +1", augments={'HP+80','STR+12','INT+12',}, priority=1},
     } -- 73 PDT / 33 MDT		3028 HP / 963 MP
 
-	-- Set to be used if you get 
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	sets.Embolden = { back={ name="Evasionist's Cape", augments={'Enmity+1','"Embolden"+15','"Dbl.Atk."+1',}},}

--- a/Sample Job Files/RUN.lua
+++ b/Sample Job Files/RUN.lua
@@ -518,7 +518,7 @@ end
 
 --Function used to automate Job Ability use - Checked first
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	if os.clock() - buff_time > Buff_Delay then
 		local ja_recasts = windower.ffxi.get_ability_recasts()
 		local delay = os.clock() - JA_Delay
@@ -567,7 +567,7 @@ end
 
 --Function used to automate Spell use
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	if os.clock() - buff_time > Buff_Delay then
 		local sp_recasts = windower.ffxi.get_spell_recasts()
 
@@ -600,7 +600,7 @@ end
 
 
 function check_tank()
-	buff = 'None'
+	local buff = 'None'
 	if os.clock() - tank_time > Tank_Delay then
 				log('tank check')
 		if (player.status == "Engaged" or windower.ffxi.get_player().target_locked) and state.JobMode2.value == "ON" then

--- a/Sample Job Files/SAM.lua
+++ b/Sample Job Files/SAM.lua
@@ -104,12 +104,21 @@ function get_sets()
 		feet="Danzo Sune-Ate"
     }
 
-	-- Set to be used if you get 
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	-- 10 + 19 for Auspice

--- a/Sample Job Files/SAM.lua
+++ b/Sample Job Files/SAM.lua
@@ -456,7 +456,7 @@ end
 
 --Function used to automate Job Ability use
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	local ja_recasts = windower.ffxi.get_ability_recasts()
 	if not buffactive['Hasso'] and not buffactive['Seigan'] and ja_recasts[138] == 0 then
 		buff = "Hasso"
@@ -475,7 +475,7 @@ end
 
 --Function used to automate Spell use
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	--local sp_recasts = windower.ffxi.get_spell_recasts()
 	return buff
 end

--- a/Sample Job Files/SAM.lua
+++ b/Sample Job Files/SAM.lua
@@ -108,7 +108,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -393,42 +393,42 @@ end
 
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 	equipSet = choose_Seigan()
 	return equipSet
 end
 
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = {}
+	local equipSet = {}
 	equipSet = choose_Seigan()
 	return equipSet
 end
 
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = {}
+	local equipSet = {}
 	equipSet = choose_Seigan()
 	return equipSet
 end
 
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = {}
+	local equipSet = {}
 	equipSet = choose_Seigan()
 	return equipSet
 end
@@ -440,7 +440,7 @@ end
 
 --Custom Function
 function choose_Seigan()
-	equipSet = {}
+	local equipSet = {}
 		if player.status == "Engaged" then
 			if buffactive.Seigan then
 				--Equip the Seigan custom set when active
@@ -486,19 +486,19 @@ function user_file_unload()
 end
 
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 	
 	return equipSet
 end
 
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end

--- a/Sample Job Files/SCH.lua
+++ b/Sample Job Files/SCH.lua
@@ -74,7 +74,7 @@ function get_sets()
 		waist="Carrier's Sash",
 		left_ear="Lugalbanda Earring",
 		right_ear={ name="Etiolation Earring", priority=1}, -- 0/3
-		left_ring={name="Stikini Ring +1", bag="wardrobe1"}, -- +1 Refresh
+		left_ring={name="Stikini Ring +1", bag="wardrobe"}, -- +1 Refresh
 		right_ring={name="Stikini Ring +1", bag="wardrobe2"}, -- +1 Refresh
 		back={ name="Lugh's Cape", augments={'HP+60','Eva.+20 /Mag. Eva.+20','Mag. Evasion+10','"Fast Cast"+10','Damage taken-5%',}}, -- 5/5
     } -- 57 PDT / 58 MDT
@@ -106,7 +106,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -253,7 +253,7 @@ function get_sets()
 		waist="Embla Sash",
 		left_ear="Mimir Earring",
 		right_ear={ name="Etiolation Earring", priority=1},
-		left_ring={name="Stikini Ring +1", bag="wardrobe1"},
+		left_ring={name="Stikini Ring +1", bag="wardrobe"},
 		right_ring={name="Stikini Ring +1", bag="wardrobe3"},
 		back={ name="Lugh's Cape", augments={'HP+60','Eva.+20 /Mag. Eva.+20','Mag. Evasion+10','"Fast Cast"+10','Damage taken-5%',}},
 	}

--- a/Sample Job Files/SCH.lua
+++ b/Sample Job Files/SCH.lua
@@ -102,12 +102,21 @@ function get_sets()
 		feet="Herald's Gaiters"
 	}
 
-	-- Set to be used if you get 
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	-- Sets are used for when player is engaged

--- a/Sample Job Files/SMN.lua
+++ b/Sample Job Files/SMN.lua
@@ -104,7 +104,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -192,7 +192,7 @@ function get_sets()
 		left_ear="Digni. Earring",
 		right_ear="Hermetic Earring",
 		left_ring={name="Stikini Ring +1", bag="wardrobe2"},
-		right_ring={name="Stikini Ring +1", bag="wardrobe1"},
+		right_ring={name="Stikini Ring +1", bag="wardrobe"},
 		back={ name="Campestres's Cape", augments={'Pet: M.Acc.+20 Pet: M.Dmg.+20','Mag. Acc+20 /Mag. Dmg.+20','Pet: Magic Damage+10','"Fast Cast"+10',}},
 	}
 
@@ -209,7 +209,7 @@ function get_sets()
 		left_ear="Digni. Earring",
 		right_ear="Hermetic Earring",
 		left_ring={name="Stikini Ring +1", bag="wardrobe2"},
-		right_ring={name="Stikini Ring +1", bag="wardrobe1"},
+		right_ring={name="Stikini Ring +1", bag="wardrobe"},
 		back={ name="Campestres's Cape", augments={'Pet: M.Acc.+20 Pet: M.Dmg.+20','Mag. Acc+20 /Mag. Dmg.+20','Pet: Magic Damage+10','"Fast Cast"+10',}},
 	}
 
@@ -228,7 +228,7 @@ function get_sets()
 		left_ear="C. Palug Earring",
 		right_ear="Andoaa Earring",
 		left_ring={name="Stikini Ring +1", bag="wardrobe2"},
-		right_ring={name="Stikini Ring +1", bag="wardrobe1"},
+		right_ring={name="Stikini Ring +1", bag="wardrobe"},
 		back="Solemnity Cape",
 	}
 	sets.Midcast.Summon = set_combine(sets.Idle, {
@@ -248,7 +248,7 @@ function get_sets()
 		left_ear={ name="Moonshade Earring", augments={'Accuracy+4','TP Bonus +250',}},
 		right_ear="Friomisi Earring",
 		left_ring={name="Stikini Ring +1", bag="wardrobe2"},
-		right_ring={name="Stikini Ring +1", bag="wardrobe1"},
+		right_ring={name="Stikini Ring +1", bag="wardrobe"},
 		back={ name="Campestres's Cape", augments={'Pet: M.Acc.+20 Pet: M.Dmg.+20','Mag. Acc+20 /Mag. Dmg.+20','Pet: Magic Damage+10','"Fast Cast"+10',}},
 	}
 
@@ -321,7 +321,7 @@ function get_sets()
 		left_ear="Lugalbanda Earring",
 		right_ear="Beck. Earring +1",
 		left_ring={name="Varar Ring +1", bag="wardrobe2"},
-		right_ring={name="Varar Ring +1", bag="wardrobe1"},
+		right_ring={name="Varar Ring +1", bag="wardrobe"},
 		back={ name="Campestres's Cape", augments={'Pet: Acc.+20 Pet: R.Acc.+20 Pet: Atk.+20 Pet: R.Atk.+20','Eva.+20 /Mag. Eva.+20','Pet: Attack+10 Pet: Rng.Atk.+10','Pet: "Regen"+10','Pet: Damage taken -5%',}},
 	}
 	-- Some magic pacts benefit more from TP than others.
@@ -392,19 +392,19 @@ function pretarget_custom(spell,action)
 end
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 	if pet.isvalid and not buffactive["Avatar\'s Favor"] and spell.name ~= "Avatar\'s Favor" then
 		add_to_chat(8,'Avatar\'s Favor is Down')
 	end
@@ -412,24 +412,24 @@ function aftercast_custom(spell)
 end
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = {}
+	local equipSet = {}
 	return equipSet
 end
 
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 	-- Select initial macro set and set lockstyle
 	-- This section likely requires changes or removal if you aren't Pergatory Macro layout
 	if pet and gain then
@@ -462,7 +462,7 @@ function pet_change_custom(pet,gain)
 end
 
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 		-- This section is for SMN Blood Pact abilities
 		if player.main_job == "SMN" then
 			is_Busy = true
@@ -527,7 +527,7 @@ function pet_midcast_custom(spell)
 end
 
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end

--- a/Sample Job Files/SMN.lua
+++ b/Sample Job Files/SMN.lua
@@ -542,13 +542,13 @@ function user_file_unload()
 end
 
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	--local ja_recasts = windower.ffxi.get_ability_recasts()
 	return buff
 end
 
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	--local sp_recasts = windower.ffxi.get_spell_recasts()
 	return buff
 end

--- a/Sample Job Files/SMN.lua
+++ b/Sample Job Files/SMN.lua
@@ -100,12 +100,21 @@ function get_sets()
 		feet="Herald's Gaiters",
 	}
 
-	-- Set to be used if you get cursna casted on you
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	sets.OffenseMode = {}

--- a/Sample Job Files/THF.lua
+++ b/Sample Job Files/THF.lua
@@ -87,12 +87,21 @@ function get_sets()
 		feet="Fajin Boots",
     }
 
-	-- Set to be used if you get 
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	sets.OffenseMode = {}

--- a/Sample Job Files/THF.lua
+++ b/Sample Job Files/THF.lua
@@ -68,7 +68,7 @@ function get_sets()
 		waist="Null Belt",
 		left_ear={ name="Odnowa Earring +1", augments={'Path: A',}},
 		right_ear="Sanare Earring",
-		left_ring={ name="Moonlight Ring", bag="wardrobe1", priority=2},
+		left_ring={ name="Moonlight Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Moonlight Ring", bag="wardrobe2", priority=1},
 		back="Null Shawl",
     }
@@ -91,7 +91,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -302,37 +302,37 @@ function pretarget_custom(spell,action)
 end
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
@@ -359,19 +359,19 @@ function user_file_unload()
 end
 
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 	
 	return equipSet
 end
 
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end

--- a/Sample Job Files/THF.lua
+++ b/Sample Job Files/THF.lua
@@ -342,13 +342,13 @@ function self_command_custom(command)
 end
 
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	--local ja_recasts = windower.ffxi.get_ability_recasts()
 	return buff
 end
 
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	--local sp_recasts = windower.ffxi.get_spell_recasts()
 	return buff
 end

--- a/Sample Job Files/WAR.lua
+++ b/Sample Job Files/WAR.lua
@@ -568,7 +568,7 @@ function user_file_unload()
 end
 
 function check_buff_JA()
-	buff = 'None'
+	local buff = 'None'
 	local ja_recasts = windower.ffxi.get_ability_recasts()
 	if not buffactive['Berserk'] and ja_recasts[1] == 0 then
 		buff = "Berserk"
@@ -586,7 +586,7 @@ function check_buff_JA()
 end
 
 function check_buff_SP()
-	buff = 'None'
+	local buff = 'None'
 	--local sp_recasts = windower.ffxi.get_spell_recasts()
 	return buff
 end

--- a/Sample Job Files/WAR.lua
+++ b/Sample Job Files/WAR.lua
@@ -91,7 +91,7 @@ function get_sets()
 		waist="Carrier's Sash",
 		left_ear="Eabani Earring",
 		right_ear={ name="Odnowa Earring +1", augments={'Path: A',}},
-		left_ring={ name="Moonlight Ring", bag="wardrobe1", priority=2},
+		left_ring={ name="Moonlight Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Moonlight Ring", bag="wardrobe2", priority=3},
 		back={ name="Cichol's Mantle", augments={'DEX+20','Accuracy+20 Attack+20','Accuracy+10','"Dbl.Atk."+10','Damage taken-5%',}},
     }
@@ -119,7 +119,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}
@@ -524,37 +524,37 @@ function pretarget_custom(spell,action)
 end
 -- Augment basic equipment sets
 function precast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 -- Augment basic equipment sets
 function aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player gains or loses a buff
 function buff_change_custom(name,gain)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --This function is called when a update request the correct equipment set
 function choose_set_custom()
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 --Function is called when the player changes states
 function status_change_custom(new,old)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
@@ -592,19 +592,19 @@ function check_buff_SP()
 end
 
 function pet_change_custom(pet,gain)
-	equipSet = {}
+	local equipSet = {}
 	
 	return equipSet
 end
 
 function pet_aftercast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end
 
 function pet_midcast_custom(spell)
-	equipSet = {}
+	local equipSet = {}
 
 	return equipSet
 end

--- a/Sample Job Files/WAR.lua
+++ b/Sample Job Files/WAR.lua
@@ -115,12 +115,21 @@ function get_sets()
 		feet="Hermes' Sandals",
 	}
 
-	-- Set to be used if you get 
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	-- 10 + 19 for Auspice

--- a/Sample Job Files/WHM.lua
+++ b/Sample Job Files/WHM.lua
@@ -124,12 +124,21 @@ function get_sets()
 		feet="Herald's Gaiters",
 	}
 
-	-- Set to be used if you get 
+	--Spell Received Sets
+	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
 	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
+	}
+	sets.Phalanx_Received = {}
+	sets.Protect_Shell_Received = {}
+	sets.Regen_Received = {}
+	sets.Refresh_Received = {}
+	sets.Waltz_Received = {}
+	sets.Holy_Water = {
+	    neck="Nicander's Necklace",
 	}
 
 	sets.OffenseMode = {

--- a/Sample Job Files/WHM.lua
+++ b/Sample Job Files/WHM.lua
@@ -87,7 +87,7 @@ function get_sets()
 		waist="Carrier's Sash",
 		left_ear={ name="Alabaster Earring", priority=2},
 		right_ear={ name="Etiolation Earring", priority=1}, -- 1
-		left_ring={name="Stikini Ring +1", bag="wardrobe1"}, -- +1 Refresh
+		left_ring={name="Stikini Ring +1", bag="wardrobe"}, -- +1 Refresh
 		right_ring={name="Stikini Ring +1", bag="wardrobe2"}, -- +1 Refresh
 		back={ name="Alaunus's Cape", augments={'HP+60','Eva.+20 /Mag. Eva.+20','HP+20','"Fast Cast"+10','Damage taken-5%',}},
     }
@@ -114,7 +114,7 @@ function get_sets()
 	sets.Idle.Refresh = set_combine(sets.Idle, {
 		body="Ebers Bliaut +3",
 	    feet={ name="Chironic Slippers", augments={'CHR+4','Attack+21','"Refresh"+2','Mag. Acc.+19 "Mag.Atk.Bns."+19',}},
-		left_ring={name="Stikini Ring +1", bag="wardrobe1"}, -- +1 Refresh
+		left_ring={name="Stikini Ring +1", bag="wardrobe"}, -- +1 Refresh
 		right_ring={name="Stikini Ring +1", bag="wardrobe2"}, -- +1 Refresh
 	})
 	sets.Idle.Resting = set_combine(sets.Idle, {})
@@ -128,7 +128,7 @@ function get_sets()
 	sets.Cure_Received = {}
 	sets.Cursna_Received = {
 	    neck="Nicander's Necklace",
-	    left_ring={ name="Eshmun's Ring", bag="wardrobe1", priority=2},
+	    left_ring={ name="Eshmun's Ring", bag="wardrobe", priority=2},
 		right_ring={ name="Eshmun's Ring", bag="wardrobe2", priority=1},
 		waist="Gishdubar Sash",
 	}


### PR DESCRIPTION
# Mirdain Enhanced GearSwap by Rahvin — v1.6.5 Patch Notes

## Changed

- **`SpellReceived` modes simplified.** `ON-Locked` and `ON-Unlocked` are collapsed into a single `ON` (behaves like the old `ON-Locked`). `ON-Unlocked` is gone as unnecessary. **Update any macro/script still passing `ON-Locked` or `ON-Unlocked` — it will now be rejected** with a suggestion instead of silently doing the wrong thing.
- **Command argument validation.** Every `//gs c <mode> [value]` command now validates its argument against that mode's real option list (case-insensitive). An unrecognized value changes nothing and prints a usage message with a "did you mean" suggestion instead of either throwing a raw Lua error or being loosely/incorrectly matched (previously true for `SpellReceived` and `hoxne`). Sending a command with no argument such as `gs c spellreceived` still cycles the mode forward exactly as before.
- **Status box redesigned.** New compact glyph-based layout: `TH`, `SR` (SpellReceived), and `HOX` (Hoxne) now render as a single colored circle (green = on or TH Full Time, amber = TH Tag, cyan = THF SATA TH, hollow grey = off) instead of full text, freeing up space. Other modes (Stance, DPS, JobMode, JobMode2) keep full text between chevrons (`<DT>`). Column widths are now derived from each mode's full option list, so the box no longer resizes as you cycle through modes.
- **New `UI_Short` / `UI_Short2` job-file variables** — optional 3-letter status-box labels for JobMode/JobMode2. If omitted, a label is auto-derived from `UI_Name`/`UI_Name2` (a small alias table, then a general first-letters rule), so **existing job files need no changes**.
- **Display drag/save reworked.** Dragging now uses the text library's own hover/drag handling instead of a custom mouse-hook, and the position save on release is silent (no chat spam). `//gs c zero` now also resets the debug box position, not just the status box.

## Bug Fixes

- Fixed `//gs c display` (toggling the status box) not updating its draggable state, so a hidden-then-reshown box could stop responding to drags.
- Fixed the debug box not resetting its cached state when re-enabled via `//gs c debug`, which could leave it showing stale values.
- Fixed a leftover unused `is_Dragging` global and a missing `local` on `available_charges` in the SCH stratagem check (was leaking as a global).
- `sub_job_change` now invalidates the status box layout, so subjob swaps that change available mode options no longer leave the box mis-sized.

## Sample Job Files (all 22 jobs)

- **Fixed a wardrobe bag-name bug:** `bag="wardrobe1"` has been corrected to `bag="wardrobe"` everywhere it appeared (left-ring entries for Stikini Ring, Moonlight Ring, Eshmun's Ring, etc.). `"wardrobe1"` is not a valid bag name — GearSwap's real primary wardrobe is `"wardrobe"` — so any gear that specified it as the *only* location was silently failing to be found/equipped whenever the item wasn't a duplicate.
- **Fixed global-variable leakage:** the local `equipSet` scratch variable in all the `*_custom` hook functions (`precast_custom`, `midcast_custom`, `aftercast_custom`, `buff_change_custom`, `choose_set_custom`, `status_change_custom`, `pet_*_custom`, etc.) and `buff` in `check_buff_JA`/`check_buff_SP`/`check_tank` are now declared `local`. Previously they were implicit globals, which could bleed state between unrelated calls.

## Other

- README updated to document the new `SpellReceived` values, argument validation behavior, status box glyphs/labels, and drag/save behavior; version bumped to 1.6.5 throughout.

---

### Upgrade notes for existing users

- If you have a macro, third-party trigger, or saved binding that sends `//gs c SpellReceived ON-Locked` or `ON-Unlocked`, change it to `//gs c SpellReceived ON`.
- No action needed for `UI_Short`/`UI_Short2` — the auto-derived label will just appear. Set them explicitly only if you dislike the derived 3-letter label.
- The `wardrobe1` → `wardrobe` fix is purely corrective; no action needed unless you had copied the old (broken) pattern into gear you added yourself, in which case switch it to `bag="wardrobe"`.